### PR TITLE
Remove subscribers after publisher ends

### DIFF
--- a/src/Node.cc
+++ b/src/Node.cc
@@ -643,11 +643,8 @@ bool Node::Unsubscribe(const std::string &_topic)
 
   // Notify to the publishers that I am no longer interested in the topic.
   MsgAddresses_M addresses;
-  if (!this->dataPtr->shared->dataPtr->msgDiscovery->Publishers(
-        fullyQualifiedTopic, addresses))
-  {
-    return false;
-  }
+  this->dataPtr->shared->dataPtr->msgDiscovery->Publishers(
+    fullyQualifiedTopic, addresses);
 
   for (auto &proc : addresses)
   {
@@ -658,6 +655,12 @@ bool Node::Unsubscribe(const std::string &_topic)
 
     this->Shared()->dataPtr->msgDiscovery->Unregister(pub);
   }
+
+  MessagePublisher pub(fullyQualifiedTopic, this->dataPtr->shared->myAddress,
+    "", this->dataPtr->shared->pUuid, this->dataPtr->nUuid,
+    kGenericMessageType, AdvertiseMessageOptions());
+
+  this->Shared()->dataPtr->msgDiscovery->Unregister(pub);
 
   return true;
 }

--- a/src/NodeShared.cc
+++ b/src/NodeShared.cc
@@ -1286,7 +1286,7 @@ void NodeShared::OnNewSrvDisconnection(const ServicePublisher &_pub)
 void NodeShared::OnNewRegistration(const MessagePublisher &_pub)
 {
   // Discard the message if the destination PUUID is not me.
-  if (!_pub.Ctrl().empty() && _pub.Ctrl() != this->pUuid)
+  if (_pub.Ctrl() != this->pUuid)
     return;
 
   std::string procUuid = _pub.PUuid();
@@ -1308,7 +1308,7 @@ void NodeShared::OnNewRegistration(const MessagePublisher &_pub)
 void NodeShared::OnEndRegistration(const MessagePublisher &_pub)
 {
   // Discard the message if the destination PUUID is not me.
-  if (_pub.Ctrl() != this->pUuid)
+  if (!_pub.Ctrl().empty() && _pub.Ctrl() != this->pUuid)
     return;
 
   std::string topic = _pub.Topic();

--- a/src/NodeShared.cc
+++ b/src/NodeShared.cc
@@ -1286,7 +1286,7 @@ void NodeShared::OnNewSrvDisconnection(const ServicePublisher &_pub)
 void NodeShared::OnNewRegistration(const MessagePublisher &_pub)
 {
   // Discard the message if the destination PUUID is not me.
-  if (_pub.Ctrl() != this->pUuid)
+  if (!_pub.Ctrl().empty() && _pub.Ctrl() != this->pUuid)
     return;
 
   std::string procUuid = _pub.PUuid();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,6 +20,7 @@ target_compile_definitions(test_config INTERFACE
   "PUB_THROTTLED_EXE=\"$<TARGET_FILE:pub_aux_throttled>\""
   "SCOPED_TOPIC_SUBSCRIBER_EXE=\"$<TARGET_FILE:scopedTopicSubscriber_aux>\""
   "TWO_PROCS_PUBLISHER_EXE=\"$<TARGET_FILE:twoProcsPublisher_aux>\""
+  "TWO_PROCS_PUB_SUB_SINGLE_SUBSCRIBER_EXE=\"$<TARGET_FILE:twoProcsPubSubSingleSubscriber_aux>\""
   "TWO_PROCS_PUB_SUB_SUBSCRIBER_EXE=\"$<TARGET_FILE:twoProcsPubSubSubscriber_aux>\""
   "TWO_PROCS_SRV_CALL_REPLIER_EXE=\"$<TARGET_FILE:twoProcsSrvCallReplier_aux>\""
   "TWO_PROCS_SRV_CALL_REPLIER_INC_EXE=\"$<TARGET_FILE:twoProcsSrvCallReplierInc_aux>\""

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -35,6 +35,7 @@ set(auxiliary_files
   pub_aux_throttled
   scopedTopicSubscriber_aux
   twoProcsPublisher_aux
+  twoProcsPubSubSingleSubscriber_aux
   twoProcsPubSubSubscriber_aux
   twoProcsSrvCallReplier_aux
   twoProcsSrvCallReplierInc_aux

--- a/test/integration/test_executables/twoProcsPubSubSingleSubscriber_aux.cc
+++ b/test/integration/test_executables/twoProcsPubSubSingleSubscriber_aux.cc
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2025 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#include <gz/msgs/vector3d.pb.h>
+
+#include <chrono>
+#include <string>
+
+#include "gz/transport/Node.hh"
+
+#include <gz/utils/Environment.hh>
+
+#include "gtest/gtest.h"
+#include "test_config.hh"
+
+using namespace gz;
+
+static bool cbExecuted;
+static bool cbRawExecuted;
+static std::string g_topic = "/foo"; // NOLINT(*)
+
+//////////////////////////////////////////////////
+/// \brief Function is called every time a topic update is received.
+void cb(const msgs::Vector3d &_msg)
+{
+  EXPECT_DOUBLE_EQ(_msg.x(), 1.0);
+  EXPECT_DOUBLE_EQ(_msg.y(), 2.0);
+  EXPECT_DOUBLE_EQ(_msg.z(), 3.0);
+  cbExecuted = true;
+}
+
+//////////////////////////////////////////////////
+void cbRaw(const char *_msgData, const size_t _size,
+           const transport::MessageInfo &_info)
+{
+  msgs::Vector3d v;
+
+  EXPECT_TRUE(v.GetTypeName() == _info.Type());
+
+  EXPECT_TRUE(v.ParseFromArray(_msgData, _size));
+
+  EXPECT_DOUBLE_EQ(v.x(), 1.0);
+  EXPECT_DOUBLE_EQ(v.y(), 2.0);
+  EXPECT_DOUBLE_EQ(v.z(), 3.0);
+
+  cbRawExecuted = true;
+}
+
+//////////////////////////////////////////////////
+void runSubscriber()
+{
+  cbExecuted = false;
+  cbRawExecuted = false;
+
+  transport::Node node;
+
+  // Add one normal subscription to `node`
+  EXPECT_TRUE(node.Subscribe(g_topic, cb));
+
+  // Add a raw subscription to `node`
+//  EXPECT_TRUE(node.SubscribeRaw(g_topic, cbRaw,
+//                                msgs::Vector3d().GetTypeName()));
+
+  int interval = 100;
+
+  // Wait until we've received at least one message.
+  // while (!cbExecuted || !cb2Executed || !cbRawExecuted)
+  while (!cbExecuted)
+  {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    interval--;
+
+    if (interval == 0)
+      break;
+  }
+
+  EXPECT_TRUE(node.Unsubscribe(g_topic));
+//  std::this_thread::sleep_for(std::chrono::milliseconds(2000));
+
+  // Check that the message was received.
+  EXPECT_TRUE(cbExecuted);
+  EXPECT_TRUE(cbRawExecuted);
+}
+
+//////////////////////////////////////////////////
+TEST(twoProcPubSub, PubSubTwoProcsTwoNodesSingleSubscriber)
+{
+  runSubscriber();
+}
+
+//////////////////////////////////////////////////
+int main(int argc, char **argv)
+{
+  if (argc != 2)
+  {
+    std::cerr << "Partition name has not be passed as argument" << std::endl;
+    return -1;
+  }
+
+  // Set the partition name for this test.
+  gz::utils::setenv("GZ_PARTITION", argv[1]);
+  gz::utils::setenv("GZ_TRANSPORT_TOPIC_STATISTICS", "1");
+
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/integration/test_executables/twoProcsPubSubSingleSubscriber_aux.cc
+++ b/test/integration/test_executables/twoProcsPubSubSingleSubscriber_aux.cc
@@ -71,14 +71,13 @@ void runSubscriber()
   EXPECT_TRUE(node.Subscribe(g_topic, cb));
 
   // Add a raw subscription to `node`
-//  EXPECT_TRUE(node.SubscribeRaw(g_topic, cbRaw,
-//                                msgs::Vector3d().GetTypeName()));
+  EXPECT_TRUE(node.SubscribeRaw(g_topic, cbRaw,
+                                msgs::Vector3d().GetTypeName()));
 
   int interval = 100;
 
   // Wait until we've received at least one message.
-  // while (!cbExecuted || !cb2Executed || !cbRawExecuted)
-  while (!cbExecuted)
+  while (!cbExecuted || !cbRawExecuted)
   {
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
     interval--;
@@ -88,7 +87,6 @@ void runSubscriber()
   }
 
   EXPECT_TRUE(node.Unsubscribe(g_topic));
-//  std::this_thread::sleep_for(std::chrono::milliseconds(2000));
 
   // Check that the message was received.
   EXPECT_TRUE(cbExecuted);

--- a/test/integration/twoProcsPubSub.cc
+++ b/test/integration/twoProcsPubSub.cc
@@ -476,7 +476,7 @@ TEST(twoProcPubSub, TopicInfo)
 /// \brief Two different nodes running in two different processes. The
 /// publisher in the main process here publishes a message to the
 /// remote subscriber in the other process before immediately going
-/// out of scope. The subcriber in the other process then unsubscribes to
+/// out of scope. The subscriber in the other process then unsubscribes to
 /// the topic. The test verifies that the publisher node in the main process
 /// is able to correctly remove its remote subscribers in the case that the
 /// publisher is destroyed before the subscriber so that HasConnections()

--- a/test/integration/twoProcsPubSub.cc
+++ b/test/integration/twoProcsPubSub.cc
@@ -498,7 +498,6 @@ TEST(twoProcPubSub, PubSubTwoProcsScopedPub)
 
       // No subscribers yet right after pub comes up because it takes time for
       // it to discover subscribers on the network
-      // from subscribers
       EXPECT_FALSE(pub.HasConnections());
 
       std::this_thread::sleep_for(std::chrono::milliseconds(100));

--- a/test/integration/twoProcsPubSub.cc
+++ b/test/integration/twoProcsPubSub.cc
@@ -473,10 +473,14 @@ TEST(twoProcPubSub, TopicInfo)
 }
 
 //////////////////////////////////////////////////
-/// \brief Three different nodes running in two different processes. In the
-/// subscriber process there are two nodes. Both should receive the message.
-/// After some time one of them unsubscribe. After that check that only one
-/// node receives the message.
+/// \brief Two different nodes running in two different processes. The
+/// publisher in the main process here publishes a message to the
+/// remote subscriber in the other process before immediately going
+/// out of scope. The subcriber in the other process then unsubscribes to
+/// the topic. The test verifies that the publisher node in the main process
+/// is able to correctly remove its remote subscribers in the case that the
+/// publisher is destroyed before the subscriber so that HasConnections()
+/// check returns the correct result.
 TEST(twoProcPubSub, PubSubTwoProcsScopedPub)
 {
   transport::Node node;

--- a/test/test_config.hh.in
+++ b/test/test_config.hh.in
@@ -55,6 +55,10 @@ constexpr const char * kScopedTopicSubscriber = SCOPED_TOPIC_SUBSCRIBER_EXE;
 constexpr const char * kTwoProcsPublisher = TWO_PROCS_PUBLISHER_EXE;
 #endif  // TWO_PROCS_PUBLISHER_EXE
 
+#ifdef TWO_PROCS_PUB_SUB_SINGLE_SUBSCRIBER_EXE
+constexpr const char * kTwoProcsPubSubSingleSubscriber = TWO_PROCS_PUB_SUB_SINGLE_SUBSCRIBER_EXE;
+#endif  // TWO_PROCS_PUB_SUB_SINGLE_SUBSCRIBER_EXE
+
 #ifdef TWO_PROCS_PUB_SUB_SUBSCRIBER_EXE
 constexpr const char * kTwoProcsPubSubSubscriber = TWO_PROCS_PUB_SUB_SUBSCRIBER_EXE;
 #endif  // TWO_PROCS_PUB_SUB_SUBSCRIBER_EXE


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-transport/issues/586

## Summary

The bug happens because the publisher is no longer available when the subscriber unsubscribes. No message is then sent to the publisher node for it to remove the remote subscribers.

The fix:  If the publisher is not available when a subscriber unsubscribes, a message with empty publisher proc address is now sent to all nodes on the network, which forces the publisher nodes to check and remove the remote subscriber if it exists.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

