### PR TITLE
Remove duplicated functionality from test_config

### DIFF
--- a/log/test/integration/playback.cc
+++ b/log/test/integration/playback.cc
@@ -21,6 +21,8 @@
 #include <gz/transport/log/Playback.hh>
 #include <gz/transport/log/Recorder.hh>
 #include <gz/transport/Node.hh>
+
+#include <gz/utils/Environment.hh>
 #include <gz/utils/ExtraTestMacros.hh>
 
 #include "ChirpParams.hh"
@@ -800,17 +802,17 @@ int main(int argc, char **argv)
   partition = testing::getRandomNumber();
 
   // Set the partition name for this process.
-  setenv("GZ_PARTITION", partition.c_str(), 1);
+  gz::utils::setenv("GZ_PARTITION", partition);
 
-  setenv("GZ_TRANSPORT_LOG_SQL_PATH",
-         GZ_TRANSPORT_LOG_SQL_PATH, 1);
+  gz::utils::setenv("GZ_TRANSPORT_LOG_SQL_PATH",
+                    GZ_TRANSPORT_LOG_SQL_PATH);
 
   // TODO(CH3): Deprecated. Remove this on tick-tock.
-  setenv("IGN_TRANSPORT_LOG_SQL_PATH",
-         GZ_TRANSPORT_LOG_SQL_PATH, 1);
+  gz::utils::setenv("IGN_TRANSPORT_LOG_SQL_PATH",
+                    GZ_TRANSPORT_LOG_SQL_PATH);
 
-  setenv(gz::transport::log::SchemaLocationEnvVar.c_str(),
-         GZ_TRANSPORT_LOG_SQL_PATH, 1);
+  gz::utils::setenv(gz::transport::log::SchemaLocationEnvVar,
+                    GZ_TRANSPORT_LOG_SQL_PATH);
 
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/log/test/integration/recorder.cc
+++ b/log/test/integration/recorder.cc
@@ -24,6 +24,8 @@
 #include <gz/transport/log/Log.hh>
 #include <gz/transport/log/Recorder.hh>
 #include <gz/transport/Node.hh>
+
+#include <gz/utils/Environment.hh>
 #include <gz/utils/ExtraTestMacros.hh>
 
 #include "ChirpParams.hh"
@@ -538,17 +540,17 @@ int main(int argc, char **argv)
   partition = testing::getRandomNumber();
 
   // Set the partition name for this process.
-  setenv("GZ_PARTITION", partition.c_str(), 1);
+  gz::utils::setenv("GZ_PARTITION", partition);
 
-  setenv("GZ_TRANSPORT_LOG_SQL_PATH",
-         GZ_TRANSPORT_LOG_SQL_PATH, 1);
+  gz::utils::setenv("GZ_TRANSPORT_LOG_SQL_PATH",
+                    GZ_TRANSPORT_LOG_SQL_PATH);
 
   // TODO(CH3): Deprecated. Remove this on tick-tock.
-  setenv("IGN_TRANSPORT_LOG_SQL_PATH",
-         GZ_TRANSPORT_LOG_SQL_PATH, 1);
+  gz::utils::setenv("IGN_TRANSPORT_LOG_SQL_PATH",
+                    GZ_TRANSPORT_LOG_SQL_PATH);
 
-  setenv(gz::transport::log::SchemaLocationEnvVar.c_str(),
-         GZ_TRANSPORT_LOG_SQL_PATH, 1);
+  gz::utils::setenv(gz::transport::log::SchemaLocationEnvVar,
+                    GZ_TRANSPORT_LOG_SQL_PATH);
 
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/log/test/integration/topicChirp_aux.cc
+++ b/log/test/integration/topicChirp_aux.cc
@@ -22,6 +22,8 @@
 
 #include <gz/transport/Node.hh>
 
+#include <gz/utils/Environment.hh>
+
 #include "ChirpParams.hh"
 
 //////////////////////////////////////////////////
@@ -90,7 +92,7 @@ int main(int argc, char **argv)
     return -2;
   }
 
-  setenv("GZ_PARTITION", argv[1], 1);
+  gz::utils::setenv("GZ_PARTITION", argv[1]);
 
   const int chirps = atoi(argv[2]);
 

--- a/src/CIface_TEST.cc
+++ b/src/CIface_TEST.cc
@@ -16,8 +16,11 @@
 */
 #include <gz/msgs/stringmsg.pb.h>
 
-#include "gtest/gtest.h"
 #include "gz/transport/CIface.h"
+
+#include <gz/utils/Environment.hh>
+
+#include "gtest/gtest.h"
 #include "test_config.hh"
 
 static int count;
@@ -180,10 +183,10 @@ int main(int argc, char **argv)
   std::string partition = testing::getRandomNumber();
 
   // Set the partition name for this process.
-  setenv("GZ_PARTITION", partition.c_str(), 1);
+  gz::utils::setenv("GZ_PARTITION", partition);
 
   // Enable verbose mode.
-  // setenv("GZ_VERBOSE", "1", 1);
+  // gz::utils::setenv("GZ_VERBOSE", "1");
 
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/src/Discovery_TEST.cc
+++ b/src/Discovery_TEST.cc
@@ -27,20 +27,10 @@
 #include "gz/transport/Publisher.hh"
 #include "gz/transport/TransportTypes.hh"
 #include "gz/transport/Uuid.hh"
-#include "test_config.hh"
 
-// Temporarily introduce a "DISABLED_ON_LINUX" macro.
-// It currently does not exist upstream.
-// This can be removed when it is in upstream gz-utils
-// or the discovery WrongGzIp test passes on linux
-#include <gz/utils/detail/ExtraTestMacros.hh>
-#if defined __linux__
-  #define GZ_UTILS_TEST_DISABLED_ON_LINUX(TestName) \
-      DETAIL_GZ_UTILS_ADD_DISABLED_PREFIX(TestName)
-#else
-  #define GZ_UTILS_TEST_DISABLED_ON_LINUX(TestName) \
-      TestName
-#endif  // defined __linux__
+#include "gz/utils/ExtraTestMacros.hh"
+
+#include "test_config.hh"
 
 using namespace gz;
 using namespace transport;
@@ -540,16 +530,9 @@ TEST(DiscoveryTest, TestActivity)
   discovery1.TestActivity(proc2Uuid, false);
 }
 
-/// Logic to disable the following test via Linux
-#if defined __linux__
-  #define TEST_NAME DISABLED_WrongIgnIp
-#else
-  #define TEST_NAME WrongIgnIp
-#endif  // defined __linux__
-
 //////////////////////////////////////////////////
 /// \brief Check that a wrong GZ_IP value makes HostAddr() to return 127.0.0.1
-TEST(DiscoveryTest, TEST_NAME)
+TEST(DiscoveryTest, GZ_UTILS_TEST_DISABLED_ON_LINUX(WrongIgnIp))
 {
   // Save the current value of GZ_IP environment variable.
   std::string gzIp;

--- a/src/Discovery_TEST.cc
+++ b/src/Discovery_TEST.cc
@@ -533,7 +533,7 @@ TEST(DiscoveryTest, TestActivity)
 
 //////////////////////////////////////////////////
 /// \brief Check that a wrong GZ_IP value makes HostAddr() to return 127.0.0.1
-TEST(DiscoveryTest, GZ_UTILS_TEST_DISABLED_ON_LINUX(WrongIgnIp))
+TEST(DiscoveryTest, GZ_UTILS_TEST_DISABLED_ON_LINUX(WrongGzIp))
 {
   // Save the current value of GZ_IP environment variable.
   std::string gzIp;

--- a/src/Discovery_TEST.cc
+++ b/src/Discovery_TEST.cc
@@ -28,6 +28,7 @@
 #include "gz/transport/TransportTypes.hh"
 #include "gz/transport/Uuid.hh"
 
+#include "gz/utils/Environment.hh"
 #include "gz/utils/ExtraTestMacros.hh"
 
 #include "test_config.hh"
@@ -536,18 +537,18 @@ TEST(DiscoveryTest, GZ_UTILS_TEST_DISABLED_ON_LINUX(WrongIgnIp))
 {
   // Save the current value of GZ_IP environment variable.
   std::string gzIp;
-  env("GZ_IP", gzIp);
+  gz::utils::env("GZ_IP", gzIp);
 
   // Incorrect value for GZ_IP
-  setenv("GZ_IP", "127.0.0.0", 1);
+  ASSERT_TRUE(gz::utils::setenv("GZ_IP", "127.0.0.0"));
 
   transport::Discovery<MessagePublisher> discovery1(pUuid1, g_ip, g_msgPort);
   EXPECT_EQ(discovery1.HostAddr(), "127.0.0.1");
 
   // Unset GZ_IP.
-  unsetenv("GZ_IP");
+  ASSERT_TRUE(gz::utils::unsetenv("GZ_IP"));
 
   // Restore GZ_IP.
   if (!gzIp.empty())
-    setenv("GZ_IP", gzIp.c_str(), 1);
+    gz::utils::setenv("GZ_IP", gzIp);
 }

--- a/src/Helpers_TEST.cc
+++ b/src/Helpers_TEST.cc
@@ -16,6 +16,9 @@
 */
 
 #include "gz/transport/Helpers.hh"
+
+#include <gz/utils/Environment.hh>
+
 #include "test_config.hh"
 #include "gtest/gtest.h"
 
@@ -33,7 +36,7 @@ TEST(HelpersTest, env)
   EXPECT_FALSE(transport::env(name, value));
 
   // Create a random environment variable and give it its name as value.
-  setenv(name.c_str(), name.c_str(), 1);
+  ASSERT_TRUE(gz::utils::setenv(name, name));
 
   // Check that we find the environment variable and the value is correct.
   EXPECT_TRUE(transport::env(name, value));

--- a/src/NodeOptions_TEST.cc
+++ b/src/NodeOptions_TEST.cc
@@ -19,6 +19,9 @@
 
 #include "gz/transport/NetUtils.hh"
 #include "gz/transport/NodeOptions.hh"
+
+#include <gz/utils/Environment.hh>
+
 #include "test_config.hh"
 #include "gtest/gtest.h"
 
@@ -30,7 +33,7 @@ TEST(NodeOptionsTest, ignPartition)
 {
   // Set GZ_PARTITION
   std::string aPartition = "customPartition";
-  setenv("GZ_PARTITION", aPartition.c_str(), 1);
+  ASSERT_TRUE(gz::utils::setenv("GZ_PARTITION", aPartition));
 
   transport::NodeOptions opts;
   EXPECT_EQ(opts.Partition(), aPartition);
@@ -53,7 +56,7 @@ TEST(NodeOptionsTest, ignPartition)
 TEST(NodeOptionsTest, accessors)
 {
   // Check the default values.
-  unsetenv("GZ_PARTITION");
+  gz::utils::unsetenv("GZ_PARTITION");
   transport::NodeOptions opts;
   EXPECT_TRUE(opts.NameSpace().empty());
   auto defaultPartition = transport::hostname() + ":" + transport::username();

--- a/src/Node_TEST.cc
+++ b/src/Node_TEST.cc
@@ -26,7 +26,6 @@
 #include <string>
 #include <thread>
 
-#include "gtest/gtest.h"
 #include "gz/transport/AdvertiseOptions.hh"
 #include "gz/transport/MessageInfo.hh"
 #include "gz/transport/Node.hh"
@@ -34,6 +33,10 @@
 #include "gz/transport/TopicStatistics.hh"
 #include "gz/transport/TopicUtils.hh"
 #include "gz/transport/TransportTypes.hh"
+
+#include <gz/utils/Environment.hh>
+
+#include "gtest/gtest.h"
 #include "test_config.hh"
 
 using namespace gz;
@@ -2324,10 +2327,10 @@ int main(int argc, char **argv)
   g_FQNPartition = std::string("/") + partition;
 
   // Set the partition name for this process.
-  setenv("GZ_PARTITION", partition.c_str(), 1);
+  gz::utils::setenv("GZ_PARTITION", partition);
 
   // Enable verbose mode.
-  setenv("GZ_VERBOSE", "1", 1);
+  gz::utils::setenv("GZ_VERBOSE", "1");
 
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/src/cmd/gz_TEST.cc
+++ b/src/cmd/gz_TEST.cc
@@ -22,6 +22,8 @@
 #include <fstream>
 #include <iostream>
 #include <string>
+
+#include <gz/utils/Environment.hh>
 #include <gz/utils/ExtraTestMacros.hh>
 
 #include "gtest/gtest.h"
@@ -536,7 +538,7 @@ int main(int argc, char **argv)
   g_partition = testing::getRandomNumber();
 
   // Set the partition name for this process.
-  setenv("GZ_PARTITION", g_partition.c_str(), 1);
+  gz::utils::setenv("GZ_PARTITION", g_partition);
 
   // Make sure that we load the library recently built and not the one installed
   // in your system.
@@ -545,7 +547,7 @@ int main(int argc, char **argv)
   transport::env("LD_LIBRARY_PATH", value);
   // Add the directory where Gazebo Transport has been built.
   value = std::string(GZ_TEST_LIBRARY_PATH) + ":" + value;
-  setenv("LD_LIBRARY_PATH", value.c_str(), 1);
+  gz::utils::setenv("LD_LIBRARY_PATH", value);
 
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/src/cmd/gz_src_TEST.cc
+++ b/src/cmd/gz_src_TEST.cc
@@ -28,10 +28,13 @@
 #pragma warning(pop)
 #endif
 
-#include "gtest/gtest.h"
 #include "gz.hh"
 #include "gz/transport/Node.hh"
+
+#include <gz/utils/Environment.hh>
+
 #include "test_config.hh"
+#include "gtest/gtest.h"
 
 using namespace gz;
 
@@ -296,7 +299,7 @@ int main(int argc, char **argv)
   g_partition = testing::getRandomNumber();
 
   // Set the partition name for this process.
-  setenv("GZ_PARTITION", g_partition.c_str(), 1);
+  gz::utils::setenv("GZ_PARTITION", g_partition);
 
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/test/integration/authPubSub.cc
+++ b/test/integration/authPubSub.cc
@@ -29,6 +29,9 @@
 #include "gtest/gtest.h"
 #include "gz/transport/Node.hh"
 #include "gz/transport/TransportTypes.hh"
+
+#include <gz/utils/Environment.hh>
+
 #include "test_config.hh"
 
 using namespace gz;
@@ -40,8 +43,8 @@ static std::string g_topic = "/foo"; // NOLINT(*)
 TEST(authPubSub, InvalidAuth)
 {
   // Setup the username and password for this test
-  setenv("GZ_TRANSPORT_USERNAME", "admin", 1);
-  setenv("GZ_TRANSPORT_PASSWORD", "test", 1);
+  ASSERT_TRUE(gz::utils::setenv("GZ_TRANSPORT_USERNAME", "admin"));
+  ASSERT_TRUE(gz::utils::setenv("GZ_TRANSPORT_PASSWORD", "test"));
 
   transport::Node node;
   auto pub = node.Advertise<msgs::Int32>(g_topic);
@@ -86,7 +89,7 @@ int main(int argc, char **argv)
   partition = testing::getRandomNumber();
 
   // Set the partition name for this process.
-  setenv("GZ_PARTITION", partition.c_str(), 1);
+  gz::utils::setenv("GZ_PARTITION", partition);
 
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/test/integration/authPubSubSubscriberInvalid_aux.cc
+++ b/test/integration/authPubSubSubscriberInvalid_aux.cc
@@ -30,6 +30,9 @@
 #endif
 
 #include "gz/transport/Node.hh"
+
+#include <gz/utils/Environment.hh>
+
 #include "gtest/gtest.h"
 #include "test_config.hh"
 
@@ -81,13 +84,13 @@ int main(int argc, char **argv)
   }
 
   // Set the partition name for this test.
-  setenv("GZ_PARTITION", argv[1], 1);
+  gz::utils::setenv("GZ_PARTITION", argv[1]);
 
   // Set the username for this test.
-  setenv("GZ_TRANSPORT_USERNAME", argv[2], 1);
+  gz::utils::setenv("GZ_TRANSPORT_USERNAME", argv[2]);
 
   // Set the password for this test.
-  setenv("GZ_TRANSPORT_PASSWORD", argv[3], 1);
+  gz::utils::setenv("GZ_TRANSPORT_PASSWORD", argv[3]);
 
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/test/integration/fastPub_aux.cc
+++ b/test/integration/fastPub_aux.cc
@@ -26,6 +26,9 @@
 #endif
 
 #include "gz/transport/Node.hh"
+
+#include <gz/utils/Environment.hh>
+
 #include "test_config.hh"
 
 using namespace gz;
@@ -58,7 +61,7 @@ int main(int argc, char **argv)
   }
 
   // Set the partition name for this test.
-  setenv("GZ_PARTITION", argv[1], 1);
+  gz::utils::setenv("GZ_PARTITION", argv[1]);
 
   advertiseAndPublish();
 }

--- a/test/integration/pub_aux.cc
+++ b/test/integration/pub_aux.cc
@@ -22,6 +22,9 @@
 
 #include "gtest/gtest.h"
 #include "gz/transport/Node.hh"
+
+#include <gz/utils/Environment.hh>
+
 #include "test_config.hh"
 
 using namespace gz;
@@ -59,7 +62,7 @@ int main(int argc, char **argv)
   }
 
   // Set the partition name for this test.
-  setenv("GZ_PARTITION", argv[1], 1);
+  gz::utils::setenv("GZ_PARTITION", argv[1]);
 
   advertiseAndPublish();
 }

--- a/test/integration/pub_aux_throttled.cc
+++ b/test/integration/pub_aux_throttled.cc
@@ -20,8 +20,11 @@
 #include <string>
 #include <thread>
 
-#include "gtest/gtest.h"
 #include "gz/transport/Node.hh"
+
+#include <gz/utils/Environment.hh>
+
+#include "gtest/gtest.h"
 #include "test_config.hh"
 
 using namespace gz;
@@ -61,7 +64,7 @@ int main(int argc, char **argv)
   }
 
   // Set the partition name for this test.
-  setenv("GZ_PARTITION", argv[1], 1);
+  gz::utils::setenv("GZ_PARTITION", argv[1]);
 
   advertiseAndPublish();
 }

--- a/test/integration/scopedTopic.cc
+++ b/test/integration/scopedTopic.cc
@@ -21,6 +21,9 @@
 
 #include "gz/transport/AdvertiseOptions.hh"
 #include "gz/transport/Node.hh"
+
+#include <gz/utils/Environment.hh>
+
 #include "gtest/gtest.h"
 #include "test_config.hh"
 
@@ -67,7 +70,7 @@ int main(int argc, char **argv)
   partition = testing::getRandomNumber();
 
   // Set the partition name for this process.
-  setenv("GZ_PARTITION", partition.c_str(), 1);
+  gz::utils::setenv("GZ_PARTITION", partition);
 
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/test/integration/scopedTopicSubscriber_aux.cc
+++ b/test/integration/scopedTopicSubscriber_aux.cc
@@ -20,6 +20,9 @@
 #include <string>
 
 #include "gz/transport/Node.hh"
+
+#include <gz/utils/Environment.hh>
+
 #include "gtest/gtest.h"
 #include "test_config.hh"
 
@@ -73,7 +76,7 @@ int main(int argc, char **argv)
   }
 
   // Set the partition name for this test.
-  setenv("GZ_PARTITION", argv[1], 1);
+  gz::utils::setenv("GZ_PARTITION", argv[1]);
 
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/test/integration/statistics.cc
+++ b/test/integration/statistics.cc
@@ -23,6 +23,9 @@
 #include "gtest/gtest.h"
 #include "gz/transport/Node.hh"
 #include "gz/transport/TransportTypes.hh"
+
+#include <gz/utils/Environment.hh>
+
 #include "test_config.hh"
 
 using namespace gz;
@@ -78,8 +81,8 @@ int main(int argc, char **argv)
   std::string partition = testing::getRandomNumber();
 
   // Set the partition name for this process.
-  setenv("GZ_PARTITION", partition.c_str(), 1);
-  setenv("GZ_TRANSPORT_TOPIC_STATISTICS", "1", 1);
+  gz::utils::setenv("GZ_PARTITION", partition);
+  gz::utils::setenv("GZ_TRANSPORT_TOPIC_STATISTICS", "1");
 
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/test/integration/twoProcsPubSub.cc
+++ b/test/integration/twoProcsPubSub.cc
@@ -20,9 +20,12 @@
 #include <chrono>
 #include <string>
 
-#include "gtest/gtest.h"
 #include "gz/transport/Node.hh"
 #include "gz/transport/TransportTypes.hh"
+
+#include <gz/utils/Environment.hh>
+
+#include "gtest/gtest.h"
 #include "test_config.hh"
 
 using namespace gz;
@@ -541,8 +544,8 @@ int main(int argc, char **argv)
   g_FQNPartition = std::string("/") + partition;
 
   // Set the partition name for this process.
-  setenv("GZ_PARTITION", partition.c_str(), 1);
-  setenv("GZ_TRANSPORT_TOPIC_STATISTICS", "1", 1);
+  gz::utils::setenv("GZ_PARTITION", partition);
+  gz::utils::setenv("GZ_TRANSPORT_TOPIC_STATISTICS", "1");
 
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/test/integration/twoProcsPubSubSubscriber_aux.cc
+++ b/test/integration/twoProcsPubSubSubscriber_aux.cc
@@ -21,6 +21,9 @@
 #include <string>
 
 #include "gz/transport/Node.hh"
+
+#include <gz/utils/Environment.hh>
+
 #include "gtest/gtest.h"
 #include "test_config.hh"
 
@@ -157,8 +160,8 @@ int main(int argc, char **argv)
   }
 
   // Set the partition name for this test.
-  setenv("GZ_PARTITION", argv[1], 1);
-  setenv("GZ_TRANSPORT_TOPIC_STATISTICS", "1", 1);
+  gz::utils::setenv("GZ_PARTITION", argv[1]);
+  gz::utils::setenv("GZ_TRANSPORT_TOPIC_STATISTICS", "1");
 
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/test/integration/twoProcsPublisher_aux.cc
+++ b/test/integration/twoProcsPublisher_aux.cc
@@ -20,6 +20,9 @@
 #include <string>
 
 #include "gz/transport/Node.hh"
+
+#include <gz/utils/Environment.hh>
+
 #include "test_config.hh"
 
 using namespace gz;
@@ -55,7 +58,7 @@ int main(int argc, char **argv)
   }
 
   // Set the partition name for this test.
-  setenv("GZ_PARTITION", argv[1], 1);
+  gz::utils::setenv("GZ_PARTITION", argv[1]);
 
   advertiseAndPublish();
 }

--- a/test/integration/twoProcsSrvCall.cc
+++ b/test/integration/twoProcsSrvCall.cc
@@ -23,6 +23,9 @@
 
 #include "gz/transport/Node.hh"
 #include "gz/transport/TopicUtils.hh"
+
+#include <gz/utils/Environment.hh>
+
 #include "gtest/gtest.h"
 #include "test_config.hh"
 
@@ -339,10 +342,10 @@ int main(int argc, char **argv)
   partition = testing::getRandomNumber();
 
   // Set the partition name for this process.
-  setenv("GZ_PARTITION", partition.c_str(), 1);
+  gz::utils::setenv("GZ_PARTITION", partition);
 
   // Enable verbose mode.
-  // setenv("GZ_VERBOSE", "1", 1);
+  // gz::utils::setenv("GZ_VERBOSE", "1");
 
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/test/integration/twoProcsSrvCallReplierInc_aux.cc
+++ b/test/integration/twoProcsSrvCallReplierInc_aux.cc
@@ -21,6 +21,9 @@
 #include <string>
 
 #include "gz/transport/Node.hh"
+
+#include <gz/utils/Environment.hh>
+
 #include "gtest/gtest.h"
 #include "test_config.hh"
 
@@ -63,7 +66,7 @@ int main(int argc, char **argv)
   }
 
   // Set the partition name for this test.
-  setenv("GZ_PARTITION", argv[1], 1);
+  gz::utils::setenv("GZ_PARTITION", argv[1]);
 
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/test/integration/twoProcsSrvCallReplier_aux.cc
+++ b/test/integration/twoProcsSrvCallReplier_aux.cc
@@ -20,6 +20,9 @@
 #include <string>
 
 #include "gz/transport/Node.hh"
+
+#include <gz/utils/Environment.hh>
+
 #include "gtest/gtest.h"
 #include "test_config.hh"
 
@@ -53,7 +56,7 @@ int main(int argc, char **argv)
   }
 
   // Set the partition name for this test.
-  setenv("GZ_PARTITION", argv[1], 1);
+  gz::utils::setenv("GZ_PARTITION", argv[1]);
 
   runReplier();
 }

--- a/test/integration/twoProcsSrvCallStress.cc
+++ b/test/integration/twoProcsSrvCallStress.cc
@@ -21,6 +21,9 @@
 #include <string>
 
 #include "gz/transport/Node.hh"
+
+#include <gz/utils/Environment.hh>
+
 #include "gtest/gtest.h"
 #include "test_config.hh"
 
@@ -68,7 +71,7 @@ int main(int argc, char **argv)
   partition = testing::getRandomNumber();
 
   // Set the partition name for this process.
-  setenv("GZ_PARTITION", partition.c_str(), 1);
+  gz::utils::setenv("GZ_PARTITION", partition);
 
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/test/integration/twoProcsSrvCallSync1.cc
+++ b/test/integration/twoProcsSrvCallSync1.cc
@@ -21,6 +21,9 @@
 #include <string>
 
 #include "gz/transport/Node.hh"
+
+#include <gz/utils/Environment.hh>
+
 #include "gtest/gtest.h"
 #include "test_config.hh"
 
@@ -83,10 +86,10 @@ int main(int argc, char **argv)
   partition = testing::getRandomNumber();
 
   // Set the partition name for this process.
-  setenv("GZ_PARTITION", partition.c_str(), 1);
+  gz::utils::setenv("GZ_PARTITION", partition);
 
   // Enable verbose mode.
-  setenv("GZ_VERBOSE", "1", 1);
+  gz::utils::setenv("GZ_VERBOSE", "1");
 
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/test/integration/twoProcsSrvCallWithoutInput.cc
+++ b/test/integration/twoProcsSrvCallWithoutInput.cc
@@ -23,6 +23,9 @@
 
 #include "gz/transport/Node.hh"
 #include "gz/transport/TopicUtils.hh"
+
+#include <gz/utils/Environment.hh>
+
 #include "gtest/gtest.h"
 #include "test_config.hh"
 
@@ -289,10 +292,10 @@ int main(int argc, char **argv)
   g_partition = testing::getRandomNumber();
 
   // Set the partition name for this process.
-  setenv("GZ_PARTITION", g_partition.c_str(), 1);
+  gz::utils::setenv("GZ_PARTITION", g_partition);
 
   // Enable verbose mode.
-  // setenv("GZ_VERBOSE", "1", 1);
+  // gz::utils::setenv("GZ_VERBOSE", "1");
 
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/test/integration/twoProcsSrvCallWithoutInputReplierInc_aux.cc
+++ b/test/integration/twoProcsSrvCallWithoutInputReplierInc_aux.cc
@@ -21,6 +21,9 @@
 #include <string>
 
 #include "gz/transport/Node.hh"
+
+#include <gz/utils/Environment.hh>
+
 #include "gtest/gtest.h"
 #include "test_config.hh"
 
@@ -64,7 +67,7 @@ int main(int argc, char **argv)
   }
 
   // Set the partition name for this test.
-  setenv("GZ_PARTITION", argv[1], 1);
+  gz::utils::setenv("GZ_PARTITION", argv[1]);
 
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/test/integration/twoProcsSrvCallWithoutInputReplier_aux.cc
+++ b/test/integration/twoProcsSrvCallWithoutInputReplier_aux.cc
@@ -20,6 +20,9 @@
 #include <string>
 
 #include "gz/transport/Node.hh"
+
+#include <gz/utils/Environment.hh>
+
 #include "gtest/gtest.h"
 #include "test_config.hh"
 
@@ -54,7 +57,7 @@ int main(int argc, char **argv)
   }
 
   // Set the partition name for this test.
-  setenv("GZ_PARTITION", argv[1], 1);
+  gz::utils::setenv("GZ_PARTITION", argv[1]);
 
   runReplier();
 }

--- a/test/integration/twoProcsSrvCallWithoutInputStress.cc
+++ b/test/integration/twoProcsSrvCallWithoutInputStress.cc
@@ -21,6 +21,9 @@
 #include <string>
 
 #include "gz/transport/Node.hh"
+
+#include <gz/utils/Environment.hh>
+
 #include "gtest/gtest.h"
 #include "test_config.hh"
 
@@ -65,7 +68,7 @@ int main(int argc, char **argv)
   g_partition = testing::getRandomNumber();
 
   // Set the partition name for this process.
-  setenv("GZ_PARTITION", g_partition.c_str(), 1);
+  gz::utils::setenv("GZ_PARTITION", g_partition);
 
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/test/integration/twoProcsSrvCallWithoutInputSync1.cc
+++ b/test/integration/twoProcsSrvCallWithoutInputSync1.cc
@@ -21,6 +21,9 @@
 #include <string>
 
 #include "gz/transport/Node.hh"
+
+#include <gz/utils/Environment.hh>
+
 #include "gtest/gtest.h"
 #include "test_config.hh"
 
@@ -78,10 +81,10 @@ int main(int argc, char **argv)
   g_partition = testing::getRandomNumber();
 
   // Set the partition name for this process.
-  setenv("GZ_PARTITION", g_partition.c_str(), 1);
+  gz::utils::setenv("GZ_PARTITION", g_partition);
 
   // Enable verbose mode.
-  setenv("GZ_VERBOSE", "1", 1);
+  gz::utils::setenv("GZ_VERBOSE", "1");
 
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/test/integration/twoProcsSrvCallWithoutOutput.cc
+++ b/test/integration/twoProcsSrvCallWithoutOutput.cc
@@ -22,6 +22,9 @@
 
 #include "gz/transport/Node.hh"
 #include "gz/transport/TopicUtils.hh"
+
+#include <gz/utils/Environment.hh>
+
 #include "gtest/gtest.h"
 #include "test_config.hh"
 
@@ -171,10 +174,10 @@ int main(int argc, char **argv)
   g_partition = testing::getRandomNumber();
 
   // Set the partition name for this process.
-  setenv("GZ_PARTITION", g_partition.c_str(), 1);
+  gz::utils::setenv("GZ_PARTITION", g_partition);
 
   // Enable verbose mode.
-  // setenv("GZ_VERBOSE", "1", 1);
+  // gz::utils::setenv("GZ_VERBOSE", "1");
 
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/test/integration/twoProcsSrvCallWithoutOutputReplierInc_aux.cc
+++ b/test/integration/twoProcsSrvCallWithoutOutputReplierInc_aux.cc
@@ -21,6 +21,9 @@
 #include <string>
 
 #include "gz/transport/Node.hh"
+
+#include <gz/utils/Environment.hh>
+
 #include "gtest/gtest.h"
 #include "test_config.hh"
 
@@ -62,7 +65,7 @@ int main(int argc, char **argv)
   }
 
   // Set the partition name for this test.
-  setenv("GZ_PARTITION", argv[1], 1);
+  gz::utils::setenv("GZ_PARTITION", argv[1]);
 
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/test/integration/twoProcsSrvCallWithoutOutputReplier_aux.cc
+++ b/test/integration/twoProcsSrvCallWithoutOutputReplier_aux.cc
@@ -20,6 +20,9 @@
 #include <string>
 
 #include "gz/transport/Node.hh"
+
+#include <gz/utils/Environment.hh>
+
 #include "gtest/gtest.h"
 #include "test_config.hh"
 
@@ -53,7 +56,7 @@ int main(int argc, char **argv)
   }
 
   // Set the partition name for this test.
-  setenv("GZ_PARTITION", argv[1], 1);
+  gz::utils::setenv("GZ_PARTITION", argv[1]);
 
   runReplier();
 }

--- a/test/integration/twoProcsSrvCallWithoutOutputStress.cc
+++ b/test/integration/twoProcsSrvCallWithoutOutputStress.cc
@@ -21,6 +21,9 @@
 #include <string>
 
 #include "gz/transport/Node.hh"
+
+#include <gz/utils/Environment.hh>
+
 #include "gtest/gtest.h"
 #include "test_config.hh"
 
@@ -61,7 +64,7 @@ int main(int argc, char **argv)
   g_partition = testing::getRandomNumber();
 
   // Set the partition name for this process.
-  setenv("GZ_PARTITION", g_partition.c_str(), 1);
+  gz::utils::setenv("GZ_PARTITION", g_partition);
 
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/test/test_config.hh.in
+++ b/test/test_config.hh.in
@@ -30,21 +30,8 @@
   DETAIL_GZ_TRANSPORT_TEST_DIR
 #endif
 
-#ifndef __APPLE__
-  #if (!(defined(__clang__) || __unix__) || \
-      (defined(__clang__) && __cplusplus >= 201703L) || \
-      (__unix__ && __GNUC__ >= 8))
-    #define GZ_HAVE_FILESYSTEM
-  #endif
-
-  #ifdef GZ_HAVE_FILESYSTEM
-    #include <filesystem>
-  #else
-    #include <experimental/filesystem>
-  #endif
-#endif
-
 #include <climits>
+#include <filesystem>
 #include <iostream>
 #include <random>
 #include <string>
@@ -60,37 +47,6 @@
 
 #include "gz/transport/Helpers.hh"
 
-#if (_MSC_VER >= 1400) // Visual Studio 2005
-  #include <sstream>
-
-  /// \brief setenv/unstenv are not present in Windows. Define them to make
-  /// the code portable.
-  /// \param[in] _name Variable name.
-  /// \param[in] _value Value.
-  /// \param[in] _rewrite If 'name' does exist in the environment, then its
-  /// value is changed to 'value' if 'rewrite' is nonzero. If overwrite is
-  /// zero, then the value of 'name' is not changed.
-  /// /return 0 on success or -1 on error.
-  int setenv(const char *_name, const char *_value, int /*_rewrite*/)
-  {
-    std::stringstream sstr;
-    std::string name = _name;
-    std::string value = _value;
-    sstr << name << '=' << value;
-    return _putenv(sstr.str().c_str());
-  }
-
-  /// \brief Deletes an environment variable.
-  /// \param[in] _name Variable name.
-  void unsetenv(const char *_name)
-  {
-    std::stringstream sstr;
-    std::string name = _name;
-    sstr << name << '=';
-    _putenv(sstr.str().c_str());
-  }
-#endif
-
 namespace testing
 {
   /// \brief Join _str1 and _str2 considering both as storing system paths.
@@ -100,17 +56,7 @@ namespace testing
   std::string portablePathUnion(const std::string &_str1,
                                 const std::string &_str2)
   {
-#ifdef __APPLE__
-    // Ugly as hell but trying to avoid boost::filesystem
-    return _str1 + "/" + _str2;
-#else
-    #ifdef GZ_HAVE_FILESYSTEM
-      using namespace std::filesystem;
-    #else
-      using namespace std::experimental::filesystem;
-    #endif
-    return (path(_str1) / path(_str2)).string();
-#endif
+    return (std::filesystem::path(_str1) / std::filesystem::path(_str2)).string();
   }
 
 #ifdef _WIN32
@@ -248,6 +194,6 @@ namespace testing
 
     return std::to_string(d(randGenerator));
   }
-}
+}  // namespace testing
 
 #endif  // header guard


### PR DESCRIPTION
* Use `gz::utils::env` family of functions rather than the OS equivalents (which are also missing on Windows)
* Use `gz::utils` disable macros rather than custom ones.
* Remove `std::filesystem` logic, as we are only supporting c++17 and above here.