### PR TITLE
Added Node::RequestRaw

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -101,6 +101,12 @@ if (EXISTS "${CMAKE_SOURCE_DIR}/requester_oneway.cc")
     ignition-transport${IGN_TRANSPORT_VER}::core)
 endif()
 
+if (EXISTS "${CMAKE_SOURCE_DIR}/requester_raw.cc")
+  add_executable(requester_raw requester_raw.cc)
+  target_link_libraries(requester_raw
+    ignition-transport${IGN_TRANSPORT_VER}::core)
+endif()
+
 if (EXISTS "${CMAKE_SOURCE_DIR}/responser_no_input.cc")
   add_executable(responser_no_input responser_no_input.cc)
   target_link_libraries(responser_no_input

--- a/example/requester_raw.cc
+++ b/example/requester_raw.cc
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <iostream>
+#include <ignition/msgs.hh>
+#include <ignition/transport.hh>
+
+//////////////////////////////////////////////////
+int main(int argc, char **argv)
+{
+  // Create a transport node.
+  ignition::transport::Node node;
+
+  // Prepare the input parameters.
+  ignition::msgs::StringMsg req;
+  req.set_data("HELLO");
+
+  bool result;
+  unsigned int timeout = 5000;
+
+  std::string reqStr, repStr, repMsgType;
+  req.SerializeToString(&reqStr);
+
+  // Request the "/echo" service.
+  bool executed = node.RequestRaw("/echo", reqStr, "ignition.msgs.StringMsg",
+      timeout, repStr, repMsgType, result);
+
+  if (executed)
+  {
+    if (result)
+    {
+      if (repMsgType == "ignition.msgs.StringMsg")
+      {
+        ignition::msgs::StringMsg rep;
+        rep.ParseFromString(repStr);
+        std::cout << "Response: [" << rep.data() << "]" << std::endl;
+      }
+      else
+      {
+        std::cout << "Expected reply message type of ignition.msgs.StringMsg "
+          << "received " << repMsgType << std::endl;
+      }
+    }
+    else
+      std::cout << "Service call failed" << std::endl;
+  }
+  else
+    std::cerr << "Service call timed out" << std::endl;
+}

--- a/include/ignition/transport/Node.hh
+++ b/include/ignition/transport/Node.hh
@@ -662,6 +662,26 @@ namespace ignition
       public: template<typename RequestT>
       bool Request(const std::string &_topic, const RequestT &_request);
 
+      /// \brief Request a new service using a blocking call. This request
+      /// function expects a serialized protobuf message as the request and
+      /// returns a serialized protobuf message as the response.
+      /// \param[in] _topic Service name requested.
+      /// \param[in] _request Protobuf message serialized into a string
+      /// containing the request's parameters.
+      /// \param[out] _requestType Message type of the request.
+      /// \param[in] _timeout The equest will timeout after '_timeout' ms.
+      /// \param[out] _response Serialized protobuf message containing the
+      ///  response.
+      /// \param[out] _responseType Message type of the response.
+      /// \param[out] _result Result of the service call.
+      /// \return true when the request was executed or false if the timeout
+      /// expired.
+      bool RequestRaw(const std::string &_topic,
+          const std::string &_request, const std::string &_requestType,
+          unsigned int _timeout,
+          std::string &_response, std::string &_responseType,
+          bool &_result);
+
       /// \brief Unadvertise a service.
       /// \param[in] _topic Service name to be unadvertised.
       /// \return true if the service was successfully unadvertised.

--- a/src/Node_TEST.cc
+++ b/src/Node_TEST.cc
@@ -341,6 +341,19 @@ class MyTestClass
 
     this->Reset();
 
+    // Request a valid service using RequestRaw.
+    std::string reqStr, repStr, repTypeName;
+    req.SerializeToString(&reqStr);
+    EXPECT_TRUE(this->node.RequestRaw(g_topic, reqStr, req.GetTypeName(),
+          timeout, repStr, repTypeName, result));
+    rep.ParseFromString(repStr);
+    ASSERT_TRUE(result);
+    EXPECT_EQ(rep.data(), data);
+    ASSERT_EQ(repTypeName, rep.GetTypeName());
+    EXPECT_TRUE(this->callbackSrvExecuted);
+
+    this->Reset();
+
     // Service requests with wrong types.
     EXPECT_FALSE(this->node.Request(g_topic, wrongReq, timeout, rep, result));
     EXPECT_FALSE(this->node.Request(g_topic, req, timeout, wrongRep, result));


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>

# 🎉 New feature

## Summary

Adds `Node::RequestRaw`, which is similar to `PublishRaw`. In this case, raw serialized request and response strings are used instead of protobuf messages.

Needed by https://github.com/gazebosim/gz-launch/pull/187

## Test it

Run the `requester_raw` example program.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.