### PR TITLE
Remove duplicate cmake_minimum_required

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -2,7 +2,6 @@ cmake_minimum_required(VERSION 3.22.1 FATAL_ERROR)
 
 # Detect if we are doing a standalone build of the bindings, using an external gz-transport
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
-  cmake_minimum_required(VERSION 3.22.1)
   find_package(gz-cmake4 4.1.0 REQUIRED)
   gz_get_package_xml_version(${CMAKE_SOURCE_DIR}/../package.xml PACKAGE_XML)
   project(gz-transport${PACKAGE_XML_VERSION_MAJOR}-python VERSION ${PACKAGE_XML_VERSION})


### PR DESCRIPTION
# 🦟 Bug fix

Simplifies the cmake code

## Summary

Since adding the `cmake_minimum_required` statement to the top of `python/CMakeLists.txt` in #603, we can remove the duplicate statement a few lines after. I would have removed it in #603, but didn't notice it.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
