### PR TITLE
Fix for a memory leak on shutdown

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -71,7 +71,7 @@ release will remove the deprecated code.
 1. The discovery wire protocol changed to use gz::msgs::Discovery
    instead of C-structs. The Packet.hh header file is deprecated, which
    contained the Header, SubscriptionMsg, and AdvertiseMessage classes. The
-   version of the wire protocal has bumped from 9 to 10. This means Gazebo
+   version of the wire protocol has bumped from 9 to 10. This means Gazebo
    Transport 8+ will not work with Gazebo Transport 7 and below.
     * [BitBucket pull request 403](https://osrf-migration.github.io/ignition-gh-pages/#!/ignitionrobotics/ign-transport/pull-requests/403)
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,6 @@ RUN apt-get update \
         pkg-config \
         cppcheck \
         git \
-        mercurial \
         build-essential \
         curl \
         libprotobuf-dev \
@@ -41,6 +40,7 @@ RUN /bin/sh -c 'echo "deb [trusted=yes] http://packages.osrfoundation.org/gazebo
     libgz-math8-dev \
     libgz-msgs11-dev \
     libgz-utils3-cli-dev \
+    libgflags-dev \
  && apt-get clean
 
 USER ubuntu

--- a/example/bench.cc
+++ b/example/bench.cc
@@ -70,7 +70,7 @@ bool gStop = false;
 /// topics. FloodSub and FloodPub can be enabled with the `-f <num>` command
 /// line argument. Flooding adds <num> extra publishers and subscribers. The
 /// purpose is to "flood" the network with extra messages while performing
-/// benchmark analyis.
+/// benchmark analysis.
 class FloodSub
 {
   /// \brief Create the subscribers.
@@ -100,7 +100,7 @@ class FloodSub
 /// topics. FloodSub and FloodPub can be enabled with the `-f <num>` command
 /// line argument. Flooding adds <num> extra publishers and subscribers. The
 /// purpose is to "flood" the network with extra messages while performing
-/// benchmark analyis.
+/// benchmark analysis.
 class FloodPub
 {
   /// \brief Create a number of publishers.
@@ -635,7 +635,7 @@ class PubTester
   private: std::chrono::time_point<std::chrono::high_resolution_clock> timeEnd;
 
   /// \brief Output filename or empty string for console output.
-  private: std::string filename = "";
+  private: std::string filename;
 
   private: int expectedStamp = 0;
 };
@@ -663,16 +663,16 @@ int main(int argc, char **argv)
   std::signal(SIGTERM, signalHandler);
 
   // Simple usage.
-  std::string usage("Benchmark testing program.");
-  usage += " Usage:\n ./bench <options>\n\n";
-  usage += " Example intraprocess latency:\n\t./bench -l\n";
-  usage += " Example interprocess latency:\n";
-  usage += " \tTerminal 1: ./bench -l -r\n";
-  usage += " \tTerminal 2: ./bench -l -p\n";
-  usage += " Example intraprocess throughput:\n\t./bench -t\n";
-  usage += " Example interprocess throughput:\n";
-  usage += " \tTerminal 1: ./bench -t -r\n";
-  usage += " \tTerminal 2: ./bench -t -p\n";
+  std::string usage = "Benchmark testing program."
+    " Usage:\n ./bench <options>\n\n"
+    " Example intraprocess latency:\n\t./bench -l\n"
+    " Example interprocess latency:\n"
+    " \tTerminal 1: ./bench -l -r\n"
+    " \tTerminal 2: ./bench -l -p\n"
+    " Example intraprocess throughput:\n\t./bench -t\n"
+    " Example interprocess throughput:\n"
+    " \tTerminal 1: ./bench -t -r\n"
+    " \tTerminal 2: ./bench -t -p\n";
 
   gflags::SetUsageMessage(usage);
 

--- a/example/record.cc
+++ b/example/record.cc
@@ -43,7 +43,7 @@ int main(int argc, char *argv[])
   const int64_t addTopicResult = recorder.AddTopic(std::regex(".*"));
   if (addTopicResult < 0)
   {
-    std::cerr << "An error occured when trying to add topics: "
+    std::cerr << "An error occurred when trying to add topics: "
               << addTopicResult << "\n";
     return -1;
   }

--- a/include/gz/transport/Discovery.hh
+++ b/include/gz/transport/Discovery.hh
@@ -234,7 +234,7 @@ namespace gz
         this->mcastAddr.sin_port = htons(static_cast<u_short>(this->port));
 
         std::vector<std::string> relays;
-        std::string gzRelay = "";
+        std::string gzRelay;
         if (env("GZ_RELAY", gzRelay) && !gzRelay.empty())
         {
           relays = transport::split(gzRelay, ':');

--- a/include/gz/transport/NetUtils.hh
+++ b/include/gz/transport/NetUtils.hh
@@ -63,7 +63,7 @@ namespace gz
     /// \brief Determine your login name.
     /// \return Name used to gain access to the computer.
     /// On linux and Mac only, if determination
-    /// of your login name failes then a string of the form "error-UUID"
+    /// of your login name fails then a string of the form "error-UUID"
     /// is returned where UUID is a universally unique identifier.
     std::string GZ_TRANSPORT_VISIBLE username();
     }

--- a/include/gz/transport/Node.hh
+++ b/include/gz/transport/Node.hh
@@ -213,7 +213,7 @@ namespace gz
       /// \param[in] _options Advertise options.
       /// \return A PublisherId, which can be used in Node::Publish calls.
       /// The PublisherId also acts as boolean, where true occurs if the topic
-      /// was succesfully advertised.
+      /// was successfully advertised.
       /// \sa AdvertiseOptions.
       public: template<typename MessageT>
       Node::Publisher Advertise(
@@ -229,7 +229,7 @@ namespace gz
       /// \param[in] _options Advertise options.
       /// \return A PublisherId, which can be used in Node::Publish calls.
       /// The PublisherId also acts as boolean, where true occurs if the topic
-      /// was succesfully advertised.
+      /// was successfully advertised.
       /// \sa AdvertiseOptions.
       public: Node::Publisher Advertise(
           const std::string &_topic,
@@ -257,7 +257,7 @@ namespace gz
 
       /// \brief Subscribe to a topic registering a callback.
       /// Note that this callback does not include any message information.
-      /// In this version the callback is a lamda function.
+      /// In this version the callback is a lambda function.
       /// \param[in] _topic Topic to be subscribed.
       /// \param[in] _callback Lambda function with the following parameters:
       ///   * _msg Protobuf message containing a new topic update.
@@ -304,7 +304,7 @@ namespace gz
 
       /// \brief Subscribe to a topic registering a callback.
       /// Note that this callback includes message information.
-      /// In this version the callback is a lamda function.
+      /// In this version the callback is a lambda function.
       /// \param[in] _topic Topic to be subscribed.
       /// \param[in] _callback Lambda function with the following parameters:
       ///   * _msg Protobuf message containing a new topic update.
@@ -523,7 +523,7 @@ namespace gz
       ///   * _reply Protobuf message containing the response.
       ///   * _result Result of the service call. If false, there was
       ///   a problem executing your request.
-      /// \return true when the service call was succesfully requested.
+      /// \return true when the service call was successfully requested.
       public: template<typename RequestT, typename ReplyT>
       bool Request(
           const std::string &_topic,
@@ -539,7 +539,7 @@ namespace gz
       ///   * _reply Protobuf message containing the response.
       ///   * _result Result of the service call. If false, there was
       ///   a problem executing your request.
-      /// \return true when the service call was succesfully requested.
+      /// \return true when the service call was successfully requested.
       public: template<typename ReplyT>
       bool Request(
           const std::string &_topic,
@@ -555,7 +555,7 @@ namespace gz
       ///   * _reply Protobuf message containing the response.
       ///   * _result Result of the service call. If false, there was
       ///   a problem executing your request.
-      /// \return true when the service call was succesfully requested.
+      /// \return true when the service call was successfully requested.
       public: template<typename RequestT, typename ReplyT>
       bool Request(
           const std::string &_topic,
@@ -572,7 +572,7 @@ namespace gz
       ///   * _reply Protobuf message containing the response.
       ///   * _result Result of the service call. If false, there was
       ///   a problem executing your request.
-      /// \return true when the service call was succesfully requested.
+      /// \return true when the service call was successfully requested.
       public: template<typename ReplyT>
       bool Request(
           const std::string &_topic,
@@ -590,7 +590,7 @@ namespace gz
       ///   * _result Result of the service call. If false, there was
       ///   a problem executing your request.
       /// \param[in] _obj Instance containing the member function.
-      /// \return true when the service call was succesfully requested.
+      /// \return true when the service call was successfully requested.
       public: template<typename ClassT, typename RequestT, typename ReplyT>
       bool Request(
           const std::string &_topic,
@@ -608,7 +608,7 @@ namespace gz
       ///   * _result Result of the service call. If false, there was
       ///   a problem executing your request.
       /// \param[in] _obj Instance containing the member function.
-      /// \return true when the service call was succesfully requested.
+      /// \return true when the service call was successfully requested.
       public: template<typename ClassT, typename ReplyT>
       bool Request(
           const std::string &_topic,
@@ -651,7 +651,7 @@ namespace gz
       /// \param[in] _topic Topic requested.
       /// \param[in] _request Protobuf message containing the request's
       /// parameters.
-      /// \return true when the service call was succesfully requested.
+      /// \return true when the service call was successfully requested.
       public: template<typename RequestT>
       bool Request(const std::string &_topic, const RequestT &_request);
 

--- a/include/gz/transport/NodeShared.hh
+++ b/include/gz/transport/NodeShared.hh
@@ -301,7 +301,7 @@ namespace gz
       protected: NodeShared();
 
       /// \brief Destructor.
-      protected: virtual ~NodeShared();
+      public: virtual ~NodeShared();
 
       /// \brief Initialize all sockets.
       /// \return True when success or false otherwise. This function might

--- a/include/gz/transport/RepHandler.hh
+++ b/include/gz/transport/RepHandler.hh
@@ -252,7 +252,7 @@ namespace gz
       private: std::shared_ptr<Req> CreateMsg(const std::string &_data) const
       {
         // Instantiate a specific protobuf message
-        std::shared_ptr<Req> msgPtr(new Req());
+        auto msgPtr = std::make_shared<Req>();
 
         // Create the message using some serialized data
         if (!msgPtr->ParseFromString(_data))

--- a/include/gz/transport/ReqHandler.hh
+++ b/include/gz/transport/ReqHandler.hh
@@ -177,7 +177,7 @@ namespace gz
 
       /// \brief When there is a blocking service call request, the call can
       /// be unlocked when a service call REP is available. This variable
-      /// captures if we have found a node that can satisty our request.
+      /// captures if we have found a node that can satisfy our request.
       public: bool repAvailable;
     };
 
@@ -201,7 +201,7 @@ namespace gz
       public: std::shared_ptr<Rep> CreateMsg(const std::string &_data) const
       {
         // Instantiate a specific protobuf message
-        std::shared_ptr<Rep> msgPtr(new Rep());
+        auto msgPtr = std::make_shared<Rep>();
 
         // Create the message using some serialized data
         if (!msgPtr->ParseFromString(_data))
@@ -225,7 +225,7 @@ namespace gz
       }
 
       /// \brief Set the REQ protobuf message for this handler.
-      /// \param[in] _reqMsg Protofub message containing the input parameters of
+      /// \param[in] _reqMsg Protobuf message containing the input parameters of
       /// of the service request.
       public: void SetMessage(const Req *_reqMsg)
       {
@@ -241,7 +241,7 @@ namespace gz
       /// \brief This function is only used for compatibility with
       /// SetResponse() when [REP = google::protobuf::Message].
       /// It shouldn't do anything.
-      /// \param[in] _repMsg Protofub message containing the variable where
+      /// \param[in] _repMsg Protobuf message containing the variable where
       /// the result will be stored.
       public: void SetResponse(const Rep *_repMsg)
       {
@@ -319,7 +319,7 @@ namespace gz
       }
 
       /// \brief Set the REQ protobuf message for this handler.
-      /// \param[in] _reqMsg Protofub message containing the input parameters of
+      /// \param[in] _reqMsg Protobuf message containing the input parameters of
       /// of the service request.
       public: void SetMessage(const google::protobuf::Message *_reqMsg)
       {
@@ -334,7 +334,7 @@ namespace gz
       }
 
       /// \brief Set the REP protobuf message for this handler.
-      /// \param[in] _repMsg Protofub message containing the variable where
+      /// \param[in] _repMsg Protobuf message containing the variable where
       /// the result will be stored. The only purpose of this function is to
       /// store the type information of _repMsg.
       public: void SetResponse(const google::protobuf::Message *_repMsg)

--- a/include/gz/transport/TopicUtils.hh
+++ b/include/gz/transport/TopicUtils.hh
@@ -79,7 +79,7 @@ namespace gz
       /// \<TOPIC\>: The topic name. A trailing slash will always be removed.
       ///
       /// Note: Intuitively, you can imagine the fully qualified name as a
-      /// UNIX absolute path, where the partition is always sorrounded by "@".
+      /// UNIX absolute path, where the partition is always surrounded by "@".
       /// A namespace, if present, corresponds with the directories of the
       /// path, and you can imagine the topic as the filename.
       ///

--- a/include/gz/transport/TransportTypes.hh
+++ b/include/gz/transport/TransportTypes.hh
@@ -54,7 +54,7 @@ namespace gz
     /// \brief Map that stores all generic publishers.
     /// The keys are the process uuids of the nodes. For each uuid key, the
     /// value contains the list of publishers advertising the topic within the
-    /// same proccess uuid.
+    /// same process uuid.
     template<typename T>
     using Addresses_M = std::map<std::string, std::vector<T>>;
 
@@ -174,7 +174,7 @@ namespace gz
     /// \brief The string type used for generic messages.
     const std::string kGenericMessageType = "google.protobuf.Message";
 
-    /// \brief The high water mark of the recieve message buffer.
+    /// \brief The high water mark of the receive message buffer.
     /// \sa NodeShared::RcvHwm
     const int kDefaultRcvHwm = 1000;
 

--- a/log/include/gz/transport/log/Batch.hh
+++ b/log/include/gz/transport/log/Batch.hh
@@ -47,7 +47,7 @@ namespace gz
         /// \param[in] _old the instance being moved into this one
         public: Batch(Batch &&_old);  // NOLINT
 
-        /// \brief Move assignement operator
+        /// \brief Move assignment operator
         /// \param[in] _other the new Batch replacing the current one
         /// \return The updated Batch instance.
         public: Batch& operator=(Batch &&_other); // NOLINT

--- a/log/include/gz/transport/log/Message.hh
+++ b/log/include/gz/transport/log/Message.hh
@@ -44,7 +44,7 @@ namespace gz
 
         /// \brief Construct with data.
         /// \internal
-        /// Referrences and pointers are borrowed, and must be kept alive by
+        /// References and pointers are borrowed, and must be kept alive by
         /// the creator for as long as an instance lives.
         /// This constructor is public for the sake of unit testing, but is not
         /// expected to be called by a user.

--- a/log/include/gz/transport/log/MsgIter.hh
+++ b/log/include/gz/transport/log/MsgIter.hh
@@ -69,7 +69,7 @@ namespace gz
         /// \return false if the two iterator point to the same message
         public: bool operator!=(const MsgIter &_other) const;
 
-        /// \brief Move assignement operator
+        /// \brief Move assignment operator
         /// \param[in] _other the new iterator replacing the current one
         /// \return The updated MsgIter.
         public: MsgIter& operator=(MsgIter &&_other); // NOLINT

--- a/log/include/gz/transport/log/Playback.hh
+++ b/log/include/gz/transport/log/Playback.hh
@@ -79,7 +79,7 @@ namespace gz
         /// In most cases there should be no issue, but if you or a library you
         /// are using calls sqlite3_config(~) to change the threading mode to
         /// Single-thread or Multi-thread (instead of the default setting of
-        /// Seralized), then starting multiple simultaneous playbacks from the
+        /// Serialized), then starting multiple simultaneous playbacks from the
         /// same log file could be dangerous.
         ///
         /// \return A handle for managing the playback of the log. You must hold

--- a/log/include/gz/transport/log/QualifiedTime.hh
+++ b/log/include/gz/transport/log/QualifiedTime.hh
@@ -67,7 +67,7 @@ namespace gz
         /// std::chrono::seconds(value)
         /// std::chrono::milliseconds(value)
         /// std::chrono::minutes(value)
-        /// // ... ect ...
+        /// // ... etc ...
         /// \endcode
         ///
         /// into any function that accepts this Time type.

--- a/log/include/gz/transport/log/SqlStatement.hh
+++ b/log/include/gz/transport/log/SqlStatement.hh
@@ -124,7 +124,7 @@ namespace gz
         /// nullptr if it does not contain a REAL value.
         public: const double *QueryReal() const;
 
-        /// \brief Get the text value of this paramter.
+        /// \brief Get the text value of this parameter.
         /// \return A pointer to this parameter's text string, or a nullptr if
         /// it does not contain a text string.
         public: const std::string *QueryText() const;

--- a/log/src/BatchPrivate.hh
+++ b/log/src/BatchPrivate.hh
@@ -32,7 +32,7 @@ class gz::transport::log::BatchPrivate
 {
   /// \brief constructor
   /// \param[in] _db an open sqlite3 database handle wrapper
-  /// \param[in] _statements a list of statments to be executed to get messages
+  /// \param[in] _statements a list of statements to be executed to get messages
   public: explicit BatchPrivate(
       const std::shared_ptr<raii_sqlite3::Database> &_db,
       std::vector<SqlStatement> &&_statements);  // NOLINT(build/c++11)

--- a/log/src/Log.cc
+++ b/log/src/Log.cc
@@ -95,7 +95,7 @@ class gz::transport::log::Log::Implementation
   public: mutable log::Descriptor descriptor;
 
   /// \brief Name of the log file.
-  public: std::string filename = "";
+  public: std::string filename;
 
   /// \brief Time of the first message in the log file.
   public: std::chrono::nanoseconds startTime = std::chrono::nanoseconds(-1);
@@ -307,7 +307,7 @@ int64_t Log::Implementation::InsertOrGetTopicId(
   returnCode = sqlite3_step(topicStatement.Handle());
   if (returnCode != SQLITE_DONE)
   {
-    LERR("Faild to insert topic: " << returnCode << "\n");
+    LERR("Failed to insert topic: " << returnCode << "\n");
     return -1;
   }
 
@@ -544,7 +544,7 @@ bool Log::InsertMessage(
   if (SQLITE_OK != this->dataPtr->EndTransactionIfEnoughTimeHasPassed())
   {
     // Something is really busted if this happens
-    LERR("Failed to end transcation: "<< sqlite3_errmsg(
+    LERR("Failed to end transaction: "<< sqlite3_errmsg(
         this->dataPtr->db->Handle()) << "\n");
     return false;
   }

--- a/log/src/MsgIter.cc
+++ b/log/src/MsgIter.cc
@@ -69,7 +69,7 @@ bool MsgIterPrivate::PrepareNextStatement()
     return false;
   }
 
-  // Bind the parameters supplied with the statment
+  // Bind the parameters supplied with the statement
   int i = 1;
   int returnCode;
   for (const SqlParameter &param : query.parameters)

--- a/log/src/MsgIterPrivate.hh
+++ b/log/src/MsgIterPrivate.hh
@@ -56,7 +56,7 @@ inline namespace GZ_TRANSPORT_VERSION_NAMESPACE
     public: void StepStatement();
 
     /// \brief Prepares the next statement to be executed
-    /// \return true if the statement was sucessfully prepared
+    /// \return true if the statement was successfully prepared
     public: bool PrepareNextStatement();
 
     /// \brief a statement that is being stepped

--- a/log/src/Playback.cc
+++ b/log/src/Playback.cc
@@ -211,7 +211,7 @@ class PlaybackHandle::Implementation
   // \brief Time read from the next message to playback
   public: std::chrono::nanoseconds nextMessageTime;
 
-  // \brief Time at which ocurred the last event in the realtime frame
+  // \brief Time at which occurred the last event in the realtime frame
   public: std::chrono::nanoseconds lastEventTime;
 
   /// \brief A mutex to use when waiting for playback to be resumed

--- a/log/src/QualifiedTime.cc
+++ b/log/src/QualifiedTime.cc
@@ -78,7 +78,7 @@ class gz::transport::log::QualifiedTime::Implementation
   /// \internal \sa QualifiedTime::operator==()
   public: bool operator==(const Implementation &_other) const
   {
-    // We mimick the behavior of NaN equality comparisons, which always return
+    // We mimic the behavior of NaN equality comparisons, which always return
     // false during an equality comparison.
     if (_other.IsIndeterminate() || this->IsIndeterminate())
       return false;

--- a/log/src/Recorder.cc
+++ b/log/src/Recorder.cc
@@ -142,7 +142,7 @@ class gz::transport::log::Recorder::Implementation
   /// from topic callbacks.
   public: std::atomic<std::size_t> maxBufferSize{1000<<20};
 
-  /// \brief Current size of the buffer (in bytes). This is computed everytime
+  /// \brief Current size of the buffer (in bytes). This is computed every time
   /// data is added or removed from the queue. Because of that, we'll use
   /// `dataQueueMutex` to protect it.
   public: std::size_t bufferSize{0};

--- a/log/src/cmd/cmdlog.rb.in
+++ b/log/src/cmd/cmdlog.rb.in
@@ -70,7 +70,7 @@ SUBCOMMANDS = { 'record' =>
   "                             between topic advertisement and publishing.\n"\
   "                             Default: 1000 (1 second).\n"+
   "  -f                         Enable fast playback. This will publish    \n"\
-  "                             messages without waiting betweeen messages \n"\
+  "                             messages without waiting between messages  \n"\
   "                             according to the logged timestamps.        \n"\
   +
   COMMON_OPTIONS

--- a/parameters/src/result.cc
+++ b/parameters/src/result.cc
@@ -96,10 +96,10 @@ transport::parameters::operator<<(
       ss << "parameter operation unexpected error";
       break;
   }
-  if (ret.ParamName() != "") {
+  if (!ret.ParamName().empty()) {
     ss << ", parameter name [" << ret.ParamName() << "]";
   }
-  if (ret.ParamType() != "") {
+  if (!ret.ParamType().empty()) {
     ss << ", parameter type [" << ret.ParamType() << "]";
   }
   os << ss.str();

--- a/python/test/pubSub_TEST.py
+++ b/python/test/pubSub_TEST.py
@@ -49,8 +49,8 @@ class PubSubTEST(unittest.TestCase):
     def tearDown(self):
         del self.pub, self.pub_node
 
-    # Check that the publisher publishes a message of the appropiate type
-    # but doesn't publish when the message is not the appropiate type.
+    # Check that the publisher publishes a message of the appropriate type
+    # but doesn't publish when the message is not the appropriate type.
     def test_publish_msg(self):
         string_msg = StringMsg()
         string_msg.data = "Hello"

--- a/src/Discovery_TEST.cc
+++ b/src/Discovery_TEST.cc
@@ -239,7 +239,7 @@ TEST(DiscoveryTest, TestAdvertise)
   reset();
 
   // This should not trigger a discovery response on discovery2. They are in
-  // different proccesses and the scope is set to "Process".
+  // different processes and the scope is set to "Process".
   AdvertiseMessageOptions opts1;
   opts1.SetScope(Scope_t::PROCESS);
   MessagePublisher publisher2("/topic2", addr1, ctrl1, pUuid1, nUuid1,

--- a/src/MessageInfo.cc
+++ b/src/MessageInfo.cc
@@ -40,13 +40,13 @@ namespace gz
       public: virtual ~MessageInfoPrivate() = default;
 
       /// \brief Topic name.
-      public: std::string topic = "";
+      public: std::string topic;
 
       /// \brief Message type name.
-      public: std::string type = "";
+      public: std::string type;
 
       /// \brief Partition name.
-      public: std::string partition = "";
+      public: std::string partition;
 
       /// \brief Was the message sent via intra-process?
       public: bool isIntraProcess = false;

--- a/src/NodeOptions.cc
+++ b/src/NodeOptions.cc
@@ -110,7 +110,7 @@ bool NodeOptions::AddTopicRemap(const std::string &_fromTopic,
     }
   }
 
-  // Sanity check: Make sure that the orignal topic hasn't been remapped already
+  // Sanity check: Make sure that the original topic hasn't been remapped already
   if (this->dataPtr->topicsRemap.find(_fromTopic) !=
       this->dataPtr->topicsRemap.end())
   {

--- a/src/NodeOptionsPrivate.hh
+++ b/src/NodeOptionsPrivate.hh
@@ -42,7 +42,7 @@ namespace gz
       public: virtual ~NodeOptionsPrivate() = default;
 
       /// \brief Namespace for this node.
-      public: std::string ns = "";
+      public: std::string ns;
 
       /// \brief Partition for this node.
       public: std::string partition = hostname() + ":" + username();

--- a/src/NodePrivate.hh
+++ b/src/NodePrivate.hh
@@ -52,7 +52,7 @@ namespace gz
 
       /// \brief Helper function to remove handlers from the shared publish
       /// queue. This is called when the node unsubscribes to a topic
-      /// \param[in] _topic Topic that the node unsubcribed to.
+      /// \param[in] _topic Topic that the node unsubscribed to.
       /// \return True on success.
       public: bool RemoveHandlersFromPubQueue(const std::string &_topic);
 
@@ -73,7 +73,7 @@ namespace gz
       public: std::string partition = hostname() + ":" + username();
 
       /// \brief Default namespace for this node.
-      public: std::string ns = "";
+      public: std::string ns;
 
       /// \brief Custom options for this node.
       public: NodeOptions options;

--- a/src/Node_TEST.cc
+++ b/src/Node_TEST.cc
@@ -1752,7 +1752,7 @@ TEST(NodeTest, ServiceCallWithoutInputSyncTimeout)
 
 //////////////////////////////////////////////////
 /// \brief Create a publisher that sends messages "forever". This function will
-/// be used emiting a SIGINT or SIGTERM signal, to make sure that the transport
+/// be used emitting a SIGINT or SIGTERM signal, to make sure that the transport
 /// library captures the signals, stop all the tasks and signal the event with
 /// the method Interrupted().
 void createInfinitePublisher()

--- a/src/Publisher_TEST.cc
+++ b/src/Publisher_TEST.cc
@@ -56,7 +56,7 @@ static const std::string g_newReqTypeName = "RequestType2"; // NOLINT(*)
 static const std::string g_newRepTypeName = "ResponseType2"; // NOLINT(*)
 
 //////////////////////////////////////////////////
-/// \brief Initalize some global variables.
+/// \brief Initialize some global variables.
 void init()
 {
   g_opts1.SetScope(g_scope);
@@ -85,7 +85,7 @@ TEST(PublisherTest, Publisher)
   // Copy constructor.
   Publisher pub2(publisher);
 
-  // Asignment operator.
+  // Assignment operator.
   Publisher pub3 = pub2;
 
   // [In]Equality operators.

--- a/src/TopicStorage_TEST.cc
+++ b/src/TopicStorage_TEST.cc
@@ -382,7 +382,7 @@ TEST(TopicStorageTest, TopicStorageAPI)
   EXPECT_FALSE(test.HasTopic(g_topic1));
 
   // Insert some topics, and remove all the topics from a process but keeping
-  // the same topics from other proccesses.
+  // the same topics from other processes.
   Publisher publisher6(g_topic1, g_addr1, g_pUuid1, g_nUuid1, g_opts1);
   Publisher publisher7(g_topic1, g_addr1, g_pUuid1, g_nUuid2, g_opts2);
   Publisher publisher8(g_topic1, g_addr2, g_pUuid2, g_nUuid3, g_opts3);

--- a/src/cmd/gz.hh
+++ b/src/cmd/gz.hh
@@ -68,7 +68,7 @@ extern "C" void cmdServiceReq(const char *_service,
                               const char *_reqData);
 
 extern "C" {
-  /// \brief Enum used for specifing the message output format for functions
+  /// \brief Enum used for specifying the message output format for functions
   /// like cmdTopicEcho.
   enum class MsgOutputFormat {
     // Default. Currently, this is Protobuf's DebugString output format.

--- a/src/cmd/service_main.cc
+++ b/src/cmd/service_main.cc
@@ -40,16 +40,16 @@ struct ServiceOptions
   ServiceCommand command{ServiceCommand::kNone};
 
   /// \brief Name of the service
-  std::string service{""};
+  std::string service;
 
   /// \brief Data used with a service request
-  std::string reqData{""};
+  std::string reqData;
 
   /// \brief Request type to use when requesting
-  std::string reqType{""};
+  std::string reqType;
 
   /// \brief Response type to use when requesting
-  std::string repType{""};
+  std::string repType;
 
   /// \brief Timeout to use when requesting (in milliseconds)
   int timeout{1000};

--- a/src/cmd/topic_main.cc
+++ b/src/cmd/topic_main.cc
@@ -44,13 +44,13 @@ struct TopicOptions
   TopicCommand command{TopicCommand::kNone};
 
   /// \brief Name of the topic
-  std::string topic{""};
+  std::string topic;
 
   /// \brief Message type to use when publishing
-  std::string msgType{""};
+  std::string msgType;
 
   /// \brief Message data to use when publishing
-  std::string msgData{""};
+  std::string msgData;
 
   /// \brief Amount of time to echo (in seconds)
   double duration{-1};

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,7 +13,7 @@ target_compile_definitions(test_config INTERFACE
 # Location of the "gz" command
   "GZ_EXE=\"${HAVE_GZ_TOOLS}\""
   "TRANSPORT_BASH_COMPLETION_SH=\"${PROJECT_SOURCE_DIR}/src/cmd/transport.bash_completion.sh\""
-# Auxillary executables for test
+# Auxiliary executables for test
   "AUTH_PUB_SUB_SUBSCRIBER_INVALID_EXE=\"$<TARGET_FILE:authPubSubSubscriberInvalid_aux>\""
   "FAST_PUB_EXE=\"$<TARGET_FILE:fastPub_aux>\""
   "PUB_EXE=\"$<TARGET_FILE:pub_aux>\""

--- a/test/integration/test_executables/authPubSubSubscriberInvalid_aux.cc
+++ b/test/integration/test_executables/authPubSubSubscriberInvalid_aux.cc
@@ -42,7 +42,7 @@ static bool cbExecuted;
 static std::string g_topic = "/foo"; // NOLINT(*)
 
 //////////////////////////////////////////////////
-/// \brief Function is called everytime a topic update is received.
+/// \brief Function is called every time a topic update is received.
 void cb(const msgs::Int32 &/*_msg*/)
 {
   std::cerr << "CALLBACK\n";

--- a/test/integration/test_executables/scopedTopicSubscriber_aux.cc
+++ b/test/integration/test_executables/scopedTopicSubscriber_aux.cc
@@ -33,7 +33,7 @@ static std::string g_topic = "/foo"; // NOLINT(*)
 static int data = 5;
 
 //////////////////////////////////////////////////
-/// \brief Function is called everytime a topic update is received.
+/// \brief Function is called every time a topic update is received.
 void cb(const msgs::Int32 &_msg)
 {
   EXPECT_EQ(_msg.data(), data);

--- a/test/integration/test_executables/twoProcsPubSubSubscriber_aux.cc
+++ b/test/integration/test_executables/twoProcsPubSubSubscriber_aux.cc
@@ -37,7 +37,7 @@ static std::string g_topic = "/foo"; // NOLINT(*)
 static std::string data = "bar"; // NOLINT(*)
 
 //////////////////////////////////////////////////
-/// \brief Function is called everytime a topic update is received.
+/// \brief Function is called every time a topic update is received.
 void cb(const msgs::Vector3d &_msg)
 {
   EXPECT_DOUBLE_EQ(_msg.x(), 1.0);
@@ -64,7 +64,7 @@ void cbRaw(const char *_msgData, const size_t _size,
 }
 
 //////////////////////////////////////////////////
-/// \brief Function is called everytime a topic update is received.
+/// \brief Function is called every time a topic update is received.
 void cb2(const msgs::Vector3d &_msg)
 {
   EXPECT_DOUBLE_EQ(_msg.x(), 1.0);

--- a/test/integration/twoProcsSrvCallWithoutOutput.cc
+++ b/test/integration/twoProcsSrvCallWithoutOutput.cc
@@ -83,7 +83,7 @@ void reset()
 }
 
 //////////////////////////////////////////////////
-/// \brief This test spawns a service that doesn't wait for ouput parameters.
+/// \brief This test spawns a service that doesn't wait for output parameters.
 /// The requester uses a wrong type for the request argument. The test should
 /// verify that the service call does not succeed.
 TEST_F(twoProcSrvCallWithoutOutput, SrvRequestWrongReq)

--- a/tutorials/06_python_support.md
+++ b/tutorials/06_python_support.md
@@ -178,11 +178,11 @@ and go directly to the next section. Otherwise, if you built the package from
 source it is needed to update the PYTHONPATH in order for Python to recognize 
 the library by doing the following:
 
-1. If you builded from source using `colcon`:
+1. If you built from source using `colcon`:
 ```{.sh}
 export PYTHONPATH=$PYTHONPATH:<path to ws>/install/lib/python
 ```
-2. If you builded from source using `cmake`:
+2. If you built from source using `cmake`:
 ```{.sh}
 export PYTHONPATH=$PYTHONPATH:<path_install_prefix>/lib/python
 ```
@@ -251,7 +251,7 @@ recommend to always use threading locks when working with object that are used
 in several places (publisher and subscribers). 
 
 We developed a couple of examples that demonstrate this particular issue. Take
-a look at a publisher and subscriber (whithin the same node) that have race
+a look at a publisher and subscriber (within the same node) that have race
 conditions triggered in the [data_race_without_mutex.py](https://github.com/gazebosim/gz-transport/blob/gz-transport14/python/examples/data_race_without_mutex.py) file. The proposed solution to this
 issue is to use the `threading` library, you can see the same example with a mutex
 in the [data_race_with_mutex.py](https://github.com/gazebosim/gz-transport/blob/gz-transport14/python/examples/data_race_with_mutex.py) file.

--- a/tutorials/07_security.md
+++ b/tutorials/07_security.md
@@ -5,8 +5,8 @@ Previous Tutorial: \ref python
 
 ## Overview
 
-Gazebo Transport's default mode of communication is unsecure, which means
-no authentication or encryption is used. Unsecure communication is the
+Gazebo Transport's default mode of communication is insecure, which means
+no authentication or encryption is used. Insecure communication is the
 default because it is simple to implement and use, supports introspection,
 and reduces third-party development effort.
 
@@ -51,7 +51,7 @@ password. Also, every subscriber will only connect to secure publishers.
 > set GZ_PARTITION=test
 > ```
 
-First, let's test unsecure communication. This example requires
+First, let's test insecure communication. This example requires
 [gz-tools](https://github.com/gazebosim/gz-tools).
 
 1. Open a terminal, and echo topic `/foo`.
@@ -60,14 +60,14 @@ gz topic -t /foo -e
 ```
 2. Open a second terminal and publish a message on topic `/foo`.
 ```
-gz topic -t /foo -m gz.msgs.StringMsg -p 'data:"Unsecure message"'
+gz topic -t /foo -m gz.msgs.StringMsg -p 'data:"Insecure message"'
 ```
 3. The first terminal should see the following output.
 ```
-data: "Unsecure message"
+data: "Insecure message"
 ```
 
-Now let's try a secure publisher and an unsecure subscriber.
+Now let's try a secure publisher and an insecure subscriber.
 
 1. Leave the first terminal running `gz topic -t /foo -e`.
 2. Setup authentication in the second terminal:
@@ -113,7 +113,7 @@ gz topic -t /foo -m gz.msgs.StringMsg -p 'data:"Secure message"'
 ```
 data: "Secure message"
 ```
-5. The unsecure subscriber in the first terminal should not change.
+5. The insecure subscriber in the first terminal should not change.
 
 ## Encryption
 

--- a/tutorials/20_env_variables.md
+++ b/tutorials/20_env_variables.md
@@ -5,7 +5,7 @@ Previous Tutorial: \ref logging
 
 ## Overview
 
-Similar to how you can programatically customize the behavior of your
+Similar to how you can programmatically customize the behavior of your
 nodes or specify some options when you advertise a topic, it is possible to
 use an environment variable to tweak the behavior of Gazebo Transport.
 Below are descriptions of the available environment variables:
@@ -40,7 +40,7 @@ Below are descriptions of the available environment variables:
     user launching the node.
     * *Description*: Specifies a partition name for all the nodes declared
     inside this process. Note that an alternative partition name  declared
-    programatically and  passed to the constructor of a Node class will take
+    programmatically and  passed to the constructor of a Node class will take
     priority over *GZ_PARTITION*.
 * **GZ_RELAY**
     * *Value allowed*: Colon delimited list of IP addresses


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #<NUMBER>

## Summary
 * Valgrind detected a memory leak in `src/NodeShared.cc`, inside `Instance` function. It's a (quite suspicious) singleton function, which store a `NodeShared` object as a raw pointer in a static variable(uno.._map). Not sure why pid is used as a a key for it. Even if application shutdown will destroy all resources, extra warnings makes additional noise in investigation in other parts of product
 * Done minor c++-fication of code
 * Fixed various typos

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.