### PR TITLE
Fix flakiness in the TopicInfo test

### DIFF
--- a/src/cmd/gz_TEST.cc
+++ b/src/cmd/gz_TEST.cc
@@ -126,7 +126,6 @@ TEST(ignTest, TopicInfo)
   auto testLoop = std::async(std::launch::async, [&]{
     while (!infoFound && retries++ < 10u)
     {
-      std::cout << "Waiting for topic ...\n";
       output = custom_exec_str(ign + " topic -t /foo -i " + g_ignVersion);
       infoFound = output.size() > 50u;
       std::this_thread::sleep_for(std::chrono::milliseconds(300));
@@ -134,7 +133,6 @@ TEST(ignTest, TopicInfo)
   });
 
   std::this_thread::sleep_for(std::chrono::seconds(1));
-  std::cout << "Fork and run " << publisher_path << std::endl;
   testing::forkHandlerType pi = testing::forkAndRun(publisher_path.c_str(),
     g_partition.c_str());
 

--- a/src/cmd/gz_TEST.cc
+++ b/src/cmd/gz_TEST.cc
@@ -17,6 +17,7 @@
 
 #include <filesystem>
 #include <fstream>
+#include <future>
 #include <iostream>
 #include <string>
 #include <ignition/msgs.hh>
@@ -115,9 +116,6 @@ TEST(ignTest, TopicInfo)
     IGN_TRANSPORT_TEST_DIR,
     "INTEGRATION_twoProcsPublisher_aux");
 
-  testing::forkHandlerType pi = testing::forkAndRun(publisher_path.c_str(),
-    g_partition.c_str());
-
   // Check the 'ign topic -i' command.
   std::string ign = std::string(IGN_PATH);
 
@@ -125,13 +123,22 @@ TEST(ignTest, TopicInfo)
   bool infoFound = false;
   std::string output;
 
-  while (!infoFound && retries++ < 10u)
-  {
-    output = custom_exec_str(ign + " topic -t /foo -i " + g_ignVersion);
-    infoFound = output.size() > 50u;
-    std::this_thread::sleep_for(std::chrono::milliseconds(300));
-  }
+  auto testLoop = std::async(std::launch::async, [&]{
+    while (!infoFound && retries++ < 10u)
+    {
+      std::cout << "Waiting for topic ...\n";
+      output = custom_exec_str(ign + " topic -t /foo -i " + g_ignVersion);
+      infoFound = output.size() > 50u;
+      std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    }
+  });
 
+  std::this_thread::sleep_for(std::chrono::seconds(1));
+  std::cout << "Fork and run " << publisher_path << std::endl;
+  testing::forkHandlerType pi = testing::forkAndRun(publisher_path.c_str(),
+    g_partition.c_str());
+
+  testLoop.wait();
   EXPECT_TRUE(infoFound) << "OUTPUT["
     << output << "] Size[" << output.size()
     << "]. Expected Size=50" << std::endl;


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #510 

## Summary
The flakiness appears to be a timing issue. The fix here involves running the loop that waits for the input messages in a separate thread before starting the publisher.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
