### PR TITLE
Allow programmatic configuration of unicast relays.

### DIFF
--- a/include/gz/transport/Discovery.hh
+++ b/include/gz/transport/Discovery.hh
@@ -740,6 +740,26 @@ namespace gz
         }
       }
 
+      /// \brief Register a new relay address.
+      /// \param[in] _ip New IP address.
+      public: void AddRelayAddress(const std::string &_ip)
+      {
+        // Sanity check: Make sure that this IP address is not already saved.
+        for (auto const &addr : this->relayAddrs)
+        {
+          if (addr.sin_addr.s_addr == inet_addr(_ip.c_str()))
+            return;
+        }
+
+        sockaddr_in addr;
+        memset(&addr, 0, sizeof(addr));
+        addr.sin_family = AF_INET;
+        addr.sin_addr.s_addr = inet_addr(_ip.c_str());
+        addr.sin_port = htons(static_cast<u_short>(this->port));
+
+        this->relayAddrs.push_back(addr);
+      }
+
       /// \brief Broadcast periodic heartbeats.
       private: void UpdateHeartbeat()
       {
@@ -1418,26 +1438,6 @@ namespace gz
         }
 
         return true;
-      }
-
-      /// \brief Register a new relay address.
-      /// \param[in] _ip New IP address.
-      private: void AddRelayAddress(const std::string &_ip)
-      {
-        // Sanity check: Make sure that this IP address is not already saved.
-        for (auto const &addr : this->relayAddrs)
-        {
-          if (addr.sin_addr.s_addr == inet_addr(_ip.c_str()))
-            return;
-        }
-
-        sockaddr_in addr;
-        memset(&addr, 0, sizeof(addr));
-        addr.sin_family = AF_INET;
-        addr.sin_addr.s_addr = inet_addr(_ip.c_str());
-        addr.sin_port = htons(static_cast<u_short>(this->port));
-
-        this->relayAddrs.push_back(addr);
       }
 
       /// \brief Default activity interval value (ms.).

--- a/include/gz/transport/NodeOptions.hh
+++ b/include/gz/transport/NodeOptions.hh
@@ -20,6 +20,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "gz/transport/config.hh"
 #include "gz/transport/Export.hh"
@@ -125,6 +126,19 @@ namespace gz
       /// false otherwise.
       public: bool TopicRemap(const std::string &_fromTopic,
                               std::string &_toTopic) const;
+
+      /// \brief Add relay IPs. This node will send UDP unicast traffic to these
+      /// addresses to connect networks when UDP multicast traffic is not
+      /// forwarded.
+      /// It's also possible to use the environment variable GZ_RELAY to add
+      /// relays.
+      /// \param[in] _relayIPs IPv4 addresses of unicast relays to add.
+      /// \return True if the relay list is valid or false otherwise.
+      public: bool SetRelays(const std::vector<std::string>& _relayIPs);
+
+      /// \brief Gets the list of relay addresses specified in this NodeOptions.
+      /// \return The list of relay addresses.
+      public: const std::vector<std::string>& Relays() const;
 
 #ifdef _WIN32
 // Disable warning C4251 which is triggered by

--- a/src/Node.cc
+++ b/src/Node.cc
@@ -512,6 +512,12 @@ Node::Node(const NodeOptions &_options)
 
   // Save the options.
   this->dataPtr->options = _options;
+
+  // Add relays from the node options.
+  for(const auto& addr : _options.Relays()) {
+    this->dataPtr->shared->dataPtr->msgDiscovery->AddRelayAddress(addr);
+    this->dataPtr->shared->dataPtr->srvDiscovery->AddRelayAddress(addr);
+  }
 }
 
 //////////////////////////////////////////////////

--- a/src/NodeOptions.cc
+++ b/src/NodeOptions.cc
@@ -17,6 +17,7 @@
 
 #include <iostream>
 #include <string>
+#include <vector>
 
 #include "gz/transport/Helpers.hh"
 #include "gz/transport/NodeOptions.hh"

--- a/src/NodeOptions.cc
+++ b/src/NodeOptions.cc
@@ -136,3 +136,15 @@ bool NodeOptions::TopicRemap(const std::string &_fromTopic,
 
   return topicIt != this->dataPtr->topicsRemap.end();
 }
+
+//////////////////////////////////////////////////
+bool NodeOptions::SetRelays(const std::vector<std::string>& _relayIPs) {
+  this->dataPtr->relayIPs = _relayIPs;
+  return true;
+}
+
+//////////////////////////////////////////////////
+const std::vector<std::string>& NodeOptions::Relays() const {
+  return this->dataPtr->relayIPs;
+}
+

--- a/src/NodeOptionsPrivate.hh
+++ b/src/NodeOptionsPrivate.hh
@@ -20,6 +20,7 @@
 
 #include <map>
 #include <string>
+#include <vector>
 
 #include "gz/transport/config.hh"
 #include "gz/transport/NetUtils.hh"
@@ -50,6 +51,9 @@ namespace gz
       /// \brief Table of remappings. The key is the original topic name and
       /// its value is the new topic name to be used instead.
       public: std::map<std::string, std::string> topicsRemap;
+
+      /// \brief List of unicast relay IPs.
+      public: std::vector<std::string> relayIPs;
     };
     }
   }

--- a/src/NodeOptions_TEST.cc
+++ b/src/NodeOptions_TEST.cc
@@ -74,4 +74,11 @@ TEST(NodeOptionsTest, accessors)
   EXPECT_EQ(opts.Partition(), defaultPartition);
   EXPECT_TRUE(opts.SetPartition(aPartition));
   EXPECT_EQ(opts.Partition(), aPartition);
+
+  // Relay
+  std::string aRelay = "123.45.67.89";
+  EXPECT_TRUE(opts.SetRelays({aRelay}));
+  auto relays = opts.Relays();
+  ASSERT_EQ(relays.size(), 1);
+  EXPECT_EQ(relays[0], aRelay);
 }


### PR DESCRIPTION
This change allows users to configure relays from code without having to `setenv(GZ_RELAY)`.

# 🎉 New feature

## Summary
This change allows users to configure relays from code without having to `setenv(GZ_RELAY)`.

## Test it
This can be tested by starting a Node across a boundary where multicast isn't enabled, and setting the relay IP via NodeOptions.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.