### PR TITLE
Use auto for loop iterators

### DIFF
--- a/src/Node.cc
+++ b/src/Node.cc
@@ -344,11 +344,9 @@ bool Node::Publisher::Publish(const ProtoMsg &_msg)
 
     if (subscribers.haveLocal)
     {
-      for (const std::pair<std::string, ISubscriptionHandler_M> &node :
-           subscribers.localHandlers)
+      for (const auto &node : subscribers.localHandlers)
       {
-        for (const std::pair<std::string, ISubscriptionHandlerPtr> &handler :
-             node.second)
+        for (const auto &handler : node.second)
         {
           if (!handler.second)
           {


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Cleans up two small warnings on clang/jammy combo: 

```
loop variable 'node' of type 'const std::pair<std::string, ISubscriptionHandler_M> &' (aka 'const pair<basic_string<char>, map<basic_string<char>, shared_ptr<gz::transport::ISubscriptionHandler>>> &') binds to a temporary constructed from type
```

The auto looks a little cleaner and prevents generating temporary copies in this context

## Checklist
- [x] Signed all commits for DCO
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
