### PR TITLE
Use a default timeout when requesting a service from CLI.

### DIFF
--- a/src/cmd/gz_TEST.cc
+++ b/src/cmd/gz_TEST.cc
@@ -355,6 +355,29 @@ TEST(gzTest, ServiceRequest)
 }
 
 //////////////////////////////////////////////////
+/// \brief Check 'gz service -r' to request a two-way service without timeout.
+TEST(gzTest, ServiceRequestNoTimeout)
+{
+  transport::Node node;
+
+  // Advertise a service.
+  std::string service = "/echo";
+  std::string value = "10";
+  EXPECT_TRUE(node.Advertise(service, srvEcho));
+
+  msgs::Int32 msg;
+  msg.set_data(10);
+
+  // Check the 'gz service -r' command.
+  auto output = custom_exec_str({"service",
+    "-s", service,
+    "--reqtype", "gz_msgs.Int32",
+    "--reptype", "gz_msgs.Int32",
+    "--req", "data: " + value});
+  ASSERT_EQ(output.cout, "data: " + value + "\n\n");
+}
+
+//////////////////////////////////////////////////
 /// \brief Check 'gz service -r' to request a one-way service.
 TEST(gzTest, ServiceOnewayRequest)
 {

--- a/src/cmd/service_main.cc
+++ b/src/cmd/service_main.cc
@@ -52,7 +52,7 @@ struct ServiceOptions
   std::string repType{""};
 
   /// \brief Timeout to use when requesting (in milliseconds)
-  int timeout{-1};
+  int timeout{1000};
 };
 
 //////////////////////////////////////////////////
@@ -104,7 +104,6 @@ void addServiceFlags(CLI::App &_app)
                                     opt->repType, "Type of a response.");
   auto timeoutOpt = _app.add_option("--timeout",
                                     opt->timeout, "Timeout in milliseconds.");
-  repTypeOpt = repTypeOpt->needs(timeoutOpt);
   timeoutOpt = timeoutOpt->needs(repTypeOpt);
 
   auto command = _app.add_option_group("command", "Command to be executed.");


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes #475

This patch makes the timeout optional when requesting services from the command line.

### How to test it?

Compile the transport examples and run:

```
./responser
```

And then type in a separate terminal:

```
gz service -s /echo --reqtype gz.msgs.StringMsg --reptype gz.msgs.StringMsg --req 'data: "Hello"'
```

You should receive:

```
data: "Hello"
```

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->



## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.