### PR TITLE
Unhide cmake warning when Python3 Development is not found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,7 +157,7 @@ if (NOT SKIP_PYBIND11)
   if (Python3_Development_FOUND)
     add_subdirectory(python)
   else ()
-    GZ_BUILD_WARNING("Python development libraries are missing: Python interfaces are disabled.")
+    message(WARNING "Python development libraries are missing: Python interfaces are disabled.")
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,9 +61,6 @@ else()
   find_package(Python3
     COMPONENTS Interpreter
     OPTIONAL_COMPONENTS Development)
-  if (NOT Python3_Development_FOUND)
-    GZ_BUILD_WARNING("Python development libraries are missing: Python interfaces are disabled.")
-  endif()
 endif()
 
 #--------------------------------------
@@ -156,8 +153,12 @@ add_subdirectory(conf)
 #============================================================================
 # gz transport python bindings
 #============================================================================
-if (Python3_Development_FOUND AND NOT SKIP_PYBIND11)
-  add_subdirectory(python)
+if (NOT SKIP_PYBIND11)
+  if (Python3_Development_FOUND)
+    add_subdirectory(python)
+  else ()
+    GZ_BUILD_WARNING("Python development libraries are missing: Python interfaces are disabled.")
+  endif()
 endif()
 
 #============================================================================


### PR DESCRIPTION
# 🦟 Bug fix

Unhides a cmake warning when python bindings will not be built

## Summary

A cmake warning should be printed when python bindings will not be built (controlled by the logic around `add_subdirectory(python)`), but the warning was in a separate part of the code, allowing the warning to be missed if the `Python3_Development_FOUND` variable changed in between.

Since `GZ_BUILD_WARNING("")` only generates a cmake warning if invoked before `gz_configure_build`, I switched to use `message(WARNING "")` in https://github.com/gazebosim/gz-transport/pull/565/commits/e464330418197347b4ce208be354864405cf5779.

Also, the failed Ubuntu Noble CI build is expected because finding python is currently broken for all platforms, but only our Ubuntu Noble CI builds report cmake warnings. I believe finding python should be fixed once https://github.com/gazebosim/gz-msgs/pull/479 is merged and released. I think it would be worth merging this so that our broken state is accurately reflected.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
