### PR TITLE
Cherry-pick #472 to main: Find Python3 directly, not with GzPython

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,6 @@ option(SKIP_PYBIND11
 
 # Python interfaces vars
 include(CMakeDependentOption)
-include(GzPython)
 cmake_dependent_option(USE_SYSTEM_PATHS_FOR_PYTHON_INSTALLATION
       "Install python modules in standard system paths in the system"
       OFF "NOT SKIP_PYBIND11" OFF)
@@ -52,6 +51,28 @@ endif()
 # Search for project-specific dependencies
 #============================================================================
 message(STATUS "\n\n-- ====== Finding Dependencies ======")
+
+#--------------------------------------
+# Python interfaces
+if (SKIP_PYBIND11)
+  message(STATUS "SKIP_PYBIND11 set - disabling python bindings")
+  find_package(Python3 COMPONENTS Interpreter)
+else()
+  find_package(Python3 COMPONENTS Interpreter Development)
+  if (NOT Python3_Development_FOUND)
+    GZ_BUILD_WARNING("Python development libraries are missing: Python interfaces are disabled.")
+  else()
+    set(PYBIND11_PYTHON_VERSION 3)
+    find_package(pybind11 2.4 CONFIG QUIET)
+
+    if (pybind11_FOUND)
+      message (STATUS "Searching for pybind11 - found version ${pybind11_VERSION}.")
+    else()
+      GZ_BUILD_WARNING("pybind11 is missing: Python interfaces are disabled.")
+      message (STATUS "Searching for pybind11 - not found.")
+    endif()
+  endif()
+endif()
 
 #--------------------------------------
 # Find Protobuf
@@ -132,31 +153,6 @@ gz_find_package(SQLite3
 #============================================================================
 # Configure the build
 #============================================================================
-
-########################################
-# Python interfaces
-if (NOT PYTHON3_FOUND)
-  GZ_BUILD_WARNING("Python is missing: Python interfaces are disabled.")
-  message (STATUS "Searching for Python - not found.")
-else()
-  message (STATUS "Searching for Python - found version ${Python3_VERSION}.")
-
-  if (SKIP_PYBIND11)
-    message(STATUS "SKIP_PYBIND11 set - disabling python bindings")
-  else()
-    set(PYBIND11_PYTHON_VERSION 3)
-    find_package(pybind11 2.4 QUIET)
-
-    if (${pybind11_FOUND})
-      find_package(Python3 ${GZ_PYTHON_VERSION} REQUIRED COMPONENTS Development)
-      message (STATUS "Searching for pybind11 - found version ${pybind11_VERSION}.")
-    else()
-      GZ_BUILD_WARNING("pybind11 is missing: Python interfaces are disabled.")
-      message (STATUS "Searching for pybind11 - not found.")
-    endif()
-  endif()
-endif()
-
 gz_configure_build(QUIT_IF_BUILD_ERRORS
   COMPONENTS log parameters)
 


### PR DESCRIPTION
PR #472 is a fix that will unbreak several CI jobs on macOS. It will be merged forward to main in #479, but that is slowed down by issues with commented tests, so I am cherry-picking this so expedite the fix of CI.

Commit message:

> This removes the use of gz-cmake's GzPython in favor of a single call to find_package(Python3). This allows setting Python3_EXECUTABLE to specify which python version to use and is needed on macOS.


**Note to maintainers**: Remember to use **Rebase-and-Merge**.
