### PR TITLE
Disable Jammy CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,4 +23,3 @@ jobs:
           cppcheck-enabled: true
           cpplint-enabled: true
           doxygen-enabled: true
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,20 +9,6 @@ on:
       - 'main'
 
 jobs:
-  jammy-ci:
-    runs-on: ubuntu-latest
-    name: Ubuntu Jammy CI
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Compile and test
-        id: ci
-        uses: gazebo-tooling/action-gz-ci@jammy
-        with:
-          codecov-enabled: true
-          cppcheck-enabled: true
-          cpplint-enabled: true
-          doxygen-enabled: true
   noble-ci:
     runs-on: ubuntu-latest
     name: Ubuntu Noble CI
@@ -32,3 +18,9 @@ jobs:
       - name: Compile and test
         id: ci
         uses: gazebo-tooling/action-gz-ci@noble
+        with:
+          # codecov-enabled: true
+          cppcheck-enabled: true
+          cpplint-enabled: true
+          doxygen-enabled: true
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
       - 'ign-transport[0-9]?'
       - 'gz-transport[0-9]?'
       - 'main'
+      - 'iche033/rm_jammy_ci'
 
 jobs:
   noble-ci:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,6 @@ on:
       - 'ign-transport[0-9]?'
       - 'gz-transport[0-9]?'
       - 'main'
-      - 'iche033/rm_jammy_ci'
 
 jobs:
   noble-ci:

--- a/log/include/gz/transport/log/MsgIter.hh
+++ b/log/include/gz/transport/log/MsgIter.hh
@@ -50,10 +50,13 @@ namespace gz
         /// \brief Destructor;
         public: ~MsgIter();
 
+
+        /// \cond
         /// \brief Copy-assignment operator
         /// \param[in] _orig the instance being copied
         /// \return a reference to this instance
         // public: MsgIter &operator=(const MsgIter &_orig);
+        /// \endcond
 
         /// \brief Prefix increment
         /// \return a reference to this instance

--- a/log/include/gz/transport/log/MsgIter.hh
+++ b/log/include/gz/transport/log/MsgIter.hh
@@ -50,7 +50,6 @@ namespace gz
         /// \brief Destructor;
         public: ~MsgIter();
 
-
         /// \cond
         /// \brief Copy-assignment operator
         /// \param[in] _orig the instance being copied


### PR DESCRIPTION

# 🦟 Bug fix

## Summary

Jetty on Jammy is not officially supported 

Made a small doxygen fix for CI to pass on noble

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

