### PR TITLE
Removing boilerplate code

### DIFF
--- a/conf/CMakeLists.txt
+++ b/conf/CMakeLists.txt
@@ -1,27 +1,2 @@
 # Used only for internal testing.
-set(ign_library_path "${CMAKE_BINARY_DIR}/test/lib/$<CONFIG>/ruby/ignition/cmd${GZ_DESIGNATION}${PROJECT_VERSION_MAJOR}")
-
-# Generate a configuration file for internal testing.
-# Note that the major version of the library is included in the name.
-# Ex: transport0.yaml
-configure_file(
-  "${GZ_DESIGNATION}.yaml.in"
-  "${CMAKE_CURRENT_BINARY_DIR}/${GZ_DESIGNATION}${PROJECT_VERSION_MAJOR}.yaml.configured" @ONLY)
-
-file(GENERATE
-  OUTPUT "${CMAKE_BINARY_DIR}/test/conf/$<CONFIG>/${GZ_DESIGNATION}${PROJECT_VERSION_MAJOR}.yaml"
-  INPUT "${CMAKE_CURRENT_BINARY_DIR}/${GZ_DESIGNATION}${PROJECT_VERSION_MAJOR}.yaml.configured")
-
-# Used for the installed version.
-set(ign_library_path "${CMAKE_INSTALL_PREFIX}/lib/ruby/ignition/cmd${GZ_DESIGNATION}${PROJECT_VERSION_MAJOR}")
-
-# Generate the configuration file that is installed.
-# Note that the major version of the library is included in the name.
-# Ex: transport0.yaml
-configure_file(
-  "${GZ_DESIGNATION}.yaml.in"
-  "${CMAKE_CURRENT_BINARY_DIR}/${GZ_DESIGNATION}${PROJECT_VERSION_MAJOR}.yaml" @ONLY)
-
-# Install the yaml configuration files in an unversioned location.
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${GZ_DESIGNATION}${PROJECT_VERSION_MAJOR}.yaml
-  DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATAROOTDIR}/ignition/)
+ign_generate_conf()

--- a/src/cmd/CMakeLists.txt
+++ b/src/cmd/CMakeLists.txt
@@ -63,50 +63,12 @@ endif()
 
 #===============================================================================
 # Generate the ruby script for internal testing.
-# Note that the major version of the library is included in the name.
-# Ex: cmdtransport0.rb
-set(cmd_script_generated_test "${CMAKE_BINARY_DIR}/test/lib/$<CONFIG>/ruby/ignition/cmd${GZ_DESIGNATION}${PROJECT_VERSION_MAJOR}.rb")
-set(cmd_script_configured_test "${CMAKE_CURRENT_BINARY_DIR}/test_cmd${GZ_DESIGNATION}${PROJECT_VERSION_MAJOR}.rb.configured")
-
-# Set the library_location variable to the full path of the library file within
-# the build directory.
-set(service_exe_location "$<TARGET_FILE:${service_executable}>")
-set(topic_exe_location "$<TARGET_FILE:${topic_executable}>")
-
-configure_file(
-  "cmd${GZ_DESIGNATION}.rb.in"
-  "${cmd_script_configured_test}"
-  @ONLY)
-
-file(GENERATE
-  OUTPUT "${cmd_script_generated_test}"
-  INPUT  "${cmd_script_configured_test}")
-
-
-#===============================================================================
-# Used for the installed version.
-# Generate the ruby script that gets installed.
-# Note that the major version of the library is included in the name.
-# Ex: cmdtransport0.rb
-set(cmd_script_generated "${CMAKE_CURRENT_BINARY_DIR}/cmd${GZ_DESIGNATION}${PROJECT_VERSION_MAJOR}.rb")
-set(cmd_script_configured "${cmd_script_generated}.configured")
+ign_generate_cmd()
 
 # Set the library_location variable to the relative path to the library file
 # within the install directory structure.
 set(service_exe_location "../../../${CMAKE_INSTALL_LIBEXECDIR}/ignition/${GZ_DESIGNATION}${PROJECT_VERSION_MAJOR}/$<TARGET_FILE_NAME:${service_executable}>")
 set(topic_exe_location "../../../${CMAKE_INSTALL_LIBEXECDIR}/ignition/${GZ_DESIGNATION}${PROJECT_VERSION_MAJOR}/$<TARGET_FILE_NAME:${topic_executable}>")
-
-configure_file(
-  "cmd${GZ_DESIGNATION}.rb.in"
-  "${cmd_script_configured}"
-  @ONLY)
-
-file(GENERATE
-  OUTPUT "${cmd_script_generated}"
-  INPUT  "${cmd_script_configured}")
-
-# Install the ruby command line library in an unversioned location.
-install(FILES ${cmd_script_generated} DESTINATION lib/ruby/ignition)
 
 #===============================================================================
 # Bash completion


### PR DESCRIPTION
# 🎉 New feature

Depends on https://github.com/gazebosim/gz-cmake/pull/270

## Summary
Removes config file and cmd file creation boilerplate with cmake macros.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.