### PR TITLE
Set GZ_IP=127.0.0.1 in tests needing network

### DIFF
--- a/log/test/integration/CMakeLists.txt
+++ b/log/test/integration/CMakeLists.txt
@@ -32,8 +32,11 @@ if (UNIX AND NOT APPLE)
 endif()
 
 foreach(test_target ${logging_tests})
+  set(_env_vars)
+  list(APPEND _env_vars "GZ_IP=127.0.0.1")
+  list(APPEND _env_vars "GZ_TRANSPORT_LOG_SQL_PATH=${PROJECT_SOURCE_DIR}/log/sql")
   set_tests_properties(${test_target} PROPERTIES
-    ENVIRONMENT GZ_TRANSPORT_LOG_SQL_PATH=${PROJECT_SOURCE_DIR}/log/sql)
+    ENVIRONMENT "${_env_vars}")
   target_compile_definitions(${test_target}
     PRIVATE GZ_TRANSPORT_LOG_SQL_PATH="${PROJECT_SOURCE_DIR}/log/sql")
 endforeach()

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -75,6 +75,7 @@ if (BUILD_TESTING AND NOT WIN32)
     endif()
     set(_env_vars)
     list(APPEND _env_vars "CMAKE_BINARY_DIR=${CMAKE_BINARY_DIR}/bin")
+    list(APPEND _env_vars "GZ_IP=127.0.0.1")
     list(APPEND _env_vars "PYTHONPATH=${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/python/:${CMAKE_BINARY_DIR}/lib:$ENV{PYTHONPATH}")
     list(APPEND _env_vars "LD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}:$ENV{LD_LIBRARY_PATH}")
     set_tests_properties(${test}.py PROPERTIES

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,7 +34,10 @@ gz_build_tests(TYPE UNIT SOURCES ${gtest_sources}
   LIB_DEPS ${EXTRA_TEST_LIB_DEPS} test_config)
 
 foreach(test ${test_list})
-  set_property(TEST ${test} PROPERTY ENVIRONMENT "GZ_VERBOSE=1")
+  set(_env_vars)
+  list(APPEND _env_vars "GZ_IP=127.0.0.1")
+  list(APPEND _env_vars "GZ_VERBOSE=1")
+  set_property(TEST ${test} PROPERTY ENVIRONMENT "${_env_vars}")
 endforeach()
 
 if(MSVC)

--- a/src/cmd/CMakeLists.txt
+++ b/src/cmd/CMakeLists.txt
@@ -61,11 +61,16 @@ endforeach()
 
 if (TARGET UNIT_gz_TEST)
 
+  set(_env_vars)
+  list(APPEND _env_vars "GZ_IP=127.0.0.1")
+  list(APPEND _env_vars
+      "GZ_CONFIG_PATH=${CMAKE_BINARY_DIR}/test/conf/$<CONFIG>;LD_LIBRARY_PATH=\"$<TARGET_FILE_DIR:${PROJECT_LIBRARY_TARGET_NAME}>\":$ENV{LD_LIBRARY_PATH}"
+  )
   set_tests_properties(
     UNIT_gz_TEST
     PROPERTIES
     ENVIRONMENT
-      "GZ_CONFIG_PATH=${CMAKE_BINARY_DIR}/test/conf/$<CONFIG>;LD_LIBRARY_PATH=\"$<TARGET_FILE_DIR:${PROJECT_LIBRARY_TARGET_NAME}>\":$ENV{LD_LIBRARY_PATH}"
+      "${_env_vars}"
   )
 endif()
 

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -28,6 +28,12 @@ gz_build_tests(TYPE INTEGRATION SOURCES ${tests}
   TEST_LIST test_list
   LIB_DEPS ${EXTRA_TEST_LIB_DEPS} test_config)
 
+foreach(test ${test_list})
+  set(_env_vars)
+  list(APPEND _env_vars "GZ_IP=127.0.0.1")
+  set_property(TEST ${test} PROPERTY ENVIRONMENT "${_env_vars}")
+endforeach()
+
 set(auxiliary_files
   authPubSubSubscriberInvalid_aux
   fastPub_aux


### PR DESCRIPTION
# 🦟 Bug fix

Fixes recent test failures on homebrew

## Summary

Firewall settings can cause test failures, so set `GZ_IP` explicitly to make tests more hermetic.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
