### PR TITLE
Fix minor typo in topic statistics tutorial

### DIFF
--- a/tutorials/23_topic_statistics.md
+++ b/tutorials/23_topic_statistics.md
@@ -76,6 +76,6 @@ if (!node.EnableStats(topic, true, "/my_stats", 100))
 If you have the Gazebo Transport sources with the example programs built,
 then you can test topic statistics by following these steps.
 
-1. Terminal 1: `GZ_TRANSPORT_TOPIC_STATISTICS=1 ./examples/build/publisher`
-1. Terminal 2: `GZ_TRANSPORT_TOPIC_STATISTICS=1 ./examples/build/subscriber_stats`
+1. Terminal 1: `GZ_TRANSPORT_TOPIC_STATISTICS=1 ./example/build/publisher`
+1. Terminal 2: `GZ_TRANSPORT_TOPIC_STATISTICS=1 ./example/build/subscriber_stats`
 1. Terminal 3: `GZ_TRANSPORT_TOPIC_STATISTICS=1 gz topic -et /statistics`


### PR DESCRIPTION
Signed-off-by: Carlos Agüero <caguero@openrobotics.org>

<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

This pull request fixes a minor typo in the `topic statistics` tutorial. Our examples are under `example` and not under `examples`.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.