### PR TITLE
Include Python tutorial in list of tutorials

### DIFF
--- a/tutorials.md.in
+++ b/tutorials.md.in
@@ -11,13 +11,14 @@ Gazebo @GZ_DESIGNATION_CAP@ library and how to use the library effectively.
 3. \subpage nodestopics "Nodes and Topics"
 4. \subpage messages "Messages"
 5. \subpage services "Services"
-6. \subpage security "Security"
-7. \subpage relay "Relay"
-8. \subpage logging "Logging"
-9. \subpage envvars "Environment Variables"
-10. \subpage contribute "How to contribute"
-11. \subpage development "Development"
-12. \subpage topicstatistics "Topic Statistics"
+6. \subpage python "Python Support"
+7. \subpage security "Security"
+8. \subpage relay "Relay"
+9. \subpage logging "Logging"
+10. \subpage envvars "Environment Variables"
+11. \subpage contribute "How to contribute"
+12. \subpage development "Development"
+13. \subpage topicstatistics "Topic Statistics"
 
 
 ## License


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
The python tutorial is missing from the list in https://gazebosim.org/api/transport/13/tutorials.html

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.