### PR TITLE
Fix python install directory

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -27,8 +27,10 @@ if(USE_SYSTEM_PATHS_FOR_PYTHON_INSTALLATION)
   endif()
 else()
   # If not a system installation, respect local paths
-  set(GZ_PYTHON_INSTALL_PATH ${GZ_LIB_INSTALL_DIR}/python/gz)
+  set(GZ_PYTHON_INSTALL_PATH ${GZ_LIB_INSTALL_DIR}/python)
 endif()
+
+set(GZ_PYTHON_INSTALL_PATH "${GZ_PYTHON_INSTALL_PATH}/gz")
 
 # Set the build location and install location for a CPython extension
 function(configure_build_install_location _library_name)


### PR DESCRIPTION
# 🦟 Bug fix


## Summary
The `gz` directory was missing from the install path. The contents of the deb file before this PR is

```
/.
/usr
/usr/lib
/usr/lib/python3
/usr/lib/python3/dist-packages
/usr/lib/python3/dist-packages/transport13
/usr/lib/python3/dist-packages/transport13/__init__.py
/usr/lib/python3/dist-packages/transport13/_transport.cpython-310-x86_64-linux-gnu.so
/usr/share
/usr/share/doc
/usr/share/doc/python3-gz-transport13
/usr/share/doc/python3-gz-transport13/changelog.Debian.gz
/usr/share/doc/python3-gz-transport13/copyright
```

It should be `/usr/lib/python3/dist-packages/gz/transport13/`

Needed by https://github.com/gazebosim/gz-sim/pull/2081

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
