### PR TITLE
Prevent invoking callbacks after a node unsubscribes to a topic

### DIFF
--- a/include/gz/transport/Node.hh
+++ b/include/gz/transport/Node.hh
@@ -753,12 +753,6 @@ namespace gz
       /// \return True on success.
       private: bool SubscribeHelper(const std::string &_fullyQualifiedTopic);
 
-      /// \brief Helper function to remove handlers from the shared publish
-      /// queue. This is called when the node unsubscribes to a topic
-      /// \param[in] _topic Topic that the node unsubcribed to.
-      /// \return True on success.
-      private: bool RemoveHandlersFromPubQueue(const std::string &_topic);
-
 #ifdef _WIN32
 // Disable warning C4251 which is triggered by
 // std::unique_ptr

--- a/include/gz/transport/Node.hh
+++ b/include/gz/transport/Node.hh
@@ -753,8 +753,8 @@ namespace gz
       /// \return True on success.
       private: bool SubscribeHelper(const std::string &_fullyQualifiedTopic);
 
-      /// \brief Helper function to remove handlers from the shared publish queue.
-      /// This is called when the node unsubscribes to a topic
+      /// \brief Helper function to remove handlers from the shared publish
+      /// queue. This is called when the node unsubscribes to a topic
       /// \param[in] _topic Topic that the node unsubcribed to.
       /// \return True on success.
       private: bool RemoveHandlersFromPubQueue(const std::string &_topic);

--- a/include/gz/transport/Node.hh
+++ b/include/gz/transport/Node.hh
@@ -759,7 +759,6 @@ namespace gz
       /// \return True on success.
       private: bool RemoveHandlersFromPubQueue(const std::string &_topic);
 
-
 #ifdef _WIN32
 // Disable warning C4251 which is triggered by
 // std::unique_ptr

--- a/include/gz/transport/Node.hh
+++ b/include/gz/transport/Node.hh
@@ -753,6 +753,13 @@ namespace gz
       /// \return True on success.
       private: bool SubscribeHelper(const std::string &_fullyQualifiedTopic);
 
+      /// \brief Helper function to remove handlers from the shared publish queue.
+      /// This is called when the node unsubscribes to a topic
+      /// \param[in] _topic Topic that the node unsubcribed to.
+      /// \return True on success.
+      private: bool RemoveHandlersFromPubQueue(const std::string &_topic);
+
+
 #ifdef _WIN32
 // Disable warning C4251 which is triggered by
 // std::unique_ptr

--- a/src/Node.cc
+++ b/src/Node.cc
@@ -400,7 +400,8 @@ bool Node::Publisher::Publish(const ProtoMsg &_msg)
     {
       std::unique_lock<std::mutex> queueLock(
           this->dataPtr->shared->dataPtr->pubThreadMutex);
-      this->dataPtr->shared->dataPtr->pubQueue.push_back(std::move(pubMsgDetails));
+      this->dataPtr->shared->dataPtr->pubQueue.push_back(
+          std::move(pubMsgDetails));
     }
 
     this->dataPtr->shared->dataPtr->signalNewPub.notify_one();

--- a/src/Node.cc
+++ b/src/Node.cc
@@ -610,7 +610,12 @@ bool Node::Unsubscribe(const std::string &_topic)
 
   // Remove handlers from shared pubQueue to avoid invoking callbacks after
   // unsuscribing to the topic
-  this->RemoveHandlersFromPubQueue(topic);
+  if (!this->RemoveHandlersFromPubQueue(topic))
+  {
+    std::cerr << "Error removing subscription handlers from publish queue "
+              << "when unsubscribing from Topic [" << _topic << "]"
+              <<  std::endl;
+  }
 
   // Remove the topic from the list of subscribed topics in this node.
   this->dataPtr->topicsSubscribed.erase(fullyQualifiedTopic);

--- a/src/NodePrivate.hh
+++ b/src/NodePrivate.hh
@@ -50,6 +50,12 @@ namespace gz
       /// \sa TopicUtils::FullyQualifiedName
       public: bool SubscribeHelper(const std::string &_fullyQualifiedTopic);
 
+      /// \brief Helper function to remove handlers from the shared publish
+      /// queue. This is called when the node unsubscribes to a topic
+      /// \param[in] _topic Topic that the node unsubcribed to.
+      /// \return True on success.
+      public: bool RemoveHandlersFromPubQueue(const std::string &_topic);
+
       /// \brief The list of topics subscribed by this node.
       public: std::unordered_set<std::string> topicsSubscribed;
 

--- a/src/NodeShared.cc
+++ b/src/NodeShared.cc
@@ -1888,7 +1888,7 @@ void NodeSharedPrivate::PublishThread()
 
       // Get the message
       msgDetails = std::move(this->pubQueue.front());
-      this->pubQueue.pop();
+      this->pubQueue.pop_front();
     }
 
     // Send the message to all the local handlers.

--- a/src/NodeSharedPrivate.hh
+++ b/src/NodeSharedPrivate.hh
@@ -21,9 +21,9 @@
 #include <zmq.hpp>
 
 #include <atomic>
+#include <list>
 #include <map>
 #include <memory>
-#include <queue>
 #include <string>
 #include <vector>
 
@@ -175,9 +175,9 @@ namespace gz
       /// \brief Mutex to protect the pubThread and pubQueue.
       public: std::mutex pubThreadMutex;
 
-      /// \brief Queue onto which new messages are pushed. The pubThread
+      /// \brief List onto which new messages are pushed. The pubThread
       /// will pop off the messages and send them to local subscribers.
-      public: std::queue<std::unique_ptr<PublishMsgDetails>> pubQueue;
+      public: std::list<std::unique_ptr<PublishMsgDetails>> pubQueue;
 
       /// \brief used to signal when new work is available
       public: std::condition_variable signalNewPub;

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -3,6 +3,7 @@ set(TEST_TYPE "INTEGRATION")
 set(tests
   authPubSub.cc
   scopedTopic.cc
+  callback_scope_TEST.cc
   statistics.cc
   twoProcsPubSub.cc
   twoProcsSrvCall.cc

--- a/test/integration/callback_scope_TEST.cc
+++ b/test/integration/callback_scope_TEST.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Open Source Robotics Foundation
+ * Copyright (C) 2023 Open Source Robotics Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/integration/callback_scope_TEST.cc
+++ b/test/integration/callback_scope_TEST.cc
@@ -32,14 +32,13 @@ TEST(CallbackScope, CleanupCorrectly)
     auto msg2 = std::make_unique<gz::msgs::Int32>();
 
     std::function<void(const gz::msgs::Int32&)> callback =
-      [&msg2](const gz::msgs::Int32& msg) {
+      [&msg2](const gz::msgs::Int32 &) {
 
         if (nullptr == msg2)
         {
           FAIL();
         }
 
-        (void) msg;
         return;
       };
 

--- a/test/integration/callback_scope_TEST.cc
+++ b/test/integration/callback_scope_TEST.cc
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#include <gz/msgs/int32.pb.h>
+
+#include <gtest/gtest.h>
+
+#include <gz/transport/Node.hh>
+
+TEST(CallbackScope, CleanupCorrectly)
+{
+  gz::transport::Node node;
+
+  auto publisher = node.Advertise<gz::msgs::Int32>("/my_topic");
+
+  gz::msgs::Int32 msg;
+
+  {
+    auto msg2 = std::make_unique<gz::msgs::Int32>();
+
+    std::function<void(const gz::msgs::Int32&)> callback =
+      [&msg2](const gz::msgs::Int32& msg) {
+
+        if (nullptr == msg2)
+        {
+          FAIL();
+        }
+
+        (void) msg;
+        return;
+      };
+
+    node.Subscribe("/my_topic", callback);
+    publisher.Publish(msg);
+    publisher.Publish(msg);
+    node.Unsubscribe("/my_topic");
+
+    // Clear msg2
+    msg2.reset();
+  }
+}


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-transport/issues/380

## Summary

This PR builds on top of the integration test in the `mjcarroll/callback_scope_test` branch and the test should now pass with these changes.

The fix is to loop through the publish queue and remove any outdated handlers that's responsible for invoking callbacks for the topic that's already been unsubscribed.

One important change that I need feedback on is the change of `pubQueue` from `std::queue` to `std::list`. This is done so that I can loop through the STL data structure


## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
