### PR TITLE
Fix compatibility with protobuf 22

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,9 +38,7 @@ message(STATUS "\n\n-- ====== Finding Dependencies ======")
 
 #--------------------------------------
 # Find Protobuf
-set(REQ_PROTOBUF_VER 3)
 ign_find_package(IgnProtobuf
-                 VERSION ${REQ_PROTOBUF_VER}
                  REQUIRED
                  PRETTY Protobuf)
 

--- a/include/gz/transport/RepHandler.hh
+++ b/include/gz/transport/RepHandler.hh
@@ -26,7 +26,7 @@
 #pragma warning(pop)
 #endif
 
-#if GOOGLE_PROTOBUF_VERSION > 2999999
+#if GOOGLE_PROTOBUF_VERSION > 2999999 && GOOGLE_PROTOBUF_VERSION < 4022000
 #include <google/protobuf/stubs/casts.h>
 #endif
 
@@ -140,7 +140,11 @@ namespace ignition
           return false;
         }
 
-#if GOOGLE_PROTOBUF_VERSION > 2999999
+#if GOOGLE_PROTOBUF_VERSION >= 4022000
+        auto msgReq =
+          google::protobuf::internal::DownCast<const Req*>(&_msgReq);
+        auto msgRep = google::protobuf::internal::DownCast<Rep*>(&_msgRep);
+#elif GOOGLE_PROTOBUF_VERSION > 2999999
         auto msgReq = google::protobuf::down_cast<const Req*>(&_msgReq);
         auto msgRep = google::protobuf::down_cast<Rep*>(&_msgRep);
 #else

--- a/include/gz/transport/SubscriptionHandler.hh
+++ b/include/gz/transport/SubscriptionHandler.hh
@@ -28,7 +28,7 @@
 
 #include <google/protobuf/stubs/common.h>
 
-#if GOOGLE_PROTOBUF_VERSION >= 3000000
+#if GOOGLE_PROTOBUF_VERSION >= 3000000 && GOOGLE_PROTOBUF_VERSION < 4022000
 #include <google/protobuf/stubs/casts.h>
 #endif
 
@@ -211,7 +211,9 @@ namespace ignition
         if (!this->UpdateThrottling())
           return true;
 
-#if GOOGLE_PROTOBUF_VERSION >= 3000000
+#if GOOGLE_PROTOBUF_VERSION >= 4022000
+        auto msgPtr = google::protobuf::internal::DownCast<const T*>(&_msg);
+#elif GOOGLE_PROTOBUF_VERSION >= 3000000
         auto msgPtr = google::protobuf::down_cast<const T*>(&_msg);
 #else
         auto msgPtr = google::protobuf::internal::down_cast<const T*>(&_msg);


### PR DESCRIPTION
# 🎉 New feature

Fix https://github.com/gazebosim/gz-transport/issues/404 by adding compatibility with protobuf >= 22 .

## Summary

Similar to https://github.com/gazebosim/gz-msgs/pull/346, but with an additional fix to change the removed `google::protobuf::down_cast` to `google::protobuf::internal::DownCast` . It may not be ideal to use a function declared in an `internal::` namepsace, but that how actually the method was called in protobuf 2 when it was first used.

## Test it

Install protobuf 22 or 23, and compile gz-citadel against it.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
