### PR TITLE
Using Pathname to check for absolute path in ruby script

### DIFF
--- a/src/cmd/cmdtransport.rb.in
+++ b/src/cmd/cmdtransport.rb.in
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'open3'
+require 'pathname'
 
 # Constants.
 LIBRARY_VERSION = '@PROJECT_VERSION_FULL@'
@@ -31,10 +31,7 @@ class Cmd
     command = args[0]
     exe_name = COMMANDS[command]
 
-    if exe_name[0] == '/'
-      # If the first character is a slash, we'll assume that we've been given an
-      # absolute path to the executable. This is only used during test mode.
-    else
+    unless Pathname.new(exe_name).absolute?
       # We're assuming that the library path is relative to the current
       # location of this script.
       exe_name = File.expand_path(File.join(File.dirname(__FILE__), exe_name))


### PR DESCRIPTION
# 🦟 Bug fix

Part of https://github.com/gazebosim/gz-tools/issues/7

## Summary
As suggested in this [comment](https://github.com/gazebosim/gz-tools/issues/7#issuecomment-2392071709) by @scpeters, porting the fix from https://github.com/gazebosim/gz-plugin/pull/131 for determination of absolute path in ruby script. 

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.