### PR TITLE
Support cmake 4.0

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,3 +1,5 @@
+cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
+
 # Detect if we are doing a standalone build of the bindings, using an external gz-transport
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   cmake_minimum_required(VERSION 3.22.1)


### PR DESCRIPTION
# 🦟 Bug fix

Fixes build errors with cmake 4.0

## Summary

The cmake version in homebrew-core was recently upgraded to 4.0, which now requires `cmake_minimum_required` to be set (see [policy CMP0000](https://cmake.org/cmake/help/latest/policy/CMP0000.html)). We currently support building python bindings separately from the core library by invoking cmake directly on `python/CMakeLists.txt`, so add support for cmake 4.0 by adding a `cmake_minimum_required` statement to `python/CMakeLists.txt`.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
