### PR TITLE
Multiple  NodeShared per process

### DIFF
--- a/python/test/nodeDiscoveryPubs_TEST.py
+++ b/python/test/nodeDiscoveryPubs_TEST.py
@@ -1,0 +1,44 @@
+from threading import Thread
+from multiprocessing import Process
+import time
+
+
+def create_pubs(id_):
+    '''creates publishers at isolated discovery network, isolated network is created based on id_'''
+    import os
+    isolated_env = {'GZ_DISCOVERY_MSG_PORT':f'{11320+id_*10}',
+            'GZ_DISCOVERY_SRV_PORT':f'{11321+id_*10}',
+            'GZ_DISCOVERY_MULTICAST_IP': f'239.255.0.{10+id_}',
+            'GZ_PARTITION':f'env{id_}',
+            }
+                        
+    print("Exec the following in cli to listen to topics at isolated env", id_)
+    [print(f'export {key}={isolated_env[key]}') for key in isolated_env]
+    os.environ.update(isolated_env)
+    import gz.transport14 as transport
+    from gz.msgs11.empty_pb2 import Empty
+    node = transport.Node()
+    pub = node.advertise(f'/empty{id_}', Empty)
+    import time 
+    while True:
+        print(f"publishing at env {id_}")
+        pub.publish(Empty())
+        time.sleep(1.0)
+    
+
+
+def pub_proc(n_threads):
+    '''process for creating multiple pubs'''
+
+    pub_threads =[Thread(target=create_pubs,args=[i]) for i in range(n_threads)]
+    for pi in pub_threads:
+        pi.start()
+        time.sleep(2.0)
+    for pi in pub_threads:
+        pi.join()
+
+
+
+proc_pub = Thread(target=pub_proc, args=[2])
+proc_pub.start()
+proc_pub.join()

--- a/python/test/nodeDiscoverySubs_TEST.py
+++ b/python/test/nodeDiscoverySubs_TEST.py
@@ -1,0 +1,64 @@
+from threading import Thread
+from multiprocessing import Process
+import time
+
+
+
+def create_subs(id_):
+    '''creates subscribers at isolated discovery network, isolated network is created based on id_'''
+    import os
+    isolated_env = {'GZ_DISCOVERY_MSG_PORT':f'{11320+id_*10}',
+            'GZ_DISCOVERY_SRV_PORT':f'{11321+id_*10}',
+            'GZ_DISCOVERY_MULTICAST_IP': f'239.255.0.{10+id_}',
+            'GZ_PARTITION':f'env{id_}',
+            }
+                        
+    print("Exec the following in cli to listen to topics at isolated env", id_)
+    [print(f'export {key}={isolated_env[key]}') for key in isolated_env]
+    os.environ.update(isolated_env)
+    import gz.transport14 as transport
+    from gz.msgs11.empty_pb2 import Empty
+    node = transport.Node()
+    def cb(msg):
+        print(f"Recieved msg at env {id_}")
+
+    sub = node.subscribe(Empty, f'/empty{id_}', cb)
+
+    import time 
+    while True:
+        time.sleep(1.0)
+
+
+
+
+def sub_proc(n_threads):
+    '''process for creating multiple subs'''
+    # We reverse the order of env, this is to ensure
+    # that the mew environments do not keep the initial envf vars
+    # For example, consider the scenario where
+    # two publishers are created with ids 0,1
+    # If the env var change did affect them, then each one should be publishing
+    # with different discovery ports
+    # If it didn't affect, then all of them should be publishing at same discovery port
+    # In order to verify that these publishers are indeed publishing at different ports
+    # We can reverse the order of env id, when creating subscribers.
+    # This ensures that the env var change indeed affected
+    # See below:
+    # 1. pub1 and pub2 created under same discovery (order of env creation 0->1)
+    #    sub1 and sub2 created under same discovery (order of env creation 0->1)
+    #    Since they are under same discovery, both pubs and subs will receive their msgs
+    #    But its not easy to verify if they were created under different discovery
+    # 2. pub1 and pub2 created under different discovery (order of env creation 0->1)
+    #    sub1 and sub2 created under different discovery (order of env creation 1->0)
+    #    If they are under same discovery, both subs will NOT receive their msgs
+
+    sub_threads =[Thread(target=create_subs,args=[i]) for i in reversed(range(n_threads))]
+    for si in sub_threads:
+        si.start()
+        time.sleep(2.0)
+    for si in sub_threads:
+        si.join()
+
+proc_sub = Thread(target=sub_proc, args=[2])
+proc_sub.start()
+proc_sub.join()

--- a/src/NodeShared.cc
+++ b/src/NodeShared.cc
@@ -163,7 +163,8 @@ NodeShared *NodeShared::Instance()
 
   // Get current process ID.
   auto pid = getProcessId();
-  // Get current thread ID, so we can create multiple NodeShared per Process, per thread
+  // Get current thread ID, so we can create multiple NodeShared per Process
+  // , per thread
   auto tid = std::this_thread::get_id();
   // Create a unique id using both pid and tid
   std::stringstream ss;


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->



# 🎉 New feature

Closes #531

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->
Currently the transport architecture restricts a single `NodeShared` object per process. This is achieved by mapping process id to an instance of `NodeShared` class. However, recently, I had some use cases where I need to isolate several nodes, each with their own `DISCOVERY` variables, such as `GZ_DISCOVERY_MSG_PORT`,`GZ_DISCOVERY_SRV_PORT`, `GZ_DISCOVERY_MULTICAST_IP`,`GZ_PARTITION`, in a single process. Due to the limitation mentioned above, this is not possible because
`DISCOVERY` is tied to a process, and when instantiating multiple Nodes per process, all of them obtain the same NodeShared object and hence the same `DISCOVERY` variables. 

To overcome this, one approach is to also use a `thread_id` to create a unique identifier that maps to a `NodeShared` object. This pins down the uniqueness of `NodeShared` object to each thread, not the process. The proposed modification performs this by the following logic:

``` 
// Map for obtaining shared node
static std::unordered_map<std::string, NodeShared*> nodeSharedMap;


 auto pid = getProcessId();
  // Get current thread ID, so we can create multiple NodeShared per Process, per thread
  auto tid = std::this_thread::get_id();
  // Create a unique id using both pid and tid
  std::stringstream ss;
  ss << tid;
  std::stringstream unique_ss;
  unique_ss << std::hex << pid << "-" << ss.str();
  auto uid = unique_ss.str();

 // create or access the shared node
 nodeSharedMap.find(uid) ; //access
// OR
 nodeSharedMap.insert(uid, new NodeShared) ; //create
```
This allows specification of `DISCOVERY` variables per thread.
 
## Test it
<!--Explain how reviewers can test this new feature manually.-->
For testing the proposed improvement, I added two test files `nodeDiscoveryPubs_TEST.py` and `nodeDiscoverySubs_TEST.py` under `python/test` directory. Each one shall be run in a separate terminal before and after modifications to see the results. Before modification, it is not possible to receive the messages by the subscribers due to the issue I mentioned. However, after my modification, the subscribers are able to receive their messages. 
Finally, the proposed modification can also be verified from `CLI`. When the publisher TEST is run, it prints the command that can be run in a shell to set the `DISCOVERY` vars to listen to their publications.

NOTE: The following tests failed:
`NodeTest.ScopeProcess`  and  `NodeTest.ScopeProcessRemap`, because the test runs by creating publisher and subscriber in different threads. Due to the proposed modification, these 2 tests will fail.

## Checklist
- [X] Signed all commits for DCO
- [X] Added tests
- [ ] Added example and/or tutorial
- [X] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
