### PR TITLE
Prepapre for 13.2.0 prerelease

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(gz-transport13 VERSION 13.1.0)
+project(gz-transport13 VERSION 13.2.0)
 
 #============================================================================
 # Find gz-cmake
@@ -33,7 +33,7 @@ cmake_dependent_option(USE_DIST_PACKAGES_FOR_PYTHON
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-gz_configure_project(VERSION_SUFFIX)
+gz_configure_project(VERSION_SUFFIX pre1)
 
 #============================================================================
 # Set project-specific options

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,21 @@
 ## Gazebo Transport 13.X
 
+### Gazebo Transport 13.2.0 (2024-xx-xx)
+
+1. No input service request from the command line
+    * [Pull request #487](https://github.com/gazebosim/gz-transport/pull/487)
+
+1. Use `std::shared_ptr` for `gz::transport::NodeShared`
+    * [Pull request #484](https://github.com/gazebosim/gz-transport/pull/484)
+
+1. Use a default timeout when requesting a service from CLI.
+    * [Pull request #486](https://github.com/gazebosim/gz-transport/pull/486)
+
+1. Fix test failures when run under `colcon test`
+    * [Pull request #483](https://github.com/gazebosim/gz-transport/pull/483)
+
 ### Gazebo Transport 13.1.0 (2024-03-14)
+
 1. Oneway service request from the command line
     * [Pull request #477](https://github.com/gazebosim/gz-transport/pull/477)
 


### PR DESCRIPTION


<!-- For maintainers only -->

# 🎈 Release

Preparation for 13.2.0~pre1 release.

Comparison to 13.1.0: https://github.com/gazebosim/gz-transport/compare/gz-transport13_13.1.0...prep_13.2.0pre1

<!-- Add links to PRs that require this release (if needed) -->
Needed by <PR(s)>

## Checklist
- [x] Asked team if this is a good time for a release
- [x] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [ ] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
