### PR TITLE
Backport Windows fix to ign-transport8

### DIFF
--- a/include/gz/transport/TopicStatistics.hh
+++ b/include/gz/transport/TopicStatistics.hh
@@ -19,11 +19,23 @@
 
 #include <gz/msgs/statistic.pb.h>
 
+#include <algorithm>
 #include <limits>
 #include <memory>
 #include <string>
 #include "gz/transport/config.hh"
 #include "gz/transport/Export.hh"
+
+#ifdef _WIN32
+#ifndef NOMINMAX
+  #define NOMINMAX
+#endif
+#ifdef min
+  #undef min
+  #undef max
+#endif
+#include <windows.h>
+#endif
 
 namespace ignition
 {


### PR DESCRIPTION
# 🦟 Bug fix

Fixes a compilation problem in a downstream project: https://github.com/robotology/robotology-superbuild/issues/1425 by backporting https://github.com/gazebosim/gz-transport/pull/250 .

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
