### PR TITLE
Fix duplicate topic name checking in Node

### DIFF
--- a/src/Node.cc
+++ b/src/Node.cc
@@ -1019,7 +1019,7 @@ Node::Publisher Node::Advertise(const std::string &_topic,
   auto currentTopics = this->AdvertisedTopics();
 
   if (std::find(currentTopics.begin(), currentTopics.end(),
-        fullyQualifiedTopic) != currentTopics.end())
+        _topic) != currentTopics.end())
   {
     std::cerr << "Topic [" << topic << "] already advertised. You cannot"
       << " advertise the same topic twice on the same node."

--- a/src/Node_TEST.cc
+++ b/src/Node_TEST.cc
@@ -951,10 +951,12 @@ TEST(NodeTest, AdvertiseTwoEqualTopics)
 
   auto pub1 = node1.Advertise<msgs::Int32>(g_topic);
   EXPECT_TRUE(pub1);
-  auto pub2 = node1.Advertise<msgs::StringMsg>(g_topic);
+  auto pub2 = node1.Advertise<msgs::Int32>(g_topic);
   EXPECT_FALSE(pub2);
-  auto pub3 = node2.Advertise<msgs::StringMsg>(g_topic);
-  EXPECT_TRUE(pub3);
+  auto pub3 = node1.Advertise<msgs::StringMsg>(g_topic);
+  EXPECT_FALSE(pub3);
+  auto pub4 = node2.Advertise<msgs::StringMsg>(g_topic);
+  EXPECT_TRUE(pub4);
 }
 
 //////////////////////////////////////////////////


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Currently when duplicate topic names are advertised from the same node, we get a discovery service error:

```
Node::Advertise(): Error advertising topic [/foo]. Did you forget to start the discovery service?
```

The msg leads the user to think that it's a discovery issue instead of duplicate topic names. Turns out that there's actually logic for checking duplicate names already but there's a bug. The code checks the fully qualified name of the input topic against a set of non-fully qualified topic names so it never finds duplicates. This PR fixes the check, and a more relevant error msg should now be printed:

```
Topic [/foo] already advertised. You cannot advertise the same topic twice on the same node. If you want to advertise the same topic with different types, use separate nodes
```

To test, run the `AdvertiseTwoEqualTopic` test in `Node_TEST`, e.g.

```
./build/gz-transport14/bin/UNIT_Node_TEST --gtest_filter="*AdvertiseTwoEqualTopic*"
```



## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
