### PR TITLE
Cast nanoseconds to int64_t

### DIFF
--- a/log/src/QueryOptions.cc
+++ b/log/src/QueryOptions.cc
@@ -113,7 +113,8 @@ class TimeRangeOption::Implementation
     if (!startCompare.empty())
     {
       sql.statement += "time_recv " + startCompare + " ?";
-      sql.parameters.emplace_back(static_cast<int64_t>(start.GetTime()->count()));
+      sql.parameters.emplace_back(static_cast<int64_t>(
+          start.GetTime()->count()));
 
       if (!finishCompare.empty())
         sql.statement += " AND ";
@@ -122,7 +123,8 @@ class TimeRangeOption::Implementation
     if (!finishCompare.empty())
     {
       sql.statement += "time_recv " + finishCompare + " ?";
-      sql.parameters.emplace_back(static_cast<int64_t>(finish.GetTime()->count()));
+      sql.parameters.emplace_back(static_cast<int64_t>(
+          finish.GetTime()->count()));
     }
 
     return sql;

--- a/log/src/QueryOptions.cc
+++ b/log/src/QueryOptions.cc
@@ -113,7 +113,7 @@ class TimeRangeOption::Implementation
     if (!startCompare.empty())
     {
       sql.statement += "time_recv " + startCompare + " ?";
-      sql.parameters.emplace_back(start.GetTime()->count());
+      sql.parameters.emplace_back(static_cast<int64_t>(start.GetTime()->count()));
 
       if (!finishCompare.empty())
         sql.statement += " AND ";
@@ -122,7 +122,7 @@ class TimeRangeOption::Implementation
     if (!finishCompare.empty())
     {
       sql.statement += "time_recv " + finishCompare + " ?";
-      sql.parameters.emplace_back(finish.GetTime()->count());
+      sql.parameters.emplace_back(static_cast<int64_t>(finish.GetTime()->count()));
     }
 
     return sql;


### PR DESCRIPTION
# 🦟 Bug fix

When `GetTime()->count()` doesn't return `int64_t`, unambiguously select `SqlParameter(int64_t _integer)`.
Fixes a build error with 64 bit android (clang).

(The choice is between int64_t and double. The input is an integer, typically an int64_t.)

## Summary

The following problem was discovered for x64 and arm64 android while reviewing the vcpkg port:

~~~
/android-ndk-r27c/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/c++/v1/__memory/allocator.h:165:24: error: call to constructor of 'gz::transport::log::SqlParameter' is ambiguous
  165 |     ::new ((void*)__p) _Up(std::forward<_Args>(__args)...);
      |                        ^   ~~~~~~~~~~~~~~~~~~~~~~~~~~~
/android-ndk-r27c/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/c++/v1/__memory/allocator_traits.h:296:9: note: in instantiation of function template specialization 'std::allocator<gz::transport::log::SqlParameter>::construct<gz::transport::log::SqlParameter, long long>' requested here
  296 |     __a.construct(__p, std::forward<_Args>(__args)...);
      |         ^
/android-ndk-r27c/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/c++/v1/vector:902:21: note: in instantiation of function template specialization 'std::allocator_traits<std::allocator<gz::transport::log::SqlParameter>>::construct<gz::transport::log::SqlParameter, long long, void>' requested here
  902 |     __alloc_traits::construct(this->__alloc(), std::__to_address(__tx.__pos_), std::forward<_Args>(__args)...);
      |                     ^
/android-ndk-r27c/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/c++/v1/vector:1508:5: note: in instantiation of function template specialization 'std::vector<gz::transport::log::SqlParameter>::__construct_one_at_end<long long>' requested here
 1508 |     __construct_one_at_end(std::forward<_Args>(__args)...);
      |     ^
/vcpkg/buildtrees/gz-transport/src/t14_14.0.0-6c9c5b9bdc.clean/log/src/QueryOptions.cc:116:22: note: in instantiation of function template specialization 'std::vector<gz::transport::log::SqlParameter>::emplace_back<long long>' requested here
  116 |       sql.parameters.emplace_back(start.GetTime()->count());
      |                      ^
/vcpkg/buildtrees/gz-transport/src/t14_14.0.0-6c9c5b9bdc.clean/log/include/gz/transport/log/SqlStatement.hh:67:26: note: candidate constructor
   67 |         public: explicit SqlParameter(int64_t _integer);
      |                          ^
/vcpkg/buildtrees/gz-transport/src/t14_14.0.0-6c9c5b9bdc.clean/log/include/gz/transport/log/SqlStatement.hh:72:26: note: candidate constructor
   72 |         public: explicit SqlParameter(double _real);
      |                          ^
1 error generated.
~~~

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
