### PR TITLE
Remove HIDE_SYMBOLS_BY_DEFAULT: replace by a default configuration in gz-cmake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,7 +158,6 @@ else()
 endif()
 
 gz_configure_build(QUIT_IF_BUILD_ERRORS
-  HIDE_SYMBOLS_BY_DEFAULT
   COMPONENTS log parameters)
 
 #============================================================================


### PR DESCRIPTION
See https://github.com/gazebosim/gz-cmake/issues/166