### PR TITLE
Acquire the GIL when invoking callbacks

### DIFF
--- a/python/src/transport/_gz_transport_pybind11.cc
+++ b/python/src/transport/_gz_transport_pybind11.cc
@@ -282,6 +282,7 @@ PYBIND11_MODULE(BINDINGS_MODULE_NAME, m) {
           {
             auto _cb = [_callback](const char *_msgData, const size_t _size,
                            const MessageInfo &_info){
+                pybind11::gil_scoped_acquire acq;
                 return _callback(py::bytes(_msgData, _size), _info);
             };
             return _node.SubscribeRaw(_topic, _cb, _msgType, _opts);


### PR DESCRIPTION
# 🦟 Bug fix


## Summary
gz-transport callbacks are invoked from a separate thread so we need to acquire the GIL. Users such as gz-sim need to release the GIL regularly to ensure callbacks are serviced in a timely manner.

Came up in tests in https://github.com/gazebosim/gz-sim/pull/2081. Tests there are flaky without this PR.
 
## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
