### PR TITLE
11.4.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-transport11 VERSION 11.3.2)
+project(ignition-transport11 VERSION 11.4.0)
 
 #============================================================================
 # Find ignition-cmake

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,15 @@
 ## Gazebo Transport 11.X
 
+### Gazebo Transport 11.4.0 (2023-03-08)
+
+1. Added Node::RequestRaw
+    * [Pull request #351](https://github.com/gazebosim/gz-transport/pull/351)
+
+1. Suppress some Windows warnings.
+    * [Pull request #367](https://github.com/gazebosim/gz-transport/pull/367)
+
+1. All changes up to version 8.2.0.
+
 ### Gazebo Transport 11.3.2 (2022-12-08)
 
 1. Fix include/ignition/.../parameters header files


### PR DESCRIPTION

# 🎈 Release

Preparation for 11.4.0 release.

Comparison to 11.3.2: https://github.com/gazebosim/gz-transport/compare/ignition-transport11_11.3.2...ign-transport11

Needed by https://github.com/gazebosim/gz-launch/pull/187

## Checklist
- [ ] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [ ] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
