### PR TITLE
Zenoh - Part1: Find Zenoh and define HAVE_ZENOH when found

### DIFF
--- a/.github/ci/before_cmake.sh
+++ b/.github/ci/before_cmake.sh
@@ -1,0 +1,2 @@
+# Set ROS_DISTRO. This is needed for finding zenoh packages vendored by ROS 2
+export ROS_DISTRO="jazzy"

--- a/.github/ci/packages-noble.apt
+++ b/.github/ci/packages-noble.apt
@@ -1,1 +1,2 @@
 cppzmq-dev
+ros-jazzy-zenoh-cpp-vendor

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,12 +108,27 @@ gz_find_package(CPPZMQ REQUIRED PRIVATE
 
 ########################################
 # Find Zenoh
-find_package(zenohc)
-find_package(zenohcxx)
-if (NOT zenohcxx_DIR)
+
+find_package(zenohc QUIET)
+find_package(zenohcxx QUIET)
+
+# If both zenohc and zenohcpp packages are not found then
+# look for these pacakages installed by ROS 2 zenoh_cpp_vendor package
+if (NOT zenohc_FOUND AND NOT zenohcxx_FOUND)
+  # Set CMAKE_PREFIX_PATH in order to find ROS 2 packages from plain cmake
+  # package, see https://github.com/ament/ament_cmake/issues/304
+  set(ros2_zenoh_cmake_path "/opt/ros/$ENV{ROS_DISTRO}/opt/zenoh_cpp_vendor/lib/cmake")
+  if (EXISTS ${ros2_zenoh_cmake_path})
+    list(PREPEND CMAKE_PREFIX_PATH ${ros2_zenoh_cmake_path})
+    find_package(zenohc QUIET)
+    find_package(zenohcxx QUIET)
+  endif()
+endif ()
+
+if (NOT zenohcxx_FOUND)
   message (STATUS "Looking for zenohcxx - not found")
   set (HAVE_ZENOH OFF CACHE BOOL "HAVE ZENOH" FORCE)
-elseif (NOT zenohc_DIR)
+elseif (NOT zenohc_FOUND)
   message (STATUS "Looking for zenohc - not found")
   set (HAVE_ZENOH OFF CACHE BOOL "HAVE ZENOH" FORCE)
 else ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,22 @@ gz_find_package(CPPZMQ REQUIRED PRIVATE
   PKGCONFIG_IGNORE # NOTE: cppzmq does not seem to offer a pkg-config file
   PRETTY CppZMQ)
 
+########################################
+# Find Zenoh
+find_package(zenohc REQUIRED)
+find_package(zenohcxx REQUIRED)
+if (NOT zenohcxx_DIR)
+  message (STATUS "Looking for zenohcxx - not found")
+  set (HAVE_ZENOH OFF CACHE BOOL "HAVE ZENOH" FORCE)
+elseif (NOT zenohc_DIR)
+  message (STATUS "Looking for zenohc - not found")
+  set (HAVE_ZENOH OFF CACHE BOOL "HAVE ZENOH" FORCE)
+else ()
+  message (STATUS "Looking for zenohcxx and zenohc - found")
+  set (HAVE_ZENOH ON CACHE BOOL "HAVE ZENOH" FORCE)
+  list(APPEND EXTRA_TEST_LIB_DEPS "zenohcxx::zenohc")
+endif ()
+
 #--------------------------------------
 # Find uuid
 if (MSVC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,8 +108,8 @@ gz_find_package(CPPZMQ REQUIRED PRIVATE
 
 ########################################
 # Find Zenoh
-find_package(zenohc REQUIRED)
-find_package(zenohcxx REQUIRED)
+find_package(zenohc)
+find_package(zenohcxx)
 if (NOT zenohcxx_DIR)
   message (STATUS "Looking for zenohcxx - not found")
   set (HAVE_ZENOH OFF CACHE BOOL "HAVE ZENOH" FORCE)

--- a/include/gz/transport/Node.hh
+++ b/include/gz/transport/Node.hh
@@ -26,6 +26,10 @@
 #include <unordered_set>
 #include <vector>
 
+#ifdef HAVE_ZENOH
+#include <zenoh.hxx>
+#endif
+
 #include "gz/transport/AdvertiseOptions.hh"
 #include "gz/transport/config.hh"
 #include "gz/transport/Export.hh"

--- a/include/gz/transport/config.hh.in
+++ b/include/gz/transport/config.hh.in
@@ -34,5 +34,6 @@
 
 #cmakedefine HAVE_IFADDRS 1
 #cmakedefine UBUNTU_FOCAL 1
+#cmakedefine HAVE_ZENOH 1
 
 #endif

--- a/log/src/CMakeLists.txt
+++ b/log/src/CMakeLists.txt
@@ -6,6 +6,11 @@ gz_add_component(log SOURCES ${sources} GET_TARGET_NAME log_lib_target)
 target_link_libraries(${log_lib_target}
   PRIVATE SQLite3::SQLite3)
 
+if (HAVE_ZENOH)
+  target_link_libraries(${log_lib_target}
+    PRIVATE zenohcxx::zenohc)
+endif()
+
 if (MSVC)
   # Warning #4251 is the "dll-interface" warning that tells you when types used
   # by a class are not being exported. These generated source files have private

--- a/log/test/integration/CMakeLists.txt
+++ b/log/test/integration/CMakeLists.txt
@@ -3,11 +3,17 @@
 
 add_library(ChirpParams STATIC ./ChirpParams.cc)
 target_link_libraries(ChirpParams PUBLIC ${PROJECT_LIBRARY_TARGET_NAME}-log ${EXTRA_TEST_LIB_DEPS})
+if (HAVE_ZENOH)
+  target_link_libraries(ChirpParams PUBLIC zenohcxx::zenohc)
+endif()
 target_compile_definitions(ChirpParams
   PRIVATE TOPIC_CHIRP_EXE="$<TARGET_FILE:topicChirp_aux>")
 
 gz_add_executable(topicChirp_aux topicChirp_aux.cc)
 target_link_libraries(topicChirp_aux ChirpParams)
+if (HAVE_ZENOH)
+  target_link_libraries(topicChirp_aux zenohcxx::zenohc)
+endif()
 
 gz_build_tests(
   TYPE "INTEGRATION"

--- a/parameters/src/CMakeLists.txt
+++ b/parameters/src/CMakeLists.txt
@@ -10,6 +10,11 @@ target_link_libraries(${param_lib_target}
   PUBLIC
     gz-utils${GZ_UTILS_VER}::gz-utils${GZ_UTILS_VER})
 
+if (HAVE_ZENOH)
+target_link_libraries(${param_lib_target}
+  PUBLIC zenohcxx::zenohc)
+endif()
+
 # Unit tests
 gz_build_tests(
   TYPE "UNIT"

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -39,6 +39,12 @@ target_link_libraries(${BINDINGS_MODULE_NAME} PRIVATE
   ${PROJECT_LIBRARY_TARGET_NAME}
 )
 
+if (HAVE_ZENOH)
+  target_link_libraries(${BINDINGS_MODULE_NAME} PRIVATE
+    zenohcxx::zenohc
+  )
+endif()
+
 target_compile_definitions(${BINDINGS_MODULE_NAME} PRIVATE
   BINDINGS_MODULE_NAME=${BINDINGS_MODULE_NAME})
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,6 +15,13 @@ target_link_libraries(${PROJECT_LIBRARY_TARGET_NAME}
     ${ZeroMQ_TARGET}
 )
 
+if (HAVE_ZENOH)
+  target_link_libraries(${PROJECT_LIBRARY_TARGET_NAME}
+    PRIVATE
+      zenohcxx::zenohc
+  )
+endif()
+
 target_include_directories(${PROJECT_LIBRARY_TARGET_NAME}
   SYSTEM PUBLIC
     $<TARGET_PROPERTY:protobuf::libprotobuf,INTERFACE_INCLUDE_DIRECTORIES>

--- a/src/cmd/CMakeLists.txt
+++ b/src/cmd/CMakeLists.txt
@@ -18,6 +18,12 @@ target_link_libraries(gz
   ${PROJECT_LIBRARY_TARGET_NAME}
 )
 
+if (HAVE_ZENOH)
+  target_link_libraries(gz
+    zenohcxx::zenohc
+  )
+endif()
+
 # Build topic CLI executable
 set(topic_executable gz-transport-topic)
 add_executable(${topic_executable} topic_main.cc)
@@ -26,6 +32,11 @@ target_link_libraries(${topic_executable}
   gz-utils${GZ_UTILS_VER}::cli
   ${PROJECT_LIBRARY_TARGET_NAME}
 )
+if (HAVE_ZENOH)
+  target_link_libraries(${topic_executable}
+    zenohcxx::zenohc
+  )
+endif()
 install(TARGETS ${topic_executable} DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/gz/${GZ_DESIGNATION}${PROJECT_VERSION_MAJOR}/)
 
 # Build service CLI executable
@@ -36,6 +47,11 @@ target_link_libraries(${service_executable}
   gz-utils${GZ_UTILS_VER}::cli
   ${PROJECT_LIBRARY_TARGET_NAME}
 )
+if (HAVE_ZENOH)
+  target_link_libraries(${service_executable}
+    zenohcxx::zenohc
+  )
+endif()
 install(TARGETS ${service_executable} DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/gz/${GZ_DESIGNATION}${PROJECT_VERSION_MAJOR}/)
 
 # Build the unit tests.

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -63,4 +63,11 @@ foreach(AUX_EXECUTABLE ${auxiliary_files})
       ${EXTRA_TEST_LIB_DEPS}
       test_config
   )
+
+  if (HAVE_ZENOH)
+    target_link_libraries(${AUX_EXECUTABLE}
+      PRIVATE
+        zenohcxx::zenohc
+    )
+  endif()
 endforeach(AUX_EXECUTABLE)


### PR DESCRIPTION
# 🎉 New feature

This patch should define `HAVE_ZENOH` if the zenoh dependencies are found at compile time.

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.