### PR TITLE
Fix bench example compilation

### DIFF
--- a/example/bench.cc
+++ b/example/bench.cc
@@ -44,6 +44,7 @@
 #include <condition_variable>
 #include <csignal>
 #include <exception>
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <thread>


### PR DESCRIPTION
Signed-off-by: Carlos Agüero <caguero@openrobotics.org>

<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

While going though the tutorials I noticed that the `bench` example doesn't compile. This patch should fix it.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
