### PR TITLE
Remove logging tutorial highlight

### DIFF
--- a/tutorials/10_logging.md
+++ b/tutorials/10_logging.md
@@ -270,7 +270,7 @@ You should receive one message in terminal 2:
 data: "Hello log"
 ```
 
-## Using `gz` for recording and playing back
+## Using gz for recording and playing back
 
 As an alternative to the C++ API, we could use the `gz` suite of command line
 tools for recording and playing back messages.


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

The [logging tutorial](https://gazebosim.org/api/transport/12/logging.html) contains a section `Using gz for recording and playing back`. `gz` is sorrounded by backticks but it's not rendered properly. For now this pull request removes the backticks.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.