### PR TITLE
Fix build for Debian Bullseye

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,8 @@ if (UNIX AND NOT APPLE)
     message(WARNING "lsb_release executable not found. Disabling focal-specific workarounds")
   elseif (${RELEASE_CODENAME} STREQUAL "focal")
     set(UBUNTU_FOCAL 1)
+  elseif (${RELEASE_CODENAME} STREQUAL "bullseye")
+    set(DEBIAN_BULLSEYE 1)
   endif()
 endif()
 

--- a/include/ignition/transport/Helpers.hh
+++ b/include/ignition/transport/Helpers.hh
@@ -38,7 +38,8 @@
 // Avoid using deprecated set function when possible
 #if CPPZMQ_VERSION >= ZMQ_MAKE_VERSION(4, 7, 0)
   // Ubuntu Focal (20.04) packages a different "4.7.0"
-  #ifndef UBUNTU_FOCAL
+  // And so does apparently Debian Bullseye
+  #if !defined(UBUNTU_FOCAL) && !defined(DEBIAN_BULLSEYE)
     #define IGN_CPPZMQ_POST_4_7_0
   #endif
 #endif

--- a/include/ignition/transport/config.hh.in
+++ b/include/ignition/transport/config.hh.in
@@ -21,5 +21,6 @@
 
 #cmakedefine HAVE_IFADDRS 1
 #cmakedefine UBUNTU_FOCAL 1
+#cmakedefine DEBIAN_BULLSEYE 1
 
 #endif


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #362

## Summary
Presumably the versioning of cppzmq has the same problem on Debian Bullseye as on Ubuntu Focal.

This adds the same workaround for Debian Bullseye which seems to solve the build issue.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.