### PR TITLE
Disable playback.ReplayStep for windows

### DIFF
--- a/log/test/integration/playback.cc
+++ b/log/test/integration/playback.cc
@@ -563,7 +563,7 @@ TEST(playback, IGN_UTILS_TEST_DISABLED_ON_MAC(ReplayPauseResume))
 //////////////////////////////////////////////////
 /// \brief Record a log and then play it back calling the Step method to control
 /// the playback workflow.
-TEST(playback, IGN_UTILS_TEST_DISABLED_ON_MAC(ReplayStep))
+TEST(playback, IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(ReplayStep))
 {
   std::vector<std::string> topics = {"/foo", "/bar", "/baz"};
 


### PR DESCRIPTION
# 🦟 Bug fix

Disables #195 

This tests has been failing flaky for a really long time. As discussed in Gazebo PMC meeting, this test will be disabled.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.