### PR TITLE
Fix race condition in TopicInfo

### DIFF
--- a/include/gz/transport/Discovery.hh
+++ b/include/gz/transport/Discovery.hh
@@ -634,7 +634,10 @@ namespace gz
       /// \param[out] _topics List of advertised topics.
       public: void TopicList(std::vector<std::string> &_topics)
       {
-        this->remoteSubscribers.Clear();
+        {
+          std::lock_guard<std::mutex> lock(this->mutex);
+          this->remoteSubscribers.Clear();
+        }
 
         // Request the list of subscribers.
         Publisher pub("", "", this->pUuid, "", AdvertiseOptions());


### PR DESCRIPTION
# 🦟 Bug fix

See #430 

## Summary

This patch fixes a potential race condition when calling `TopicList`.

See #430 to reproduce the issue/fix with the Gazebo `Image Display` plugin.
 
## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
