### PR TITLE
Pass std::function by value to Node::Subscribe

### DIFF
--- a/include/gz/transport/Node.hh
+++ b/include/gz/transport/Node.hh
@@ -273,7 +273,7 @@ namespace ignition
       public: template<typename MessageT>
       bool Subscribe(
           const std::string &_topic,
-          std::function<void(const MessageT &_msg)> &_callback,
+          std::function<void(const MessageT &_msg)> _callback,
           const SubscribeOptions &_opts = SubscribeOptions());
 
       /// \brief Subscribe to a topic registering a callback.
@@ -322,7 +322,7 @@ namespace ignition
       bool Subscribe(
           const std::string &_topic,
           std::function<void(const MessageT &_msg,
-                             const MessageInfo &_info)> &_callback,
+                             const MessageInfo &_info)> _callback,
           const SubscribeOptions &_opts = SubscribeOptions());
 
       /// \brief Subscribe to a topic registering a callback.

--- a/include/gz/transport/detail/Node.hh
+++ b/include/gz/transport/detail/Node.hh
@@ -20,6 +20,7 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 
 namespace ignition
 {
@@ -59,10 +60,10 @@ namespace ignition
         const SubscribeOptions &_opts)
     {
       std::function<void(const MessageT &, const MessageInfo &)> f =
-        [_cb](const MessageT & _internalMsg,
+        [cb = std::move(_cb)](const MessageT & _internalMsg,
               const MessageInfo &/*_internalInfo*/)
       {
-        _cb(_internalMsg);
+        cb(_internalMsg);
       };
 
       return this->Subscribe<MessageT>(_topic, f, _opts);
@@ -129,7 +130,7 @@ namespace ignition
           new SubscriptionHandler<MessageT>(this->NodeUuid(), _opts));
 
       // Insert the callback into the handler.
-      subscrHandlerPtr->SetCallback(_cb);
+      subscrHandlerPtr->SetCallback(std::move(_cb));
 
       std::lock_guard<std::recursive_mutex> lk(this->Shared()->mutex);
 

--- a/include/gz/transport/detail/Node.hh
+++ b/include/gz/transport/detail/Node.hh
@@ -55,7 +55,7 @@ namespace ignition
     template<typename MessageT>
     bool Node::Subscribe(
         const std::string &_topic,
-        std::function<void(const MessageT &_msg)> &_cb,
+        std::function<void(const MessageT &_msg)> _cb,
         const SubscribeOptions &_opts)
     {
       std::function<void(const MessageT &, const MessageInfo &)> f =
@@ -109,7 +109,7 @@ namespace ignition
     bool Node::Subscribe(
         const std::string &_topic,
         std::function<void(const MessageT &_msg,
-                           const MessageInfo &_info)> &_cb,
+                           const MessageInfo &_info)> _cb,
         const SubscribeOptions &_opts)
     {
       // Topic remapping.


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>

# 🎉 New feature

Yes this does break API in a released version of transport. However, I believe it doesn't functionally change how `Node::Subscribe` operates, and should not affect downstream users.

The [Node::Subscribe](https://github.com/gazebosim/gz-transport/blob/ign-transport8/include/gz/transport/detail/Node.hh#L56) functions that take a `std::function` use pass by non-const reference. The provided `_cb` function is then copy-captured in a lambda function, or copied in [SubscriptionHandler::SetCallback](https://github.com/gazebosim/gz-transport/blob/ign-transport8/include/gz/transport/SubscriptionHandler.hh#L193).

Passing by value, which this PR proposes, has the same result as passing by reference. A copy is ultimately made.

You can read about [lambda captures here](https://en.cppreference.com/w/cpp/language/lambda#Lambda_capture).

You can look at what the compiler does [here](https://godbolt.org/z/ac45KfxMo). Change the parameter types and you should see the same set of operations.

Given that, I'd like to make an exception to our API rule. As a side benefit, users will gain the ability to do the following:

```
    n.Subscribe([](const Foo& msg){ return; });
```

Thanks to @mjcarroll for the help and @codebot for the suggestion.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.