### PR TITLE
Prepare for 13.2.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ cmake_dependent_option(USE_DIST_PACKAGES_FOR_PYTHON
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-gz_configure_project(VERSION_SUFFIX pre2)
+gz_configure_project(VERSION_SUFFIX)
 
 #============================================================================
 # Set project-specific options

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,9 @@
 ## Gazebo Transport 13.X
 
-### Gazebo Transport 13.2.0 (2024-xx-xx)
+### Gazebo Transport 13.2.0 (2024-04-09)
+
+1. Use relative install path for gz tool data
+    * [Pull request #492](https://github.com/gazebosim/gz-transport/pull/492)
 
 1. No input service request from the command line
     * [Pull request #487](https://github.com/gazebosim/gz-transport/pull/487)


### PR DESCRIPTION
# 🎈 Release

Preparation for 13.2.0 release.

Comparison to 13.1.0: https://github.com/gazebosim/gz-transport/compare/gz-transport13_13.1.0...azeey:prep_13.2.0

<!-- Add links to PRs that require this release (if needed) -->
Needed by <PR(s)>

## Checklist
- [ ] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [ ] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
