### PR TITLE
Show subscribers info when running topic info

### DIFF
--- a/include/gz/transport/Node.hh
+++ b/include/gz/transport/Node.hh
@@ -670,8 +670,17 @@ namespace gz
       /// \param[in] _topic Name of the topic.
       /// \param[out] _publishers List of publishers on the topic
       /// \return False if unable to get topic info
-      public: bool TopicInfo(const std::string &_topic,
+      public: bool GZ_DEPRECATED(13) TopicInfo(const std::string &_topic,
                              std::vector<MessagePublisher> &_publishers) const;
+
+      /// \brief Get the information about a topic.
+      /// \param[in] _topic Name of the topic.
+      /// \param[out] _publishers List of publishers on the topic.
+      /// \param[out] _subscribers List of subscribers on the topic.
+      /// \return False if unable to get topic info.
+      public: bool TopicInfo(const std::string &_topic,
+                             std::vector<MessagePublisher> &_publishers,
+                             std::vector<MessagePublisher> &_subscribers) const;
 
       /// \brief Get the list of topics currently advertised in the network.
       /// Note that this function can block for some time if the

--- a/src/Node.cc
+++ b/src/Node.cc
@@ -873,7 +873,18 @@ std::unordered_set<std::string> &Node::SrvsAdvertised() const
 bool Node::TopicInfo(const std::string &_topic,
                      std::vector<MessagePublisher> &_publishers) const
 {
-  this->dataPtr->shared->dataPtr->msgDiscovery->WaitForInit();
+  std::vector<MessagePublisher> unused;
+  return this->TopicInfo(_topic, _publishers, unused);
+}
+
+//////////////////////////////////////////////////
+bool Node::TopicInfo(const std::string &_topic,
+                     std::vector<MessagePublisher> &_publishers,
+                     std::vector<MessagePublisher> &_subscribers) const
+{
+  // We trigger a topic list to update the list of remote subscribers.
+  std::vector<std::string> allTopics;
+  this->dataPtr->shared->dataPtr->msgDiscovery->TopicList(allTopics);
 
   // Construct a topic name with the partition and namespace
   std::string fullyQualifiedTopic;
@@ -883,31 +894,45 @@ bool Node::TopicInfo(const std::string &_topic,
     return false;
   }
 
-  std::lock_guard<std::recursive_mutex> lk(this->dataPtr->shared->mutex);
-
-  // Get all the publishers on the given topics
-  MsgAddresses_M pubs;
-  if (!this->dataPtr->shared->dataPtr->msgDiscovery->Publishers(
-        fullyQualifiedTopic, pubs))
+  // Helper function to do some conversion.
+  auto convert = [](MsgAddresses_M &_input,
+                    std::vector<MessagePublisher> &_output)
   {
-    return false;
-  }
+    _output.clear();
 
-  _publishers.clear();
-
-  // Copy the publishers.
-  for (MsgAddresses_M::iterator iter = pubs.begin(); iter != pubs.end(); ++iter)
-  {
-    for (std::vector<MessagePublisher>::iterator pubIter = iter->second.begin();
-         pubIter != iter->second.end(); ++pubIter)
+    // Copy the publishers.
+    for (MsgAddresses_M::iterator iter = _input.begin();
+           iter != _input.end(); ++iter)
     {
-      // Add the publisher if it doesn't already exist.
-      if (std::find(_publishers.begin(), _publishers.end(), *pubIter) ==
-          _publishers.end())
+      for (std::vector<MessagePublisher>::iterator pubIter =
+             iter->second.begin(); pubIter != iter->second.end(); ++pubIter)
       {
-        _publishers.push_back(*pubIter);
+        // Add the publisher if it doesn't already exist.
+        if (std::find(_output.begin(), _output.end(), *pubIter) ==
+            _output.end())
+        {
+          _output.push_back(*pubIter);
+        }
       }
     }
+  };
+
+  std::lock_guard<std::recursive_mutex> lk(this->dataPtr->shared->mutex);
+
+  // Get all the publishers on the given topics.
+  MsgAddresses_M pubs;
+  if (this->dataPtr->shared->dataPtr->msgDiscovery->Publishers(
+        fullyQualifiedTopic, pubs))
+  {
+    convert(pubs, _publishers);
+  }
+
+  // Get all the remote subscribers on the given topics.
+  MsgAddresses_M subs;
+  if (this->dataPtr->shared->dataPtr->msgDiscovery->RemoteSubscribers(
+        fullyQualifiedTopic, subs))
+  {
+    convert(subs, _subscribers);
   }
 
   return true;

--- a/src/cmd/gz.cc
+++ b/src/cmd/gz.cc
@@ -61,22 +61,22 @@ extern "C" void cmdTopicInfo(const char *_topic)
     return;
   }
 
-  Node node;
-
   // Get the publishers on the requested topic
   std::vector<MessagePublisher> publishers;
-  node.TopicInfo(_topic, publishers);
+  std::vector<MessagePublisher> subscribers;
+  Node node;
+  node.TopicInfo(_topic, publishers, subscribers);
 
   if (!publishers.empty())
   {
     std::cout << "Publishers [Address, Message Type]:\n";
 
-    /// List the publishers
+    // List the publishers
     for (std::vector<MessagePublisher>::iterator iter = publishers.begin();
         iter != publishers.end(); ++iter)
     {
       std::cout << "  " << (*iter).Addr() << ", "
-        << (*iter).MsgTypeName() << std::endl;
+                << (*iter).MsgTypeName() << std::endl;
     }
   }
   else
@@ -84,7 +84,23 @@ extern "C" void cmdTopicInfo(const char *_topic)
     std::cout << "No publishers on topic [" << _topic << "]\n";
   }
 
-  // TODO(anyone): Add subscribers lists
+  // Get the subscribers on the requested topic
+  if (!subscribers.empty())
+  {
+    std::cout << "Subscribers [Address, Message Type]:\n";
+
+    // List the subscribers
+    for (std::vector<MessagePublisher>::iterator iter = subscribers.begin();
+        iter != subscribers.end(); ++iter)
+    {
+      std::cout << "  " << (*iter).Addr() << ", "
+                << (*iter).MsgTypeName() << std::endl;
+    }
+  }
+  else
+  {
+    std::cout << "No subscribers on topic [" << _topic << "]\n";
+  }
 }
 
 //////////////////////////////////////////////////

--- a/src/cmd/gz_TEST.cc
+++ b/src/cmd/gz_TEST.cc
@@ -172,15 +172,17 @@ TEST(gzTest, TopicInfo)
 
   while (!infoFound && retries++ < 10u)
   {
-    output = custom_exec_str(gz + " topic -t /foo -i " + g_gzVersion);
-    infoFound = output.size() > 60u;
+    output = custom_exec_str(gz + " topic -t /foo2 -i " + g_gzVersion);
+    std::cout << output.size() << std::endl;
+    infoFound = output.size() > 70u;
     std::this_thread::sleep_for(std::chrono::milliseconds(300));
   }
 
   EXPECT_TRUE(infoFound) << "OUTPUT["
     << output << "] Size[" << output.size()
-    << "]. Expected Size>60" << std::endl;
+    << "]. Expected Size>70" << std::endl;
   EXPECT_TRUE(output.find("gz.msgs.Vector3d") != std::string::npos);
+  std::cout << output << std::endl;
 
   // Wait for the child process to return.
   testing::waitAndCleanupFork(pi);

--- a/src/cmd/gz_TEST.cc
+++ b/src/cmd/gz_TEST.cc
@@ -172,17 +172,16 @@ TEST(gzTest, TopicInfo)
 
   while (!infoFound && retries++ < 10u)
   {
-    output = custom_exec_str(gz + " topic -t /foo2 -i " + g_gzVersion);
-    std::cout << output.size() << std::endl;
-    infoFound = output.size() > 70u;
+    output = custom_exec_str(gz + " topic -t /foo -i " + g_gzVersion);
+    bool pubsFound = output.find("No publishers") == std::string::npos;
+    bool subsFound = output.find("No subscribers") == std::string::npos;
+    // We should have publishers info but no subscribers.
+    infoFound = pubsFound && !subsFound;
     std::this_thread::sleep_for(std::chrono::milliseconds(300));
   }
 
-  EXPECT_TRUE(infoFound) << "OUTPUT["
-    << output << "] Size[" << output.size()
-    << "]. Expected Size>70" << std::endl;
+  EXPECT_TRUE(infoFound);
   EXPECT_TRUE(output.find("gz.msgs.Vector3d") != std::string::npos);
-  std::cout << output << std::endl;
 
   // Wait for the child process to return.
   testing::waitAndCleanupFork(pi);
@@ -211,13 +210,14 @@ TEST(gzTest, TopicInfoSub)
     {
       output = custom_exec_str(gz + " topic -i -t " + topic + " "
         + g_gzVersion);
-      infoFound = output.size() > 60u;
+      bool pubsFound = output.find("No publishers") == std::string::npos;
+      bool subsFound = output.find("No subscribers") == std::string::npos;
+      // We should have subscribers info but no publishers.
+      infoFound = !pubsFound && subsFound;
       std::this_thread::sleep_for(std::chrono::milliseconds(300));
     }
 
-    EXPECT_TRUE(infoFound) << "OUTPUT["
-      << output << "] Size[" << output.size()
-      << "]. Expected Size>60" << std::endl;
+    EXPECT_TRUE(infoFound);
     EXPECT_TRUE(output.find("gz.msgs.") != std::string::npos);
   }
 }

--- a/src/cmd/gz_TEST.cc
+++ b/src/cmd/gz_TEST.cc
@@ -173,13 +173,13 @@ TEST(gzTest, TopicInfo)
   while (!infoFound && retries++ < 10u)
   {
     output = custom_exec_str(gz + " topic -t /foo -i " + g_gzVersion);
-    infoFound = output.size() > 50u;
+    infoFound = output.size() > 60u;
     std::this_thread::sleep_for(std::chrono::milliseconds(300));
   }
 
   EXPECT_TRUE(infoFound) << "OUTPUT["
     << output << "] Size[" << output.size()
-    << "]. Expected Size=50" << std::endl;
+    << "]. Expected Size>60" << std::endl;
   EXPECT_TRUE(output.find("gz.msgs.Vector3d") != std::string::npos);
 
   // Wait for the child process to return.
@@ -341,7 +341,7 @@ TEST(gzTest, TopicInfoSameProc)
   while (!infoFound && retries++ < 10u)
   {
     output = custom_exec_str(gz + " topic -t /foo -i " + g_gzVersion);
-    infoFound = output.size() > 50u;
+    infoFound = output.size() > 60u;
     std::this_thread::sleep_for(std::chrono::milliseconds(300));
   }
 

--- a/src/cmd/gz_src_TEST.cc
+++ b/src/cmd/gz_src_TEST.cc
@@ -88,7 +88,10 @@ TEST(gzTest, cmdTopicInfo)
 
   // A topic without advertisers should show an empty list of publishers.
   cmdTopicInfo(g_topic.c_str());
-  EXPECT_EQ(stdOutBuffer.str(), "No publishers on topic [/topic]\n");
+  EXPECT_TRUE(stdOutBuffer.str().find("No publishers on topic [/topic]\n") !=
+    std::string::npos);
+  EXPECT_TRUE(stdOutBuffer.str().find("No subscribers on topic [/topic]\n") !=
+    std::string::npos);
   clearIOStreams(stdOutBuffer, stdErrBuffer);
 
   restoreIO();

--- a/test/integration/twoProcsPubSub.cc
+++ b/test/integration/twoProcsPubSub.cc
@@ -514,17 +514,18 @@ TEST(twoProcPubSub, TopicInfo)
 
   transport::Node node;
   std::vector<transport::MessagePublisher> publishers;
+  std::vector<transport::MessagePublisher> subscribers;
 
   // We need some time for discovering the other node.
   std::this_thread::sleep_for(std::chrono::milliseconds(2500));
 
-  EXPECT_FALSE(node.TopicInfo("@", publishers));
+  EXPECT_FALSE(node.TopicInfo("@", publishers, subscribers));
   EXPECT_EQ(publishers.size(), 0u);
 
-  EXPECT_FALSE(node.TopicInfo("/bogus", publishers));
+  EXPECT_FALSE(node.TopicInfo("/bogus", publishers, subscribers));
   EXPECT_EQ(publishers.size(), 0u);
 
-  EXPECT_TRUE(node.TopicInfo("/foo", publishers));
+  EXPECT_TRUE(node.TopicInfo("/foo", publishers, subscribers));
   EXPECT_EQ(publishers.size(), 1u);
   EXPECT_EQ(publishers.front().MsgTypeName(), "gz.msgs.Vector3d");
 

--- a/test/integration/twoProcsPubSub.cc
+++ b/test/integration/twoProcsPubSub.cc
@@ -522,7 +522,7 @@ TEST(twoProcPubSub, TopicInfo)
   EXPECT_FALSE(node.TopicInfo("@", publishers, subscribers));
   EXPECT_EQ(publishers.size(), 0u);
 
-  EXPECT_FALSE(node.TopicInfo("/bogus", publishers, subscribers));
+  EXPECT_TRUE(node.TopicInfo("/bogus", publishers, subscribers));
   EXPECT_EQ(publishers.size(), 0u);
 
   EXPECT_TRUE(node.TopicInfo("/foo", publishers, subscribers));


### PR DESCRIPTION
# 🎉 New feature

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

This patch includes the subscribed topics in the output of `gz topic -i`.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

In one terminal run:

```
gz topic -e -t /foo
```

In another terminal run:

```
gz topic -i -t /foo
```

Your output should be:
```
No publishers on topic [/foo]
Subscribers [Address, Message Type]:
  tcp://172.17.0.1:39133, google.protobuf.Message

```

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

