### PR TITLE
 Disable playback.ReplayStep for windows (#517)

### DIFF
--- a/log/test/integration/playback.cc
+++ b/log/test/integration/playback.cc
@@ -568,7 +568,7 @@ TEST(playback, GZ_UTILS_TEST_DISABLED_ON_MAC(ReplayPauseResume))
 //////////////////////////////////////////////////
 /// \brief Record a log and then play it back calling the Step method to control
 /// the playback workflow.
-TEST(playback, GZ_UTILS_TEST_DISABLED_ON_MAC(ReplayStep))
+TEST(playback, GZ_UTILS_TEST_ENABLED_ONLY_ON_LINUX(ReplayStep))
 {
   std::vector<std::string> topics = {"/foo", "/bar", "/baz"};
 


### PR DESCRIPTION


# ➡️ Forward port

Port `gz-transport13` to `gz-transport14`

Branch comparison: https://github.com/gazebosim/gz-transport/compare/gz-transport14...claraberendsen:claraberendsen/13_to_14_2024-10-01

Follow up of https://github.com/gazebosim/gz-transport/pull/517, https://github.com/gazebosim/gz-transport/pull/518, https://github.com/gazebosim/gz-transport/pull/521, #522 

Disables https://github.com/gazebosim/gz-transport/issues/195

**Note to maintainers**: Remember to **Merge** with commit (not squash-merge or rebase)


