### PR TITLE
Prepare for 13.0.0~pre2 Release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ cmake_dependent_option(USE_DIST_PACKAGES_FOR_PYTHON
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-gz_configure_project(VERSION_SUFFIX pre1)
+gz_configure_project(VERSION_SUFFIX pre2)
 
 #============================================================================
 # Set project-specific options

--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@
     * [Pull request #438](https://github.com/gazebosim/gz-transport/pull/438)
     * [Pull request #437](https://github.com/gazebosim/gz-transport/pull/437)
     * [Pull request #439](https://github.com/gazebosim/gz-transport/pull/439)
+    * [Pull request #441](https://github.com/gazebosim/gz-transport/pull/441)
 
 1. Protect remoteSubscribers with mutex.
     * [Pull request #432](https://github.com/gazebosim/gz-transport/pull/432)

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@
 1. Documentation fixes
     * [Pull request #438](https://github.com/gazebosim/gz-transport/pull/438)
     * [Pull request #437](https://github.com/gazebosim/gz-transport/pull/437)
+    * [Pull request #439](https://github.com/gazebosim/gz-transport/pull/439)
 
 1. Protect remoteSubscribers with mutex.
     * [Pull request #432](https://github.com/gazebosim/gz-transport/pull/432)
@@ -31,19 +32,6 @@
 
 1. Fix topic/service list inconsistency
     * [Pull request #415](https://github.com/gazebosim/gz-transport/pull/415)
-
-1. Fix compiler warnings
-    * [Pull request #408](https://github.com/gazebosim/gz-transport/pull/408)
-    * [Pull request #401](https://github.com/gazebosim/gz-transport/pull/401)
-
-1. Fix compatibility with protobuf 22
-    * [Pull request #405](https://github.com/gazebosim/gz-transport/pull/405)
-
-1. Fix filesystem headers for tests
-    * [Pull request #402](https://github.com/gazebosim/gz-transport/pull/402)
-
-1. Fix typos
-    * [Pull request #403](https://github.com/gazebosim/gz-transport/pull/403)
 
 1. Show subscribers info when running topic info
     * [Pull request #384](https://github.com/gazebosim/gz-transport/pull/384)

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,58 @@
 
 ### Gazebo Transport 13.0.0 (202X-XX-XX)
 
+1. Fix Docker in Harmonic
+    * [Pull request #440](https://github.com/gazebosim/gz-transport/pull/440)
+
+1. Documentation fixes
+    * [Pull request #438](https://github.com/gazebosim/gz-transport/pull/438)
+    * [Pull request #437](https://github.com/gazebosim/gz-transport/pull/437)
+
+1. Protect remoteSubscribers with mutex.
+    * [Pull request #432](https://github.com/gazebosim/gz-transport/pull/432)
+
+1. Remove deprecations in Harmonic
+    * [Pull request #426](https://github.com/gazebosim/gz-transport/pull/426)
+
+1. ign -> gz
+    * [Pull request #424](https://github.com/gazebosim/gz-transport/pull/424)
+
+1. Infrastructure
+    * [Pull request #428](https://github.com/gazebosim/gz-transport/pull/428)
+    * [Pull request #423](https://github.com/gazebosim/gz-transport/pull/423)
+    * [Pull request #427](https://github.com/gazebosim/gz-transport/pull/427)
+
+1. Python Bindings for Publisher, Subscriber and Service Request features.
+    * [Pull request #411](https://github.com/gazebosim/gz-transport/pull/411)
+    * [Pull request #433](https://github.com/gazebosim/gz-transport/pull/433)
+    * [Pull request #431](https://github.com/gazebosim/gz-transport/pull/431)
+    * [Pull request #443](https://github.com/gazebosim/gz-transport/pull/443)
+
+1. Fix topic/service list inconsistency
+    * [Pull request #415](https://github.com/gazebosim/gz-transport/pull/415)
+
+1. Fix compiler warnings
+    * [Pull request #408](https://github.com/gazebosim/gz-transport/pull/408)
+    * [Pull request #401](https://github.com/gazebosim/gz-transport/pull/401)
+
+1. Fix compatibility with protobuf 22
+    * [Pull request #405](https://github.com/gazebosim/gz-transport/pull/405)
+
+1. Fix filesystem headers for tests
+    * [Pull request #402](https://github.com/gazebosim/gz-transport/pull/402)
+
+1. Fix typos
+    * [Pull request #403](https://github.com/gazebosim/gz-transport/pull/403)
+
+1. Show subscribers info when running topic info
+    * [Pull request #384](https://github.com/gazebosim/gz-transport/pull/384)
+
+1. List subscribed topics when running topic list
+    * [Pull request #379](https://github.com/gazebosim/gz-transport/pull/379)
+
+1. ⬆️  Bump main to 13.0.0~pre1
+    * [Pull request #344](https://github.com/gazebosim/gz-transport/pull/344)
+
 ## Gazebo Transport 12.X
 
 ### Gazebo Transport 12.2.1 (2023-09-26)


### PR DESCRIPTION
# 🎈 Release

Preparation for 13.0.0~pre2 release.

Comparison to gz-transport12: https://github.com/gazebosim/gz-transport/compare/gz-transport12...gz-transport13

## Checklist
- [ ] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [ ] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.