### PR TITLE
12.1.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ set(GZ_CMAKE_VER ${gz-cmake3_VERSION_MAJOR})
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-gz_configure_project(VERSION_SUFFIX pre1)
+gz_configure_project(VERSION_SUFFIX)
 
 #============================================================================
 # Set project-specific options

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,16 @@
 ## Gazebo Transport 12.X
 
+### Gazebo Transport 12.1.0 (2023-01-11)
+
+1. Ignition to Gazebo renaming.
+    * [Pull request #347](https://github.com/gazebosim/gz-transport/pull/347)
+
+1. Use new ignition-specific formatter.
+    * [Pull request #296](https://github.com/gazebosim/gz-transport/pull/296)
+
+1. Remove warnings in Garden on Ubuntu 22.04.
+    * [Pull request #364](https://github.com/gazebosim/gz-transport/pull/364)
+
 ### Gazebo Transport 12.0.0 (2022-09-22)
 
 1. Improved windows instructions


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>

# 🎈 Release

Preparation for 12.1.0 release.

Comparison to 12.0.0: https://github.com/gazebosim/gz-transport/compare/gz-transport12_12.0.0...gz-transport12

## Checklist
- [x] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [x] Bumped minor for new features, patch for bug fixes
- [x] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
