### PR TITLE
Cherry-pick #405 to garden: Fix compatibility with protobuf 22

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,9 +39,7 @@ message(STATUS "\n\n-- ====== Finding Dependencies ======")
 
 #--------------------------------------
 # Find Protobuf
-set(REQ_PROTOBUF_VER 3)
 gz_find_package(GzProtobuf
-                 VERSION ${REQ_PROTOBUF_VER}
                  REQUIRED
                  PRETTY Protobuf)
 

--- a/include/gz/transport/RepHandler.hh
+++ b/include/gz/transport/RepHandler.hh
@@ -24,7 +24,7 @@
 #endif
 #include <google/protobuf/message.h>
 #include <google/protobuf/stubs/common.h>
-#if GOOGLE_PROTOBUF_VERSION >= 3000000
+#if GOOGLE_PROTOBUF_VERSION > 2999999 && GOOGLE_PROTOBUF_VERSION < 4022000
 #include <google/protobuf/stubs/casts.h>
 #endif
 #ifdef _MSC_VER
@@ -141,7 +141,11 @@ namespace gz
           return false;
         }
 
-#if GOOGLE_PROTOBUF_VERSION > 2999999
+#if GOOGLE_PROTOBUF_VERSION >= 4022000
+        auto msgReq =
+          google::protobuf::internal::DownCast<const Req*>(&_msgReq);
+        auto msgRep = google::protobuf::internal::DownCast<Rep*>(&_msgRep);
+#elif GOOGLE_PROTOBUF_VERSION > 2999999
         auto msgReq = google::protobuf::down_cast<const Req*>(&_msgReq);
         auto msgRep = google::protobuf::down_cast<Rep*>(&_msgRep);
 #else

--- a/include/gz/transport/SubscriptionHandler.hh
+++ b/include/gz/transport/SubscriptionHandler.hh
@@ -24,7 +24,7 @@
 #endif
 #include <google/protobuf/message.h>
 #include <google/protobuf/stubs/common.h>
-#if GOOGLE_PROTOBUF_VERSION >= 3000000
+#if GOOGLE_PROTOBUF_VERSION >= 3000000 && GOOGLE_PROTOBUF_VERSION < 4022000
 #include <google/protobuf/stubs/casts.h>
 #endif
 #ifdef _MSC_VER
@@ -210,7 +210,9 @@ namespace gz
         if (!this->UpdateThrottling())
           return true;
 
-#if GOOGLE_PROTOBUF_VERSION >= 3000000
+#if GOOGLE_PROTOBUF_VERSION >= 4022000
+        auto msgPtr = google::protobuf::internal::DownCast<const T*>(&_msg);
+#elif GOOGLE_PROTOBUF_VERSION >= 3000000
         auto msgPtr = google::protobuf::down_cast<const T*>(&_msg);
 #else
         auto msgPtr = google::protobuf::internal::down_cast<const T*>(&_msg);

--- a/src/cmd/gz.cc
+++ b/src/cmd/gz.cc
@@ -274,8 +274,16 @@ extern "C" void cmdTopicEcho(const char *_topic,
       case MsgOutputFormat::kJSON:
         {
           std::string jsonStr;
-          google::protobuf::util::MessageToJsonString(_msg, &jsonStr);
-          std::cout << jsonStr << std::endl;
+          auto status =
+              google::protobuf::util::MessageToJsonString(_msg, &jsonStr);
+          if (status.ok())
+          {
+            std::cout << jsonStr << std::endl;
+          }
+          else
+          {
+            std::cerr << status;
+          }
         }
         break;
       default:


### PR DESCRIPTION
Part of https://github.com/osrf/homebrew-simulation/issues/2274. Cherry-picking forward to assist with rebuilding broken bottles.

Thanks to @traversaro for the patch!

Use rebase-and-merge.