### PR TITLE
Fix issue #468

### DIFF
--- a/include/gz/transport/Discovery.hh
+++ b/include/gz/transport/Discovery.hh
@@ -306,6 +306,8 @@ namespace gz
       /// (e.g. if the discovery has not been started).
       public: bool Advertise(const Pub &_publisher)
       {
+        DiscoveryCallback<Pub> cb;
+
         {
           std::lock_guard<std::mutex> lock(this->mutex);
 
@@ -315,10 +317,12 @@ namespace gz
           // Add the addressing information (local publisher).
           if (!this->info.AddPublisher(_publisher))
             return false;
+
+          cb = this->connectionCb;
         }
 
-        if (this->connectionCb)
-          this->connectionCb(_publisher);
+        if (cb)
+          cb(_publisher);
 
         // Only advertise a message outside this process if the scope
         // is not 'Process'

--- a/include/gz/transport/Discovery.hh
+++ b/include/gz/transport/Discovery.hh
@@ -317,6 +317,8 @@ namespace gz
             return false;
         }
 
+        this->connectionCb(_publisher);
+
         // Only advertise a message outside this process if the scope
         // is not 'Process'
         if (_publisher.Options().Scope() != Scope_t::PROCESS)

--- a/include/gz/transport/Discovery.hh
+++ b/include/gz/transport/Discovery.hh
@@ -317,7 +317,8 @@ namespace gz
             return false;
         }
 
-        this->connectionCb(_publisher);
+        if (this->connectionCb)
+          this->connectionCb(_publisher);
 
         // Only advertise a message outside this process if the scope
         // is not 'Process'

--- a/src/Node_TEST.cc
+++ b/src/Node_TEST.cc
@@ -433,6 +433,23 @@ class MyTestClass
     EXPECT_FALSE(this->callbackSrvExecuted);
   }
 
+  /// \brief Advertise and request a service without waiting for response.
+  public: void TestServiceCallRequestingBeforeAdvertising()
+  {
+    msgs::Int32 req;
+    req.set_data(data);
+
+    this->Reset();
+
+    // Request a valid service using a member function callback.
+    this->node.Request(g_topic, req, &MyTestClass::EchoResponse, this);
+
+    // Advertise and request a valid service.
+    EXPECT_TRUE(this->node.Advertise(g_topic, &MyTestClass::Echo, this));
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    EXPECT_TRUE(this->responseExecuted);
+  }
+
   public: void Reset()
   {
     this->callbackExecuted = false;
@@ -1152,6 +1169,14 @@ TEST(NodeTest, ClassMemberCallbackServiceWithoutInput)
 {
   MyTestClass client;
   client.TestServiceCallWithoutInput();
+}
+
+//////////////////////////////////////////////////
+/// \brief Make an asynchronous service call, and then, advertise the service.
+TEST(NodeTest, ClassMemberRequestServiceBeforeAdvertise)
+{
+  MyTestClass client;
+  client.TestServiceCallRequestingBeforeAdvertising();
 }
 
 //////////////////////////////////////////////////


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes #468 

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

As described in issue #468, the case of a `Request()` before an `Advertise()` when both calls are within the same process wasn't considered. This patch makes it work as in the case where requester and responser are in different processes (which was already working).

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.