### PR TITLE
Prepare for 13.0.0 Release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ cmake_dependent_option(USE_DIST_PACKAGES_FOR_PYTHON
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-gz_configure_project(VERSION_SUFFIX pre2)
+gz_configure_project(VERSION_SUFFIX)
 
 #============================================================================
 # Set project-specific options

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 ## Gazebo Transport 13.X
 
-### Gazebo Transport 13.0.0 (202X-XX-XX)
+### Gazebo Transport 13.0.0 (2023-09-29)
 
 1. Fix Docker in Harmonic
     * [Pull request #440](https://github.com/gazebosim/gz-transport/pull/440)


### PR DESCRIPTION
# 🎈 Release

Preparation for 13.0.0 release.

Comparison to 13.0.0-pre2: https://github.com/gazebosim/gz-transport/compare/gz-transport13_13.0.0-pre2...gz-transport13

<!-- Add links to PRs that require this release (if needed) -->
Needed by <PR(s)>

## Checklist
- [ ] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [ ] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.