### PR TITLE
Fix filesystem headers for tests

### DIFF
--- a/test/test_config.hh.in
+++ b/test/test_config.hh.in
@@ -31,15 +31,16 @@
 #endif
 
 #ifndef __APPLE__
-  #if ((defined(__clang__) && __cplusplus < 201703L) || \
-      (__unix__ && __GNUC__ < 8))
-    #define GZ_EXPERIMENTAL_FILESYSTEM
+  #if (!(defined(__clang__) || __unix__) || \
+      (defined(__clang__) && __cplusplus >= 201703L) || \
+      (__unix__ && __GNUC__ >= 8))
+    #define GZ_HAVE_FILESYSTEM
   #endif
 
-  #ifdef GZ_EXPERIMENTAL_FILESYSTEM
-    #include <experimental/filesystem>
-  #else
+  #ifdef GZ_HAVE_FILESYSTEM
     #include <filesystem>
+  #else
+    #include <experimental/filesystem>
   #endif
 #endif
 
@@ -103,10 +104,10 @@ namespace testing
     // Ugly as hell but trying to avoid boost::filesystem
     return _str1 + "/" + _str2;
 #else
-  #ifdef GZ_EXPERIMENTAL_FILESYSTEM
-      using namespace std::experimental::filesystem;
-    #else
+    #ifdef GZ_HAVE_FILESYSTEM
       using namespace std::filesystem;
+    #else
+      using namespace std::experimental::filesystem;
     #endif
     return (path(_str1) / path(_str2)).string();
 #endif


### PR DESCRIPTION
The current logic for choosing <filesystem> vs <experimental/filesystem> in tests is slightly wrong. For either clang toolchains with C++17 support or for gcc compiler >= 8, we should use the standard filesystem. In addition, this PR preserves the logic that if the system is not unix-like and also doesn't have a clang toolchain (e.g. windows), we should use the standard filesystem.