### PR TITLE
Fix compiler warning and signedness issue

### DIFF
--- a/include/gz/transport/Discovery.hh
+++ b/include/gz/transport/Discovery.hh
@@ -788,7 +788,7 @@ namespace ignition
         sockaddr_in clntAddr;
         socklen_t addrLen = sizeof(clntAddr);
 
-        uint16_t received = recvfrom(this->sockets.at(0),
+        ssize_t received = recvfrom(this->sockets.at(0),
               reinterpret_cast<raw_type *>(rcvStr),
               this->kMaxRcvStr, 0,
               reinterpret_cast<sockaddr *>(&clntAddr),
@@ -820,7 +820,7 @@ namespace ignition
           // unexpected size, then we ignore the message.
 
           // If-condition for version 8+
-          if (len + sizeof(len) == received)
+          if (len + sizeof(len) == static_cast<uint16_t>(received))
           {
             std::string srcAddr = inet_ntoa(clntAddr.sin_addr);
             uint16_t srcPort = ntohs(clntAddr.sin_port);


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #<NUMBER>

## Summary

This commit fixes a compiler warning I was getting with regard to signed and unsigned types. On line 794 of `Discovery.hh` we use the recvfrom but we use an unsigned int to check if the error is correct or not. By default recvfrom returns an `ssize_t` not a `uint16_t`. It seems a fix for this has landed in garden but has not been backported to citadel or fortress.

<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->


<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
