### PR TITLE
No input service request from the command line

### DIFF
--- a/src/cmd/gz_TEST.cc
+++ b/src/cmd/gz_TEST.cc
@@ -54,6 +54,14 @@ void srvOneway(const msgs::StringMsg &_msg)
 }
 
 //////////////////////////////////////////////////
+/// \brief Provide a service without input.
+bool srvNoInput(msgs::StringMsg &_msg)
+{
+  _msg.set_data("good_value");
+  return true;
+}
+
+//////////////////////////////////////////////////
 /// \brief Topic callback
 void topicCB(const msgs::StringMsg &_msg)
 {
@@ -398,6 +406,23 @@ TEST(gzTest, ServiceOnewayRequest)
 
   std::this_thread::sleep_for(std::chrono::milliseconds(500));
   EXPECT_EQ("good_value", g_topicCBStr);
+}
+
+//////////////////////////////////////////////////
+/// \brief Check 'gz service -r' to request a service without input args.
+TEST(gzTest, ServiceRequestNoInput)
+{
+  // Advertise a service.
+  transport::Node node;
+  std::string service = "/no_input";
+  EXPECT_TRUE(node.Advertise(service, srvNoInput));
+
+  // Check the 'gz service -r' no input command.
+  auto output = custom_exec_str(
+    {"service", "-s", service, "--reptype", "gz.msgs.StringMsg", "--req"});
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
+  EXPECT_EQ("data: \"good_value\"\n\n", output.cout);
 }
 
 //////////////////////////////////////////////////

--- a/src/cmd/service_main.cc
+++ b/src/cmd/service_main.cc
@@ -103,14 +103,11 @@ void addServiceFlags(CLI::App &_app)
 {
   auto opt = std::make_shared<ServiceOptions>();
 
-  auto serviceOpt = _app.add_option("-s,--service",
+  auto serviceOpt = _app.add_option("-s,--service", 
                                     opt->service, "Name of a service.");
-  _app.add_option("--reqtype",
-                                    opt->reqType, "Type of a request.");
-  _app.add_option("--reptype",
-                                    opt->repType, "Type of a response.");
-  _app.add_option("--timeout",
-                                    opt->timeout, "Timeout in milliseconds.");
+  _app.add_option("--reqtype", opt->reqType, "Type of a request.");
+  _app.add_option("--reptype", opt->repType, "Type of a response.");
+  _app.add_option("--timeout", opt->timeout, "Timeout in milliseconds.");
 
   auto command = _app.add_option_group("command", "Command to be executed.");
 
@@ -141,7 +138,7 @@ the same used by Protobuf DebugString(). E.g.:
     --req 'data: "Hello"'
 )")
     ->needs(serviceOpt)
-    ->expected(0,1);
+    ->expected(0, 1);
 
   _app.callback([opt](){runServiceCommand(*opt); });
 }

--- a/src/cmd/service_main.cc
+++ b/src/cmd/service_main.cc
@@ -75,6 +75,13 @@ void runServiceCommand(const ServiceOptions &_opt)
             _opt.reqType.c_str(), "gz.msgs.Empty",
             0, _opt.reqData.c_str());
       }
+      else if (_opt.reqType.empty())
+      {
+        // No input service request.
+        cmdServiceReq(_opt.service.c_str(),
+            "gz.msgs.Empty", _opt.repType.c_str(),
+            _opt.timeout, "unused:true");
+      }
       else
       {
         // Two-way service request.
@@ -104,7 +111,6 @@ void addServiceFlags(CLI::App &_app)
                                     opt->repType, "Type of a response.");
   auto timeoutOpt = _app.add_option("--timeout",
                                     opt->timeout, "Timeout in milliseconds.");
-  timeoutOpt = timeoutOpt->needs(repTypeOpt);
 
   auto command = _app.add_option_group("command", "Command to be executed.");
 
@@ -135,7 +141,7 @@ the same used by Protobuf DebugString(). E.g.:
     --req 'data: "Hello"'
 )")
     ->needs(serviceOpt)
-    ->needs(reqTypeOpt);
+    ->expected(0,1);
 
   _app.callback([opt](){runServiceCommand(*opt); });
 }

--- a/src/cmd/service_main.cc
+++ b/src/cmd/service_main.cc
@@ -103,7 +103,7 @@ void addServiceFlags(CLI::App &_app)
 {
   auto opt = std::make_shared<ServiceOptions>();
 
-  auto serviceOpt = _app.add_option("-s,--service", 
+  auto serviceOpt = _app.add_option("-s,--service",
                                     opt->service, "Name of a service.");
   _app.add_option("--reqtype", opt->reqType, "Type of a request.");
   _app.add_option("--reptype", opt->repType, "Type of a response.");

--- a/src/cmd/service_main.cc
+++ b/src/cmd/service_main.cc
@@ -105,11 +105,11 @@ void addServiceFlags(CLI::App &_app)
 
   auto serviceOpt = _app.add_option("-s,--service",
                                     opt->service, "Name of a service.");
-  auto reqTypeOpt = _app.add_option("--reqtype",
+  _app.add_option("--reqtype",
                                     opt->reqType, "Type of a request.");
-  auto repTypeOpt = _app.add_option("--reptype",
+  _app.add_option("--reptype",
                                     opt->repType, "Type of a response.");
-  auto timeoutOpt = _app.add_option("--timeout",
+  _app.add_option("--timeout",
                                     opt->timeout, "Timeout in milliseconds.");
 
   auto command = _app.add_option_group("command", "Command to be executed.");


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes #97 and #474

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

This patch makes it possible to request a no input service request from the command line. Before, it was possible passing `--reqtype gz.msgs.Empty` but always adding the `--req 'unused: true'`

## How to test it?

You can compile the examples, and then:

1. Launch the no-input responser:
```
./responser_no_input
```

2. Request the service using the "old" way:
```
gz service -s /quote --reqtype gz.msgs.Empty --reptype gz.msgs.StringMsg -r 'unused:true'
```

3. Use the new no-input request and verify that you still get a reply:
```
gz service -s /quote --reptype gz.msgs.StringMsg -r
``` 

Note that both requests should reach the responser and you should get a reply on the requester terminal:
```
data: "This is it! This is the answer. It says here...that a bolt of lightning is going to strike the clock tower at precisely 10:04pm, next Saturday night! If...If we could somehow...harness this lightning...channel it...into the flux capacitor...it just might work. Next Saturday night, we\'re sending you back to the future!"
```

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.