### PR TITLE
Fix table in "Nodes and topics tutorial"

### DIFF
--- a/tutorials/03_nodesAndTopics.md
+++ b/tutorials/03_nodesAndTopics.md
@@ -115,5 +115,5 @@ invalid too.
 |          |topic A    |                       | Invalid |   Topic contains white space            |
 |my ns     |topicA     |                       | Invalid |  Namespace contains white space         |
 |//ns      |topicA     |                       | Invalid |  Namespace contains two consecutive `//`|
-|          |topicA     |                       | Invalid |  `/` namespace is not allowed           |
+|/         |topicA     |                       | Invalid |  `/` namespace is not allowed           |
 |~myns     |topicA     |                       | Invalid |  Symbol `~` not allowed                 |

--- a/tutorials/03_nodesAndTopics.md
+++ b/tutorials/03_nodesAndTopics.md
@@ -46,7 +46,7 @@ The following symbols are not allowed as part of the topic name: `@`, `:=`, `~`.
 | /topicA/    | Valid    | Equivalent to /topicA         |
 | topicA      | Valid    |                               |
 | /a/b        | Valid    |                               |
-| \           | Invalid  | Empty string is invalid       |
+|             | Invalid  | Empty string is invalid       |
 | my topic    | Invalid  | Contains white space          |
 | //image     | Invalid  | Contains two consecutive `//` |
 | /           | Invalid  | `/` topic is not allowed      |
@@ -108,12 +108,12 @@ invalid too.
 |Namespace |Topic name | Fully qualified topic | Validity| Comment                                 |
 |:-------: |:---------:| :--------------------:|:-------:|:---------------------------------------:|
 |ns1       |/topicA    | /topicA               | Valid   |  Absolute topic                         |
-|\         |/topicA    | /topicA               | Valid   |  Absolute topic                         |
+|          |/topicA    | /topicA               | Valid   |  Absolute topic                         |
 |ns1       |topicA     | /ns1/topicA           | Valid   |                                         |
-|\         |topicA     | /topicA               | Valid   |                                         |
-|ns1       |topic A    | \                     | Invalid |  Topic contains white space             |
-|\         |topic A    | \                     | Invalid |   Topic contains white space            |
-|my ns     |topicA     | \                     | Invalid |  Namespace contains white space         |
-|//ns      |topicA     | \                     | Invalid |  Namespace contains two consecutive `//`|
-|/         |topicA     | \                     | Invalid |  `/` namespace is not allowed           |
-|~myns     |topicA     | \                     | Invalid |  Symbol `~` not allowed                 |
+|          |topicA     | /topicA               | Valid   |                                         |
+|ns1       |topic A    |                       | Invalid |  Topic contains white space             |
+|          |topic A    |                       | Invalid |   Topic contains white space            |
+|my ns     |topicA     |                       | Invalid |  Namespace contains white space         |
+|//ns      |topicA     |                       | Invalid |  Namespace contains two consecutive `//`|
+|          |topicA     |                       | Invalid |  `/` namespace is not allowed           |
+|~myns     |topicA     |                       | Invalid |  Symbol `~` not allowed                 |


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

The tutorial ["Nodes and Topics"](https://gazebosim.org/api/transport/12/nodestopics.html) uses two tables to show legal/ilegal topics and namespaces. The empty topics and namespaces are rendered as `</td>`. I'm trying this fix but not 100% sure if this will fix it.

Tagging @nkoenig in case he has extra tips.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.