### PR TITLE
Make empty constructor as peer to explicit

### DIFF
--- a/include/gz/transport/Node.hh
+++ b/include/gz/transport/Node.hh
@@ -198,9 +198,11 @@ namespace gz
 #endif
       };
 
+      public: Node();
+
       /// \brief Constructor.
       /// \param[in] _options Node options.
-      public: explicit Node(const NodeOptions &_options = NodeOptions());
+      public: explicit Node(const NodeOptions &_options);
 
       /// \brief Destructor.
       public: virtual ~Node();

--- a/src/Node.cc
+++ b/src/Node.cc
@@ -515,6 +515,12 @@ Node::Node(const NodeOptions &_options)
 }
 
 //////////////////////////////////////////////////
+Node::Node():
+  Node(gz::transport::NodeOptions())
+{
+}
+
+//////////////////////////////////////////////////
 Node::~Node()
 {
   // Unsubscribe from all the topics.


### PR DESCRIPTION
I think this is actually what we intended to do with the `Node` constructor.

The `explicit` keyword makes using the default constructor a little strange in combination with `ImplPtr`.

For example:

```
class Foo
{
   GZ_UTILS_UNIQUE_IMPL_PTR(dataPtr)
};

class Foo::Implementation
{
  gz::transport::Node node;
};
```

Produces the compiler error:

```
In file included from /usr/local/google/home/mjcarroll/workspaces/gz_ionic/src/gz-gui/src/plugins/camera_tracking/CameraTracking.cc:18:
In file included from /usr/local/google/home/mjcarroll/workspaces/gz_ionic/install/include/gz/utils2/gz/utils/ImplPtr.hh:258:
/usr/local/google/home/mjcarroll/workspaces/gz_ionic/install/include/gz/utils2/gz/utils/detail/ImplPtr.hh:145:46: error: chosen constructor is explicit in copy-initialization
            new T{std::forward<Args>(args)...},
                                             ^
/usr/local/google/home/mjcarroll/workspaces/gz_ionic/src/gz-gui/src/plugins/camera_tracking/CameraTracking.cc:434:24: note: in instantiation of function template specialization 'gz::utils::MakeUniqueImpl<gz::gui::plugins::CameraTracking::Implementation>' requested here
  : dataPtr(gz::utils::MakeUniqueImpl<Implementation>())
                       ^
/usr/local/google/home/mjcarroll/workspaces/gz_ionic/install/include/gz/transport13/gz/transport/Node.hh:203:24: note: explicit constructor declared here
      public: explicit Node(const NodeOptions &_options = NodeOptions());
                       ^
/usr/local/google/home/mjcarroll/workspaces/gz_ionic/src/gz-gui/src/plugins/camera_tracking/CameraTracking.cc:135:27: note: in implicit initialization of field 'node' with omitted initializer
  public: transport::Node node;
                          ^
1 error generated.
```

The other option is to update each Implementation class to explicitly pass the NodeOptions such as follows, but this seems excessive in my mind.

```
class Foo::Implementation
{
  gz::transport::Node node {gz::transport::NodeOptions()};
};
```
