### PR TITLE
8.4.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-transport8 VERSION 8.3.0)
+project(ignition-transport8 VERSION 8.4.0)
 
 #============================================================================
 # Find ignition-cmake

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,16 @@
 ## Ignition Transport 8
 
+### Gazebo Transport 8.4.0 (2022-11-17)
+
+1. ign -> gz : Remove redundant namespace references.
+    * [Pull request #345](https://github.com/gazebosim/gz-transport/pull/345)
+
+1. Backport Windows fix from main branch.
+    * [Pull request #350](https://github.com/gazebosim/gz-transport/pull/350)
+
+1. ign -> gz Migrate Ignition Headers : gz-transport.
+    * [Pull request #347](https://github.com/gazebosim/gz-transport/pull/347)
+
 ### Gazebo Transport 8.3.0 (2022-07-27)
 
 1. Ignition -> Gazebo


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>

# 🎈 Release

Preparation for 8.4.0 release.

Comparison to  8.3.0: https://github.com/gazebosim/gz-transport/compare/ignition-transport8_8.3.0...ign-transport8


## Checklist
- [ ] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [ ] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
