### PR TITLE
Add an explicit dependency on cppzmq-dev

### DIFF
--- a/.github/ci/packages-noble.apt
+++ b/.github/ci/packages-noble.apt
@@ -1,0 +1,1 @@
+cppzmq-dev

--- a/.github/ci/packages.apt
+++ b/.github/ci/packages.apt
@@ -1,3 +1,4 @@
+cppzmq-dev
 libgz-cmake4-dev
 libgz-math8-dev
 libgz-msgs11-dev

--- a/.github/ci/packages.apt
+++ b/.github/ci/packages.apt
@@ -1,4 +1,3 @@
-cppzmq-dev
 libgz-cmake4-dev
 libgz-math8-dev
 libgz-msgs11-dev


### PR DESCRIPTION
# 🦟 Bug fix


## Summary
In Jammy, the zmq C++ headers were included in libzmq-dev. However, in Noble, the headers are now in a separate package, `cppzmq-dev`, and that package is recommended by libzmq-dev. This shouldn't affect most users, but anywhere these dependencies are installed with `--no-install-recommends` will now break because it won't have cppzmq-dev installed. This patch just adds an explicit dependency to avoid the problem.


## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
