### PR TITLE
Enable 24.04 CI, require cmake 3.22.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,3 +23,12 @@ jobs:
           cppcheck-enabled: true
           cpplint-enabled: true
           doxygen-enabled: true
+  noble-ci:
+    runs-on: ubuntu-latest
+    name: Ubuntu Noble CI
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Compile and test
+        id: ci
+        uses: gazebo-tooling/action-gz-ci@noble

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 
 #============================================================================
 # Initialize the project

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 
 project(gz-transport-examples)
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,21 +1,6 @@
-if(WIN32 AND CMAKE_BUILD_TYPE STREQUAL "Debug")
-  # pybind11 logic for setting up a debug build when both a debug and release
-  # python interpreter are present in the system seems to be pretty much broken.
-  # This works around the issue.
-  set(PYTHON_LIBRARIES "${PYTHON_DEBUG_LIBRARIES}")
-endif()
-
 if(USE_SYSTEM_PATHS_FOR_PYTHON_INSTALLATION)
-  if(${CMAKE_VERSION} VERSION_LESS "3.12.0")
-    execute_process(
-      COMMAND "${PYTHON_EXECUTABLE}" -c "if True:
-  from distutils import sysconfig as sc
-  print(sc.get_python_lib(plat_specific=True))"
-      OUTPUT_VARIABLE Python3_SITEARCH
-      OUTPUT_STRIP_TRAILING_WHITESPACE)
-  else()
+  if(NOT Python3_SITEARCH)
     # Get install variable from Python3 module
-    # Python3_SITEARCH is available from 3.12 on, workaround if needed:
     find_package(Python3 COMPONENTS Interpreter)
   endif()
 


### PR DESCRIPTION
# 🎉 New feature

Part of https://github.com/gazebosim/gz-cmake/issues/350.

## Summary

This adds a GitHub workflow using Noble and increases our minimum required cmake version to 3.22.1 since we are already requiring that in gz-cmake4. It also removes some old code to support older versions of cmake.

## Test it

Look at the 24.04 CI results.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
