### PR TITLE
Prepare for 8.5.1 Release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-transport8 VERSION 8.5.0)
+project(ignition-transport8 VERSION 8.5.1)
 
 #============================================================================
 # Find ignition-cmake

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 ## Ignition Transport 8
 
+### Gazebo Transport 8.5.1 (2025-01-29)
+
+1. Disable playback.ReplayStep for windows
+    * [Pull request #517](https://github.com/gazebosim/gz-transport/pull/517)
+
 ### Gazebo Transport 8.5.0 (2024-01-05)
 
 1. Update github action workflows


### PR DESCRIPTION
# 🎈 Release

Preparation for 8.5.1 release.

Comparison to 8.5.0: https://github.com/gazebosim/gz-transport/compare/ignition-transport8_8.5.0...ign-transport8

Part of https://github.com/gazebo-tooling/release-tools/issues/1252

## Checklist
- [ ] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [ ] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.