### PR TITLE
Prepare for 14.0.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ cmake_dependent_option(USE_DIST_PACKAGES_FOR_PYTHON
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-gz_configure_project(VERSION_SUFFIX pre1)
+gz_configure_project(VERSION_SUFFIX)
 
 #============================================================================
 # Set project-specific options

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,8 +1,24 @@
 ## Gazebo Transport 14.X
 
-### Gazebo Transport 14.0.0 (2024-08-26)
+### Gazebo Transport 14.0.0 (2024-09-25)
 
 1. **Baseline:** this includes all changes from 13.4.0 and earlier.
+
+1. Miscellaneous documentation fixes
+    * [Pull request #536](https://github.com/gazebosim/gz-transport/pull/536)
+    * [Pull request #539](https://github.com/gazebosim/gz-transport/pull/539)
+    * [Pull request #537](https://github.com/gazebosim/gz-transport/pull/537)
+    * [Pull request #534](https://github.com/gazebosim/gz-transport/pull/534)
+    * [Pull request #532](https://github.com/gazebosim/gz-transport/pull/532)
+    * [Pull request #528](https://github.com/gazebosim/gz-transport/pull/528)
+    * [Pull request #527](https://github.com/gazebosim/gz-transport/pull/527)
+    * [Pull request #526](https://github.com/gazebosim/gz-transport/pull/526)
+
+1. Simplify the relay tutorial docker setup
+    * [Pull request #530](https://github.com/gazebosim/gz-transport/pull/530)
+
+1. Replace deprecated File.exists with File.exist and tweak tutorial
+    * [Pull request #529](https://github.com/gazebosim/gz-transport/pull/529)
 
 1. Update gz-transport14 badge URLs
     * [Pull request #524](https://github.com/gazebosim/gz-transport/pull/524)


### PR DESCRIPTION

# 🎈 Release

Preparation for 14.0.0 release.

Comparison to 14.0.0-pre1: https://github.com/gazebosim/gz-transport/compare/gz-transport14_14.0.0-pre1...gz-transport14


## Checklist
- [ ] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [ ] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
