### PR TITLE
(Forward port) Remove python3-distutils since it's not needed on Jammy (#496)

### DIFF
--- a/.github/ci/packages.apt
+++ b/.github/ci/packages.apt
@@ -10,7 +10,6 @@ libzmq3-dev
 pkg-config
 protobuf-compiler
 python3-dev
-python3-distutils
 python3-psutil
 python3-pybind11
 python3-pytest


### PR DESCRIPTION
# 🦟 Bug fix

Should fix debbuilders not finding distutils dependency on main for Noble.
Reference build: https://build.osrfoundation.org/job/gz-transport14-debbuilder/310/

## Summary
Removing distutils dependency, forward port differs a bit from original PR because in gz-transport13 there is a package.xml not available in main yet.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.