### PR TITLE
Add compatibility with protobuf 28

### DIFF
--- a/include/gz/transport/RepHandler.hh
+++ b/include/gz/transport/RepHandler.hh
@@ -146,6 +146,18 @@ namespace gz
           google::protobuf::DynamicCastMessage<Req>(&_msgReq);
         auto msgRep =
           google::protobuf::DynamicCastMessage<Rep>(&_msgRep);
+#elif GOOGLE_PROTOBUF_VERSION >= 4022000
+        auto msgReq =
+          google::protobuf::internal::DownCast<const Req*>(&_msgReq);
+        auto msgRep = google::protobuf::internal::DownCast<Rep*>(&_msgRep);
+#elif GOOGLE_PROTOBUF_VERSION > 2999999
+        auto msgReq = google::protobuf::down_cast<const Req*>(&_msgReq);
+        auto msgRep = google::protobuf::down_cast<Rep*>(&_msgRep);
+#else
+        auto msgReq =
+          google::protobuf::internal::down_cast<const Req*>(&_msgReq);
+        auto msgRep = google::protobuf::internal::down_cast<Rep*>(&_msgRep);
+#endif
 
         // Verify the dynamically casted messages are valid
         if (msgReq == nullptr || msgRep == nullptr)
@@ -185,18 +197,6 @@ namespace gz
           std::cerr.flush();
           return false;
         }
-#elif GOOGLE_PROTOBUF_VERSION >= 4022000
-        auto msgReq =
-          google::protobuf::internal::DownCast<const Req*>(&_msgReq);
-        auto msgRep = google::protobuf::internal::DownCast<Rep*>(&_msgRep);
-#elif GOOGLE_PROTOBUF_VERSION > 2999999
-        auto msgReq = google::protobuf::down_cast<const Req*>(&_msgReq);
-        auto msgRep = google::protobuf::down_cast<Rep*>(&_msgRep);
-#else
-        auto msgReq =
-          google::protobuf::internal::down_cast<const Req*>(&_msgReq);
-        auto msgRep = google::protobuf::internal::down_cast<Rep*>(&_msgRep);
-#endif
 
         return this->cb(*msgReq, *msgRep);
       }

--- a/include/gz/transport/RepHandler.hh
+++ b/include/gz/transport/RepHandler.hh
@@ -141,7 +141,51 @@ namespace gz
           return false;
         }
 
-#if GOOGLE_PROTOBUF_VERSION >= 4022000
+#if GOOGLE_PROTOBUF_VERSION >= 5028000
+        const auto msgReq =
+          google::protobuf::DynamicCastMessage<Req>(&_msgReq);
+        auto msgRep =
+          google::protobuf::DynamicCastMessage<Rep>(&_msgRep);
+
+        // Verify the dynamically casted messages are valid
+        if (msgReq == nullptr || msgRep == nullptr)
+        {
+          if (msgReq == nullptr)
+          {
+            if (_msgReq.GetDescriptor() != nullptr)
+            {
+              std::cerr << "RepHandler::RunLocalCallback() error: "
+                        << "Failed to cast the request of the type "
+                        << _msgReq.GetDescriptor()->full_name()
+                        << " to the specified type" << '\n';
+            }
+            else
+            {
+              std::cerr << "RepHandler::RunLocalCallback() error: "
+                        << "Failed to cast the request of an unknown type"
+                        << " to the specified type" << '\n';
+            }
+          }
+          if (msgRep == nullptr)
+          {
+            if (_msgRep.GetDescriptor() != nullptr)
+            {
+              std::cerr << "RepHandler::RunLocalCallback() error: "
+                        << "Failed to cast the response of the type "
+                        << _msgRep.GetDescriptor()->full_name()
+                        << " to the specified type" << '\n';
+            }
+            else
+            {
+              std::cerr << "RepHandler::RunLocalCallback() error: "
+                        << "Failed to cast the response of an unknown type"
+                        << " to the specified type" << '\n';
+            }
+          }
+          std::cerr.flush();
+          return false;
+        }
+#elif GOOGLE_PROTOBUF_VERSION >= 4022000
         auto msgReq =
           google::protobuf::internal::DownCast<const Req*>(&_msgReq);
         auto msgRep = google::protobuf::internal::DownCast<Rep*>(&_msgRep);

--- a/include/gz/transport/SubscriptionHandler.hh
+++ b/include/gz/transport/SubscriptionHandler.hh
@@ -216,6 +216,13 @@ namespace gz
 
 #if GOOGLE_PROTOBUF_VERSION >= 5028000
         auto msgPtr = google::protobuf::DynamicCastMessage<T>(&_msg);
+#elif GOOGLE_PROTOBUF_VERSION >= 4022000
+        auto msgPtr = google::protobuf::internal::DownCast<const T*>(&_msg);
+#elif GOOGLE_PROTOBUF_VERSION >= 3000000
+        auto msgPtr = google::protobuf::down_cast<const T*>(&_msg);
+#else
+        auto msgPtr = google::protobuf::internal::down_cast<const T*>(&_msg);
+#endif
 
         // Verify the dynamically casted message is valid
         if (msgPtr == nullptr)
@@ -236,13 +243,6 @@ namespace gz
           std::cerr.flush();
           return false;
         }
-#elif GOOGLE_PROTOBUF_VERSION >= 4022000
-        auto msgPtr = google::protobuf::internal::DownCast<const T*>(&_msg);
-#elif GOOGLE_PROTOBUF_VERSION >= 3000000
-        auto msgPtr = google::protobuf::down_cast<const T*>(&_msg);
-#else
-        auto msgPtr = google::protobuf::internal::down_cast<const T*>(&_msg);
-#endif
 
         this->cb(*msgPtr, _info);
         return true;

--- a/include/gz/transport/SubscriptionHandler.hh
+++ b/include/gz/transport/SubscriptionHandler.hh
@@ -214,7 +214,29 @@ namespace gz
         if (!this->UpdateThrottling())
           return true;
 
-#if GOOGLE_PROTOBUF_VERSION >= 4022000
+#if GOOGLE_PROTOBUF_VERSION >= 5028000
+        auto msgPtr = google::protobuf::DynamicCastMessage<T>(&_msg);
+
+        // Verify the dynamically casted message is valid
+        if (msgPtr == nullptr)
+        {
+          if (_msg.GetDescriptor() != nullptr)
+          {
+            std::cerr << "SubscriptionHandler::RunLocalCallback() error: "
+                      << "Failed to cast the message of the type "
+                      << _msg.GetDescriptor()->full_name()
+                      << " to the specified type" << '\n';
+          }
+          else
+          {
+            std::cerr << "SubscriptionHandler::RunLocalCallback() error: "
+                      << "Failed to cast the message of an unknown type"
+                      << " to the specified type" << '\n';
+          }
+          std::cerr.flush();
+          return false;
+        }
+#elif GOOGLE_PROTOBUF_VERSION >= 4022000
         auto msgPtr = google::protobuf::internal::DownCast<const T*>(&_msg);
 #elif GOOGLE_PROTOBUF_VERSION >= 3000000
         auto msgPtr = google::protobuf::down_cast<const T*>(&_msg);


### PR DESCRIPTION
# 🎉 New feature

Adds compatibility with the Google Protocol Buffers v28.

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->
Basically, rules for message down casting have been changed in protobuf and this PR modifies the way protobuf is used for downcasting.

Protobuf does not allow to use google::protobuf::internal::DownCast function to downcast message types with concepts enabled in version 28 (see port.h file in [this](https://github.com/protocolbuffers/protobuf/commit/e0690ce6c7b97ca2fe89f23f363d549764a0fc39#diff-ae1dc11d096fc98a5d3ab8a8c1bdac8b004433aa350c39a11348600d44308dcdR165) diff). When compiling custom packages which depend on the gz-transport with C++ concepts enabled, there will be compile-time errors, if RepHandler::RunLocalCallback or SubscriptionHandler::RunLocalCallback functions were used (not necessarily used directly, but via some other function, for example: Node::Request).

Alternatively. there are google::protobuf::DynamicCastMessage and google::protobuf::DownCastMessage functions. Because google::protobuf::DynamicCastMessage function has more sanity checks, it was used in this PR with some additional error logging.

## Test it
<!--Explain how reviewers can test this new feature manually.-->
To test the changes you may install the Google Protocol Buffers v28, write some code that uses RepHandler::RunLocalCallback or SubscriptionHandler::RunLocalCallback (not necessarily directly) with C++ concepts enabled, and try to compile the code.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
