### PR TITLE
Prepare for 8.2.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-transport8 VERSION 8.2.0)
+project(ignition-transport8 VERSION 8.2.1)
 
 #============================================================================
 # Find ignition-cmake

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,24 @@
 ## Ignition Transport 8
 
+### Ignition Transport 8.2.1 (2021-10-27)
+
+1. Make zmq check for post 4.3.1 not to include 4.3.1
+    * [Pull request #237](https://github.com/ignitionrobotics/ign-transport/pull/237)
+    * [Pull request #274](https://github.com/ignitionrobotics/ign-transport/pull/274)
+
+1. Fix Homebrew warning (backport from Fortress)
+    * [Pull request #268](https://github.com/ignitionrobotics/ign-transport/pull/268)
+
+1. Infrastructure
+    * [Pull request #246](https://github.com/ignitionrobotics/ign-transport/pull/246)
+    * [Pull request #224](https://github.com/ignitionrobotics/ign-transport/pull/224)
+
+1. Remove deprecated test
+    * [Pull request #239](https://github.com/ignitionrobotics/ign-transport/pull/239)
+
+1. Add Windows Installation using conda-forge, and cleanup install docs
+    * [Pull request #214](https://github.com/ignitionrobotics/ign-transport/pull/214)
+
 ### Ignition Transport 8.2.0 (2020-01-05)
 
 1. All changes up to version 7.5.1.


### PR DESCRIPTION
# 🎈 Release

Preparation for 8.2.1 release.

Comparison to 8.2.0: https://github.com/ignitionrobotics/ign-transport/compare/ignition-transport8_8.2.0...ign-transport8

Needed to fix debian buster build for this and downstream packages

## Checklist
- [ ] Asked team if this is a good time for a release
- [X] There are no changes to be ported from the previous major version
- [X] No PRs targeted at this major version are close to getting in
- [X] Bumped minor for new features, patch for bug fixes
- [X] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [ignition-release](https://github.com/ignition-release) (as needed): <LINK>

<!-- Please refer to http://github.com/docs/release.md#triggering-a-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge**
