### PR TITLE
Allow programmatic configuration of unicast relays.

### DIFF
--- a/include/gz/transport/Discovery.hh
+++ b/include/gz/transport/Discovery.hh
@@ -64,7 +64,6 @@
 #include <map>
 #include <memory>
 #include <mutex>
-#include <shared_mutex>
 #include <string>
 #include <thread>
 #include <vector>
@@ -745,7 +744,7 @@ namespace gz
       /// \param[in] _ip New IP address.
       public: void AddRelayAddress(const std::string &_ip)
       {
-        std::lock_guard<std::shared_mutex> lock(this->relayAddrsMutex);
+        std::lock_guard<std::mutex> lock(this->mutex);
         // Sanity check: Make sure that this IP address is not already saved.
         for (auto const &addr : this->relayAddrs)
         {
@@ -768,7 +767,7 @@ namespace gz
       {
         std::vector<std::string> result;
 
-        std::shared_lock<std::shared_mutex> lock(this->relayAddrsMutex);
+        std::lock_guard<std::mutex> lock(this->mutex);
 
         for (auto const &addr : this->relayAddrs) {
           result.push_back(inet_ntoa(addr.sin_addr));
@@ -1291,7 +1290,7 @@ namespace gz
         if (_msg.SerializeToArray(buffer + sizeof(msgSize), msgSize))
         {
           // Send the discovery message to the unicast relays.
-          std::shared_lock<std::shared_mutex> lock(this->relayAddrsMutex);
+          std::lock_guard<std::mutex> lock(this->mutex);
 
           for (const auto &sockAddr : this->relayAddrs)
           {
@@ -1553,9 +1552,6 @@ namespace gz
 
       /// \brief Collection of socket addresses used as remote relays.
       private: std::vector<sockaddr_in> relayAddrs;
-
-      /// \brief Mutex to guarantee exclusive write access to relayAddrs.
-      private: mutable std::shared_mutex relayAddrsMutex;
 
       /// \brief Mutex to guarantee exclusive access between the threads.
       private: mutable std::mutex mutex;

--- a/include/gz/transport/Discovery.hh
+++ b/include/gz/transport/Discovery.hh
@@ -740,6 +740,37 @@ namespace gz
         }
       }
 
+      /// \brief Register a new relay address.
+      /// \param[in] _ip New IP address.
+      public: void AddRelayAddress(const std::string &_ip)
+      {
+        // Sanity check: Make sure that this IP address is not already saved.
+        for (auto const &addr : this->relayAddrs)
+        {
+          if (addr.sin_addr.s_addr == inet_addr(_ip.c_str()))
+            return;
+        }
+
+        sockaddr_in addr;
+        memset(&addr, 0, sizeof(addr));
+        addr.sin_family = AF_INET;
+        addr.sin_addr.s_addr = inet_addr(_ip.c_str());
+        addr.sin_port = htons(static_cast<u_short>(this->port));
+
+        this->relayAddrs.push_back(addr);
+      }
+
+      public: std::vector<std::string> RelayAddresses() const
+      {
+        std::vector<std::string> result;
+
+        for (auto const &addr : this->relayAddrs) {
+          result.push_back(inet_ntoa(addr.sin_addr));
+        }
+
+        return result;
+      }
+
       /// \brief Broadcast periodic heartbeats.
       private: void UpdateHeartbeat()
       {
@@ -1418,26 +1449,6 @@ namespace gz
         }
 
         return true;
-      }
-
-      /// \brief Register a new relay address.
-      /// \param[in] _ip New IP address.
-      private: void AddRelayAddress(const std::string &_ip)
-      {
-        // Sanity check: Make sure that this IP address is not already saved.
-        for (auto const &addr : this->relayAddrs)
-        {
-          if (addr.sin_addr.s_addr == inet_addr(_ip.c_str()))
-            return;
-        }
-
-        sockaddr_in addr;
-        memset(&addr, 0, sizeof(addr));
-        addr.sin_family = AF_INET;
-        addr.sin_addr.s_addr = inet_addr(_ip.c_str());
-        addr.sin_port = htons(static_cast<u_short>(this->port));
-
-        this->relayAddrs.push_back(addr);
       }
 
       /// \brief Default activity interval value (ms.).

--- a/include/gz/transport/Discovery.hh
+++ b/include/gz/transport/Discovery.hh
@@ -760,6 +760,8 @@ namespace gz
         this->relayAddrs.push_back(addr);
       }
 
+      // \brief Gets this instance's relay addresses.
+      // \return The list of relay addresses.
       public: std::vector<std::string> RelayAddresses() const
       {
         std::vector<std::string> result;

--- a/include/gz/transport/Node.hh
+++ b/include/gz/transport/Node.hh
@@ -762,7 +762,17 @@ namespace gz
       public: std::optional<TopicStatistics> TopicStats(
                   const std::string &_topic) const;
 
-      public: void AddGlobalRelay(const std::string& relay_address);
+      /// \brief Adds a unicast relay IP. All nodes in this process will send
+      /// UDP unicast traffic to the address to connect networks when UDP
+      /// multicast traffic is not forwarded.
+      /// It's also possible to use the environment variable GZ_RELAY to add
+      /// relays.
+      /// \param[in] _relayAddress IPv4 address of the relay to add.
+      public: void AddGlobalRelay(const std::string& _relayAddress);
+
+      /// \brief Gets the relay addresses configured for all nodes in this
+      /// process.
+      /// \return The relay addresses.
       public: std::vector<std::string> GlobalRelays() const;
 
       /// \brief Get a pointer to the shared node (singleton shared by all the

--- a/include/gz/transport/Node.hh
+++ b/include/gz/transport/Node.hh
@@ -762,6 +762,9 @@ namespace gz
       public: std::optional<TopicStatistics> TopicStats(
                   const std::string &_topic) const;
 
+      public: void AddGlobalRelay(const std::string& relay_address);
+      public: std::vector<std::string> GlobalRelays() const;
+
       /// \brief Get a pointer to the shared node (singleton shared by all the
       /// nodes).
       /// \return The pointer to the shared node.

--- a/include/gz/transport/NodeShared.hh
+++ b/include/gz/transport/NodeShared.hh
@@ -284,7 +284,17 @@ namespace gz
       public: std::optional<TopicStatistics> TopicStats(
                   const std::string &_topic) const;
 
-      public: void AddGlobalRelay(const std::string& relay_address);
+      /// \brief Adds a unicast relay IP. All nodes in this process will send
+      /// UDP unicast traffic to the address to connect networks when UDP
+      /// multicast traffic is not forwarded.
+      /// It's also possible to use the environment variable GZ_RELAY to add
+      /// relays.
+      /// \param[in] _relayAddress IPv4 address of the relay to add.
+      public: void AddGlobalRelay(const std::string& _relayAddress);
+
+      /// \brief Gets the relay addresses configured for all nodes in this
+      /// process.
+      /// \return The relay addresses.
       public: std::vector<std::string> GlobalRelays() const;
 
       /// \brief Constructor.

--- a/include/gz/transport/NodeShared.hh
+++ b/include/gz/transport/NodeShared.hh
@@ -284,6 +284,9 @@ namespace gz
       public: std::optional<TopicStatistics> TopicStats(
                   const std::string &_topic) const;
 
+      public: void AddGlobalRelay(const std::string& relay_address);
+      public: std::vector<std::string> GlobalRelays() const;
+
       /// \brief Constructor.
       protected: NodeShared();
 

--- a/src/Node.cc
+++ b/src/Node.cc
@@ -1140,8 +1140,8 @@ bool Node::RequestRaw(const std::string &_topic,
   return executed && res->SerializeToString(&_response);
 }
 
-void Node::AddGlobalRelay(const std::string& relay_address) {
-  Shared()->AddGlobalRelay(relay_address);
+void Node::AddGlobalRelay(const std::string& _relayAddress) {
+  Shared()->AddGlobalRelay(_relayAddress);
 }
 
 std::vector<std::string> Node::GlobalRelays() const {

--- a/src/Node.cc
+++ b/src/Node.cc
@@ -1140,10 +1140,12 @@ bool Node::RequestRaw(const std::string &_topic,
   return executed && res->SerializeToString(&_response);
 }
 
+/////////////////////////////////////////////////
 void Node::AddGlobalRelay(const std::string& _relayAddress) {
   Shared()->AddGlobalRelay(_relayAddress);
 }
 
+/////////////////////////////////////////////////
 std::vector<std::string> Node::GlobalRelays() const {
   return Shared()->GlobalRelays();
 }

--- a/src/Node.cc
+++ b/src/Node.cc
@@ -1139,3 +1139,11 @@ bool Node::RequestRaw(const std::string &_topic,
   bool executed = this->Request(_topic, *req, _timeout, *res, _result);
   return executed && res->SerializeToString(&_response);
 }
+
+void Node::AddGlobalRelay(const std::string& relay_address) {
+  Shared()->AddGlobalRelay(relay_address);
+}
+
+std::vector<std::string> Node::GlobalRelays() const {
+  return Shared()->GlobalRelays();
+}

--- a/src/NodeShared.cc
+++ b/src/NodeShared.cc
@@ -1941,3 +1941,22 @@ int NodeSharedPrivate::NonNegativeEnvVar(const std::string &_envVar,
   }
   return numVal;
 }
+
+void NodeShared::AddGlobalRelay(const std::string& relay_address) {
+  dataPtr->msgDiscovery->AddRelayAddress(relay_address);
+  dataPtr->srvDiscovery->AddRelayAddress(relay_address);
+}
+
+std::vector<std::string> NodeShared::GlobalRelays() const {
+  // Merge relays from message and service discovery. They should be identical
+  // since they're typically build from the same sources.
+  //
+  // This is confusing - do we want to add different handling here?
+  auto msgRelays = dataPtr->msgDiscovery->RelayAddresses();
+  std::set<std::string> msgRelaySet(msgRelays.cbegin(), msgRelays.cend());
+  auto srvRelays = dataPtr->srvDiscovery->RelayAddresses();
+  std::set<std::string> srvRelaySet(srvRelays.cbegin(), srvRelays.cend());
+  srvRelaySet.merge(msgRelaySet);
+
+  return std::vector<std::string>(srvRelaySet.cbegin(), srvRelaySet.cend());
+}

--- a/src/NodeShared.cc
+++ b/src/NodeShared.cc
@@ -1943,9 +1943,9 @@ int NodeSharedPrivate::NonNegativeEnvVar(const std::string &_envVar,
   return numVal;
 }
 
-void NodeShared::AddGlobalRelay(const std::string& relay_address) {
-  dataPtr->msgDiscovery->AddRelayAddress(relay_address);
-  dataPtr->srvDiscovery->AddRelayAddress(relay_address);
+void NodeShared::AddGlobalRelay(const std::string& _relayAddress) {
+  dataPtr->msgDiscovery->AddRelayAddress(_relayAddress);
+  dataPtr->srvDiscovery->AddRelayAddress(_relayAddress);
 }
 
 std::vector<std::string> NodeShared::GlobalRelays() const {

--- a/src/NodeShared.cc
+++ b/src/NodeShared.cc
@@ -23,6 +23,7 @@
 #include <iostream>
 #include <map>
 #include <mutex>
+#include <set>
 #include <shared_mutex>  //NOLINT
 #include <string>
 #include <thread>

--- a/src/Node_TEST.cc
+++ b/src/Node_TEST.cc
@@ -2342,6 +2342,31 @@ TEST(NodeTest, statistics)
 }
 
 //////////////////////////////////////////////////
+/// \brief Test adding and querying relays
+TEST(NodeTest, relay) {
+  transport::Node node;
+
+  // Make sure the relay we're about to add hasn't already been configured.
+  const std::vector<std::string> relays_before_add = node.GlobalRelays();
+  {
+    auto relays_before_it = std::find_if(
+        relays_before_add.cbegin(), relays_before_add.cend(),
+        [](const std::string &relay) { return relay == "127.0.0.123"; });
+    ASSERT_EQ(relays_before_it, relays_before_add.cend());
+  }
+  node.AddGlobalRelay("127.0.0.123");
+
+  const std::vector<std::string> relays_after_add = node.GlobalRelays();
+  {
+    EXPECT_EQ(relays_after_add.size(), relays_before_add.size() + 1);
+    auto relay_it = std::find_if(
+        relays_after_add.cbegin(), relays_after_add.cend(),
+        [](const std::string &relay) { return relay == "127.0.0.123"; });
+    EXPECT_NE(relay_it, relays_after_add.cend());
+  }
+}
+
+//////////////////////////////////////////////////
 int main(int argc, char **argv)
 {
   // Get a random partition name.

--- a/src/Node_TEST.cc
+++ b/src/Node_TEST.cc
@@ -2347,22 +2347,22 @@ TEST(NodeTest, relay) {
   transport::Node node;
 
   // Make sure the relay we're about to add hasn't already been configured.
-  const std::vector<std::string> relays_before_add = node.GlobalRelays();
+  const std::vector<std::string> relaysBeforeAdd = node.GlobalRelays();
   {
-    auto relays_before_it = std::find_if(
-        relays_before_add.cbegin(), relays_before_add.cend(),
+    auto relaysBeforeIt = std::find_if(
+        relaysBeforeAdd.cbegin(), relaysBeforeAdd.cend(),
         [](const std::string &relay) { return relay == "127.0.0.123"; });
-    ASSERT_EQ(relays_before_it, relays_before_add.cend());
+    ASSERT_EQ(relaysBeforeIt, relaysBeforeAdd.cend());
   }
   node.AddGlobalRelay("127.0.0.123");
 
-  const std::vector<std::string> relays_after_add = node.GlobalRelays();
+  const std::vector<std::string> relaysAfterAdd = node.GlobalRelays();
   {
-    EXPECT_EQ(relays_after_add.size(), relays_before_add.size() + 1);
-    auto relay_it = std::find_if(
-        relays_after_add.cbegin(), relays_after_add.cend(),
+    EXPECT_EQ(relaysAfterAdd.size(), relaysBeforeAdd.size() + 1);
+    auto relayIt = std::find_if(
+        relaysAfterAdd.cbegin(), relaysAfterAdd.cend(),
         [](const std::string &relay) { return relay == "127.0.0.123"; });
-    EXPECT_NE(relay_it, relays_after_add.cend());
+    EXPECT_NE(relayIt, relaysAfterAdd.cend());
   }
 }
 


### PR DESCRIPTION
This change allows users to configure relays from code without having to `setenv(GZ_RELAY)`.

# 🎉 New feature

## Summary
This change allows users to configure relays from code without having to `setenv(GZ_RELAY)`.

Supersedes https://github.com/gazebosim/gz-transport/pull/497

## Test it
This can be tested by starting a Node across a boundary where multicast isn't enabled, and setting the relay IP via NodeOptions.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.