### PR TITLE
11 :arrow_right: 12 - Disable playback.ReplayStep for windows (#517)

### DIFF
--- a/log/test/integration/playback.cc
+++ b/log/test/integration/playback.cc
@@ -568,7 +568,7 @@ TEST(playback, GZ_UTILS_TEST_DISABLED_ON_MAC(ReplayPauseResume))
 //////////////////////////////////////////////////
 /// \brief Record a log and then play it back calling the Step method to control
 /// the playback workflow.
-TEST(playback, GZ_UTILS_TEST_DISABLED_ON_MAC(ReplayStep))
+TEST(playback, GZ_UTILS_TEST_ENABLED_ONLY_ON_LINUX(ReplayStep))
 {
   std::vector<std::string> topics = {"/foo", "/bar", "/baz"};
 


### PR DESCRIPTION
# ➡️ Forward port

Port ign-transport11 to gz-transport12

Follow up of #517, #518 

Disables #195

Branch comparison: https://github.com/gazebosim/gz-transport/compare/ign-transport12...ign-transport11

**Note to maintainers**: Remember to **Merge** with commit (not squash-merge or rebase)