### PR TITLE
Prepare for 14.0.0~pre1 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ cmake_dependent_option(USE_DIST_PACKAGES_FOR_PYTHON
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-gz_configure_project(VERSION_SUFFIX)
+gz_configure_project(VERSION_SUFFIX pre1)
 
 #============================================================================
 # Set project-specific options

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,13 @@
 
 ### Gazebo Transport 14.0.0 (2024-08-26)
 
-Changes since 13.4.0:
+1. **Baseline:** this includes all changes from 13.4.0 and earlier.
+
+1. Update gz-transport14 badge URLs
+    * [Pull request #524](https://github.com/gazebosim/gz-transport/pull/524)
+
+1. Ionic Changelog
+    * [Pull request #523](https://github.com/gazebosim/gz-transport/pull/523)
 
 1. Replace IGN_IP with GZ_IP
     * [Pull request #515](https://github.com/gazebosim/gz-transport/pull/515)


### PR DESCRIPTION

<!-- For maintainers only -->

# 🎈 Release

Preparation for 14.0.0~pre1 release.

Comparison to 13.4.0: https://github.com/gazebosim/gz-transport/compare/gz-transport13_13.4.0...prep_14.0.0pre1

## Checklist
- [x] Asked team if this is a good time for a release
- [x] There are no changes to be ported from the previous major version
- [x] No PRs targeted at this major version are close to getting in
- [x] Bumped minor for new features, patch for bug fixes
- [x] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
