### PR TITLE
Find Python3 directly, not with GzPython

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,19 +56,23 @@ message(STATUS "\n\n-- ====== Finding Dependencies ======")
 # Python interfaces
 if (SKIP_PYBIND11)
   message(STATUS "SKIP_PYBIND11 set - disabling python bindings")
+  find_package(Python3 COMPONENTS Interpreter)
 else()
-  set(PYBIND11_PYTHON_VERSION 3)
-  find_package(pybind11 2.4 QUIET)
-
-  if (${pybind11_FOUND})
-    message (STATUS "Searching for pybind11 - found version ${pybind11_VERSION}.")
-    find_package(Python3 REQUIRED COMPONENTS Development Interpreter)
+  find_package(Python3 COMPONENTS Interpreter Development)
+  if (NOT Python3_Development_FOUND)
+    GZ_BUILD_WARNING("Python development libraries are missing: Python interfaces are disabled.")
   else()
-    GZ_BUILD_WARNING("pybind11 is missing: Python interfaces are disabled.")
-    message (STATUS "Searching for pybind11 - not found.")
+    set(PYBIND11_PYTHON_VERSION 3)
+    find_package(pybind11 2.4 CONFIG QUIET)
+
+    if (pybind11_FOUND)
+      message (STATUS "Searching for pybind11 - found version ${pybind11_VERSION}.")
+    else()
+      GZ_BUILD_WARNING("pybind11 is missing: Python interfaces are disabled.")
+      message (STATUS "Searching for pybind11 - not found.")
+    endif()
   endif()
 endif()
-
 
 #--------------------------------------
 # Find Protobuf

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,6 @@ option(SKIP_PYBIND11
 
 # Python interfaces vars
 include(CMakeDependentOption)
-include(GzPython)
 cmake_dependent_option(USE_SYSTEM_PATHS_FOR_PYTHON_INSTALLATION
       "Install python modules in standard system paths in the system"
       OFF "NOT SKIP_PYBIND11" OFF)
@@ -135,25 +134,18 @@ gz_find_package(SQLite3
 
 ########################################
 # Python interfaces
-if (NOT PYTHON3_FOUND)
-  GZ_BUILD_WARNING("Python is missing: Python interfaces are disabled.")
-  message (STATUS "Searching for Python - not found.")
+if (SKIP_PYBIND11)
+  message(STATUS "SKIP_PYBIND11 set - disabling python bindings")
 else()
-  message (STATUS "Searching for Python - found version ${Python3_VERSION}.")
+  set(PYBIND11_PYTHON_VERSION 3)
+  find_package(pybind11 2.4 QUIET)
 
-  if (SKIP_PYBIND11)
-    message(STATUS "SKIP_PYBIND11 set - disabling python bindings")
+  if (${pybind11_FOUND})
+    message (STATUS "Searching for pybind11 - found version ${pybind11_VERSION}.")
+    find_package(Python3 REQUIRED COMPONENTS Development Interpreter)
   else()
-    set(PYBIND11_PYTHON_VERSION 3)
-    find_package(pybind11 2.4 QUIET)
-
-    if (${pybind11_FOUND})
-      find_package(Python3 ${GZ_PYTHON_VERSION} REQUIRED COMPONENTS Development)
-      message (STATUS "Searching for pybind11 - found version ${pybind11_VERSION}.")
-    else()
-      GZ_BUILD_WARNING("pybind11 is missing: Python interfaces are disabled.")
-      message (STATUS "Searching for pybind11 - not found.")
-    endif()
+    GZ_BUILD_WARNING("pybind11 is missing: Python interfaces are disabled.")
+    message (STATUS "Searching for pybind11 - not found.")
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,24 @@ endif()
 message(STATUS "\n\n-- ====== Finding Dependencies ======")
 
 #--------------------------------------
+# Python interfaces
+if (SKIP_PYBIND11)
+  message(STATUS "SKIP_PYBIND11 set - disabling python bindings")
+else()
+  set(PYBIND11_PYTHON_VERSION 3)
+  find_package(pybind11 2.4 QUIET)
+
+  if (${pybind11_FOUND})
+    message (STATUS "Searching for pybind11 - found version ${pybind11_VERSION}.")
+    find_package(Python3 REQUIRED COMPONENTS Development Interpreter)
+  else()
+    GZ_BUILD_WARNING("pybind11 is missing: Python interfaces are disabled.")
+    message (STATUS "Searching for pybind11 - not found.")
+  endif()
+endif()
+
+
+#--------------------------------------
 # Find Protobuf
 gz_find_package(GzProtobuf
                 REQUIRED
@@ -131,24 +149,6 @@ gz_find_package(SQLite3
 #============================================================================
 # Configure the build
 #============================================================================
-
-########################################
-# Python interfaces
-if (SKIP_PYBIND11)
-  message(STATUS "SKIP_PYBIND11 set - disabling python bindings")
-else()
-  set(PYBIND11_PYTHON_VERSION 3)
-  find_package(pybind11 2.4 QUIET)
-
-  if (${pybind11_FOUND})
-    message (STATUS "Searching for pybind11 - found version ${pybind11_VERSION}.")
-    find_package(Python3 REQUIRED COMPONENTS Development Interpreter)
-  else()
-    GZ_BUILD_WARNING("pybind11 is missing: Python interfaces are disabled.")
-    message (STATUS "Searching for pybind11 - not found.")
-  endif()
-endif()
-
 gz_configure_build(QUIT_IF_BUILD_ERRORS
   COMPONENTS log parameters)
 


### PR DESCRIPTION
# 🦟 Bug fix

Motivated by https://github.com/gazebosim/gz-sim/issues/2249.

## Summary

While testing the use of `-DPython3_EXECUTABLE=$(which python3)` to aid in finding the right version of python3 on macOS (see https://github.com/osrf/homebrew-simulation/pull/2543), I ran into some cmake configuration issues when testing locally (the bottle build seems to be progressing fine though). I was able to fix my local build by consolidating the logic for finding python3 by removing the use of gz-cmake's `GzPython` in favor of a single call to `find_package(Python3)`. This fixes setting `Python3_EXECUTABLE` to specify which python version to use and is needed on macOS.

As an aside, I'm going to suggest that we deprecate `GzPython` on `main` since it's better and simpler to just find python directly with modern versions of cmake.

Check the diff without whitespace to see a simpler version of the changes without the indentation.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
