### PR TITLE
Backport Windows fix from main branch

### DIFF
--- a/include/ignition/transport/TopicStatistics.hh
+++ b/include/ignition/transport/TopicStatistics.hh
@@ -19,11 +19,23 @@
 
 #include <ignition/msgs/statistic.pb.h>
 
+#include <algorithm>
 #include <limits>
 #include <memory>
 #include <string>
 #include "ignition/transport/config.hh"
 #include "ignition/transport/Export.hh"
+
+#ifdef _WIN32
+#ifndef NOMINMAX
+  #define NOMINMAX
+#endif
+#ifdef min
+  #undef min
+  #undef max
+#endif
+#include <windows.h>
+#endif
 
 namespace ignition
 {


### PR DESCRIPTION
Backport from https://github.com/gazebosim/gz-transport/pull/250 . We recently updated to ign-transport 8.3.0 on conda-forge, and in downstream tests (https://github.com/robotology/robotology-superbuild/issues/1242) we experienced a Windows error that was fixed in recent version of ign/gz-transport, but that was not fixed on the ign-transport8 branch.


# 🦟 Bug fix

Fix compilation problem in downstream projects.

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
