### PR TITLE
Find zenoh_cpp_vendor package from ROS 2

### DIFF
--- a/.github/ci/before_cmake.sh
+++ b/.github/ci/before_cmake.sh
@@ -1,0 +1,1 @@
+source /opt/ros/jazzy/setup.bash

--- a/.github/ci/before_cmake.sh
+++ b/.github/ci/before_cmake.sh
@@ -1,7 +1,2 @@
-#!/bin/sh -l
-
-set -x
-
-ROS_DISTRO="jazzy"
-export LD_LIBRARY_PATH="/opt/ros/${ROS_DISTRO}/opt/zenoh_cpp_vendor/lib:$LD_LIBRARY_PATH"
-export CMAKE_PREFIX_PATH="/opt/ros/${ROS_DISTRO}/opt/zenoh_cpp_vendor/lib/cmake:$CMAKE_PREFIX_PATH"
+# Set ROS_DISTRO. This is needed for finding zenoh packages vendored by ROS 2
+export ROS_DISTRO="jazzy"

--- a/.github/ci/before_cmake.sh
+++ b/.github/ci/before_cmake.sh
@@ -1,1 +1,7 @@
-source /opt/ros/jazzy/setup.bash
+#!/bin/sh -l
+
+set -x
+
+ROS_DISTRO="jazzy"
+export LD_LIBRARY_PATH="/opt/ros/${ROS_DISTRO}/opt/zenoh_cpp_vendor/lib:$LD_LIBRARY_PATH"
+export CMAKE_PREFIX_PATH="/opt/ros/${ROS_DISTRO}/opt/zenoh_cpp_vendor/lib/cmake:$CMAKE_PREFIX_PATH"

--- a/.github/ci/packages-noble.apt
+++ b/.github/ci/packages-noble.apt
@@ -1,1 +1,2 @@
 cppzmq-dev
+ros-jazzy-zenoh-cpp-vendor

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,9 +113,16 @@ find_package(zenohc QUIET)
 find_package(zenohcxx QUIET)
 
 # If both zenohc and zenohcpp packages are not found then
-# look for zenoh_cpp_vendor from ROS 2
+# look for these pacakages installed by ROS 2 zenoh_cpp_vendor package
 if (NOT zenohc_FOUND AND NOT zenohcxx_FOUND)
-  find_package(zenoh_cpp_vendor)
+  # Set CMAKE_PREFIX_PATH in order to find ROS 2 packages from plain cmake
+  # package, see https://github.com/ament/ament_cmake/issues/304
+  set(ros2_zenoh_cmake_path "/opt/ros/$ENV{ROS_DISTRO}/opt/zenoh_cpp_vendor/lib/cmake")
+  if (EXISTS ${ros2_zenoh_cmake_path})
+    list(PREPEND CMAKE_PREFIX_PATH ${ros2_zenoh_cmake_path})
+    find_package(zenohc QUIET)
+    find_package(zenohcxx QUIET)
+  endif()
 endif ()
 
 if (NOT zenohcxx_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,12 +108,20 @@ gz_find_package(CPPZMQ REQUIRED PRIVATE
 
 ########################################
 # Find Zenoh
-find_package(zenohc)
-find_package(zenohcxx)
-if (NOT zenohcxx_DIR)
+
+find_package(zenohc QUIET)
+find_package(zenohcxx QUIET)
+
+# If both zenohc and zenohcpp packages are not found then
+# look for zenoh_cpp_vendor from ROS 2
+if (NOT zenohc_FOUND AND NOT zenohcxx_FOUND)
+  find_package(zenoh_cpp_vendor)
+endif ()
+
+if (NOT zenohcxx_FOUND)
   message (STATUS "Looking for zenohcxx - not found")
   set (HAVE_ZENOH OFF CACHE BOOL "HAVE ZENOH" FORCE)
-elseif (NOT zenohc_DIR)
+elseif (NOT zenohc_FOUND)
   message (STATUS "Looking for zenohc - not found")
   set (HAVE_ZENOH OFF CACHE BOOL "HAVE ZENOH" FORCE)
 else ()


### PR DESCRIPTION
# 🎉 New feature

Related PR:
* https://github.com/gazebo-tooling/gzdev/pull/96
* https://github.com/gazebo-tooling/release-tools/pull/1311

## Summary

If upstream zenohc and zenohcpp packages are not found, try look for zenoh_cpp_vendor packages from the ros2 repo

## Test it

Tested with `ros-rolling-zenoh-cpp-vendor` package on noble and gz-transport is able to find zenohc and zenohcxx with this package.



## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
