### PR TITLE
Prepare for 11.4.1 Release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-transport11 VERSION 11.4.0)
+project(ignition-transport11 VERSION 11.4.1)
 
 #============================================================================
 # Find ignition-cmake

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,32 @@
 ## Gazebo Transport 11.X
 
+### Gazebo Transport 11.4.1 (2023-09-01)
+
+1. Fix topic/service list inconsistency
+    * [Pull request #415](https://github.com/gazebosim/gz-transport/pull/415)
+
+1. Backport Windows fix to ign-transport8
+    * [Pull request #406](https://github.com/gazebosim/gz-transport/pull/406)
+
+1. Fix unused-result warning
+    * [Pull request #408](https://github.com/gazebosim/gz-transport/pull/408)
+
+1. Fix compatibility with protobuf 22
+    * [Pull request #405](https://github.com/gazebosim/gz-transport/pull/405)
+
+1. Fix compiler warning and signedness issue
+    * [Pull request #401](https://github.com/gazebosim/gz-transport/pull/401)
+
+1. Rename COPYING to LICENSE
+    * [Pull request #392](https://github.com/gazebosim/gz-transport/pull/392)
+
+1. Infrastructure
+    * [Pull request #391](https://github.com/gazebosim/gz-transport/pull/391)
+    * [Pull request #394](https://github.com/gazebosim/gz-transport/pull/394)
+
+1. Support clang and std::filesystem
+    * [Pull request #390](https://github.com/gazebosim/gz-transport/pull/390)
+
 ### Gazebo Transport 11.4.0 (2023-03-08)
 
 1. Added Node::RequestRaw


### PR DESCRIPTION
# 🎈 Release

Preparation for 11.4.1 release.

Comparison to 11.4.0: https://github.com/gazebosim/gz-transport/compare/ignition-transport11_11.4.0...ign-transport11

<!-- Add links to PRs that require this release (if needed) -->
Needed by <PR(s)>

## Checklist
- [ ] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [ ] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.