### PR TITLE
Replace deprecated ruby File.exists with File.exist and tweak tutorial

### DIFF
--- a/example/playback.cc
+++ b/example/playback.cc
@@ -21,6 +21,7 @@
 /// Launch the gz-transport subscriber example if the log was created
 /// by recording the publisher example.
 
+//! [complete]
 #include <cstdint>
 #include <iostream>
 #include <regex>
@@ -62,4 +63,7 @@ int main(int argc, char *argv[])
   // Wait until the player stops on its own
   std::cout << "Playing all messages in the log file\n";
   handle->WaitUntilFinished();
+
+  return 0;
 }
+//! [complete]

--- a/example/record.cc
+++ b/example/record.cc
@@ -20,6 +20,7 @@
 /// Launch the gz-transport publisher example so this example has
 /// something to record.
 
+//! [complete]
 #include <cstdint>
 #include <iostream>
 #include <regex>
@@ -65,4 +66,7 @@ int main(int argc, char *argv[])
   recorder.Stop();
 
   std::cout << "\nRecording finished!" << std::endl;
+
+  return 0;
 }
+//! [complete]

--- a/log/src/cmd/cmdlog.rb.in
+++ b/log/src/cmd/cmdlog.rb.in
@@ -187,7 +187,7 @@ class Cmd
 
       case options['subcommand']
       when 'record'
-        if options['force'] and File.exists?(options['file'])
+        if options['force'] and File.exist?(options['file'])
           begin
             File.delete(options['file'])
           rescue Exception => e

--- a/tutorials/10_logging.md
+++ b/tutorials/10_logging.md
@@ -28,54 +28,7 @@ cd ~/gz_transport_tutorial
 Download the [record.cc](https://github.com/gazebosim/gz-transport/raw/gz-transport14/example/record.cc)
 file within the `gz_transport_tutorial` folder and open it with your favorite editor:
 
-```{.cpp}
-#include <cstdint>
-#include <iostream>
-#include <regex>
-
-#include <gz/transport/Node.hh>
-#include <gz/transport/log/Recorder.hh>
-
-//////////////////////////////////////////////////
-int main(int argc, char *argv[])
-{
-  if (argc != 2)
-  {
-    std::cerr << "Usage: " << argv[0] << " OUTPUT.tlog\n";
-    return -1;
-  }
-
-  gz::transport::log::Recorder recorder;
-
-  // Record all topics
-  const int64_t addTopicResult = recorder.AddTopic(std::regex(".*"));
-  if (addTopicResult < 0)
-  {
-    std::cerr << "An error occurred when trying to add topics: "
-              << addTopicResult << "\n";
-    return -1;
-  }
-
-  // Begin recording, saving received messages to the given file
-  const auto result = recorder.Start(argv[1]);
-  if (gz::transport::log::RecorderError::SUCCESS != result)
-  {
-    std::cerr << "Failed to start recording: " << static_cast<int64_t>(result)
-              << "\n";
-    return -2;
-  }
-
-  std::cout << "Press Ctrl+C to finish recording.\n  Recording... "
-            << std::endl;
-
-  // Wait until the interrupt signal is sent.
-  gz::transport::waitForShutdown();
-
-  recorder.Stop();
-
-  std::cout << "\nRecording finished!" << std::endl;
-}
-```
+\snippet example/record.cc complete
 
 ### Walkthrough
 
@@ -130,50 +83,7 @@ Download the [playback.cc](https://github.com/gazebosim/gz-transport/raw/gz-tran
 file within the `gz_transport_tutorial` folder and open it with your favorite
 editor:
 
-```{.cpp}
-#include <cstdint>
-#include <iostream>
-#include <regex>
-#include <gz/transport/log/Playback.hh>
-
-//////////////////////////////////////////////////
-int main(int argc, char *argv[])
-{
-  if (argc != 2)
-  {
-    std::cerr << "Usage: " << argv[0] << " INPUT.tlog\n";
-    return -1;
-  }
-
-  gz::transport::log::Playback player(argv[1]);
-
-  // Playback all topics
-  const int64_t addTopicResult = player.AddTopic(std::regex(".*"));
-  if (addTopicResult == 0)
-  {
-    std::cout << "No topics to play back\n";
-    return 0;
-  }
-  else if (addTopicResult < 0)
-  {
-    std::cerr << "Failed to advertise topics: " << addTopicResult
-              << "\n";
-    return -1;
-  }
-
-  // Begin playback
-  const auto handle = player.Start();
-  if (!handle)
-  {
-    std::cerr << "Failed to start playback\n";
-    return -2;
-  }
-
-  // Wait until the player stops on its own
-  std::cout << "Playing all messages in the log file\n";
-  handle->WaitUntilFinished();
-}
-```
+\snippet example/playback.cc complete
 
 ### Walkthrough
 


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

While testing the [logging tutorial ](https://gazebosim.org/api/transport/14/logging.html), I ran into an issue executing:

```
gz log record --force --file tutorial.tlog
```

The ruby `File.exists()` function was removed in `3.2.0`, which is the version in Ubuntu Noble. I updated the code and also used `snippet` in the tutorial.

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.