### PR TITLE
Prepare for 11.3.0~pre1 Release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-transport11 VERSION 11.2.0)
+project(ignition-transport11 VERSION 11.3.0)
 
 #============================================================================
 # Find ignition-cmake
@@ -15,7 +15,7 @@ set(IGN_CMAKE_VER ${ignition-cmake2_VERSION_MAJOR})
 #============================================================================
 # Configure the project
 #============================================================================
-ign_configure_project(VERSION_SUFFIX)
+ign_configure_project(VERSION_SUFFIX pre1)
 
 #============================================================================
 # Set project-specific options

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,13 @@
 ## Gazebo Transport 11.X
 
+### Gazebo Transport 11.3.0 (2022-10-31)
+
+1. Add parameters component
+    * [Pull request #305](https://github.com/gazebosim/ign-transport/pull/305)
+
+1. Fix build for Debian Bullseye
+    * [Pull request #363](https://github.com/gazebosim/ign-transport/pull/363)
+
 ### Gazebo Transport 11.2.0 (2022-08-16)
 
 1. Remove problematic discovery test


### PR DESCRIPTION
# 🎈 Release

Preparation for 11.3.0~pre1 release.

Comparison to 11.2.0: https://github.com/ignitionrobotics/ign-transport/compare/ignition-transport11_11.2.0...ign-transport11

<!-- Add links to PRs that require this release (if needed) -->
Needed by <PR(s)>

## Checklist
- [ ] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [x] Bumped minor for new features, patch for bug fixes
- [x] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.