### PR TITLE
Remove python3-distutils since it's not needed on Jammy

### DIFF
--- a/.github/ci/packages.apt
+++ b/.github/ci/packages.apt
@@ -10,7 +10,6 @@ libzmq3-dev
 pkg-config
 protobuf-compiler
 python3-dev
-python3-distutils
 python3-psutil
 python3-pybind11
 python3-pytest

--- a/package.xml
+++ b/package.xml
@@ -22,7 +22,6 @@
   <depend>protobuf-dev</depend>
   <depend>pybind11-dev</depend>
   <depend>python3-dev</depend>
-  <depend>python3-distutils</depend>
   <depend>python3-psutil</depend>
   <depend>python3-pytest</depend>
   <depend>uuid</depend>


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Similar to https://github.com/gazebosim/gz-sim/pull/2374


## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
