### PR TITLE
Backport Node::CreateSubscriber API

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -6,31 +6,6 @@ Deprecated code produces compile-time warnings. These warning serve as
 notification to users that their code should be upgraded. The next major
 release will remove the deprecated code.
 
-## Gazebo Transport 14.X to 15.X
-
-### Breaking Changes
-
-1. All variants of the `bool Node::Subscribe` functions are combined into
-   one `bool Subscribe(Args && ...args)` function that forwards arguments to
-   various `Node::SubscribeImpl` private helper functions. All existing
-   `Node::Subscribe` calls should continue to work without code changes.
-   One exception is when the subscribe callback function is an overloaded
-   function, e.g.
-   ```cpp
-   void cb(const msgs::StringMsg_V &_msg);
-   void cb(const msgs::StringMsg_V &_res, const bool _result);
-   ...
-   bool res = node.Subscribe(topic, cb);
-   ```
-   This will now result in a compile error. The fix is to use unique callback
-   function names, eg.
-   ```cpp
-   void topicCb(const msgs::StringMsg_V &_msg);
-   void serviceCb(const msgs::StringMsg_V &_res, const bool _result);
-   ...
-   bool res = node.Subscribe(topic, topicCb);
-   ```
-
 ## Gazebo Transport 11.X to 12.X
 
 ### Deprecated

--- a/Migration.md
+++ b/Migration.md
@@ -6,6 +6,31 @@ Deprecated code produces compile-time warnings. These warning serve as
 notification to users that their code should be upgraded. The next major
 release will remove the deprecated code.
 
+## Gazebo Transport 14.X to 15.X
+
+### Breaking Changes
+
+1. All variants of the `bool Node::Subscribe` functions are combined into
+   one `bool Subscribe(Args && ...args)` function that forwards arguments to
+   various `Node::SubscribeImpl` private helper functions. All existing
+   `Node::Subscribe` calls should continue to work without code changes.
+   One exception is when the subscribe callback function is an overloaded
+   function, e.g.
+   ```cpp
+   void cb(const msgs::StringMsg_V &_msg);
+   void cb(const msgs::StringMsg_V &_res, const bool _result);
+   ...
+   bool res = node.Subscribe(topic, cb);
+   ```
+   This will now result in a compile error. The fix is to use unique callback
+   function names, eg.
+   ```cpp
+   void topicCb(const msgs::StringMsg_V &_msg);
+   void serviceCb(const msgs::StringMsg_V &_res, const bool _result);
+   ...
+   bool res = node.Subscribe(topic, topicCb);
+   ```
+
 ## Gazebo Transport 11.X to 12.X
 
 ### Deprecated

--- a/include/gz/transport/Node.hh
+++ b/include/gz/transport/Node.hh
@@ -307,21 +307,101 @@ namespace gz
       public: std::vector<std::string> AdvertisedTopics() const;
 
       /// \brief Subscribe to a topic registering a callback.
-      /// This is function is overloaded with different variants of callback
-      /// functions.
-      /// Supported function callbacks are:
-      ///   * free function
-      ///   * member function
-      ///   * lambda function
-      /// The callback function can contain one (_msg) or both (_msg, _info) of
-      /// the following parameters:
+      /// Note that this callback does not include any message information.
+      /// In this version the callback is a free function.
+      /// \param[in] _topic Topic to be subscribed.
+      /// \param[in] _callback Pointer to the callback function with the
+      /// following parameters:
+      ///   * _msg Protobuf message containing a new topic update.
+      /// \param[in] _opts Subscription options.
+      /// \return true when successfully subscribed or false otherwise.
+      public: template<typename MessageT>
+      bool Subscribe(
+          const std::string &_topic,
+          void(*_callback)(const MessageT &_msg),
+          const SubscribeOptions &_opts = SubscribeOptions());
+
+      /// \brief Subscribe to a topic registering a callback.
+      /// Note that this callback does not include any message information.
+      /// In this version the callback is a lambda function.
+      /// \param[in] _topic Topic to be subscribed.
+      /// \param[in] _callback Lambda function with the following parameters:
+      ///   * _msg Protobuf message containing a new topic update.
+      /// \param[in] _opts Subscription options.
+      /// \return true when successfully subscribed or false otherwise.
+      public: template<typename MessageT>
+      bool Subscribe(
+          const std::string &_topic,
+          std::function<void(const MessageT &_msg)> _callback,
+          const SubscribeOptions &_opts = SubscribeOptions());
+
+      /// \brief Subscribe to a topic registering a callback.
+      /// Note that this callback does not include any message information.
+      /// In this version the callback is a member function.
+      /// \param[in] _topic Topic to be subscribed.
+      /// \param[in] _callback Pointer to the callback function with the
+      /// following parameters:
+      ///   * _msg Protobuf message containing a new topic update.
+      /// \param[in] _obj Instance containing the member function.
+      /// \param[in] _opts Subscription options.
+      /// \return true when successfully subscribed or false otherwise.
+      public: template<typename ClassT, typename MessageT>
+      bool Subscribe(
+          const std::string &_topic,
+          void(ClassT::*_callback)(const MessageT &_msg),
+          ClassT *_obj,
+          const SubscribeOptions &_opts = SubscribeOptions());
+
+      /// \brief Subscribe to a topic registering a callback.
+      /// Note that this callback includes message information.
+      /// In this version the callback is a free function.
+      /// \param[in] _topic Topic to be subscribed.
+      /// \param[in] _callback Pointer to the callback function with the
+      /// following parameters:
       ///   * _msg Protobuf message containing a new topic update.
       ///   * _info Message information (e.g.: topic name).
-      /// \param[in] args Arguments to be forwarded to SubscribeImpl
+      /// \param[in] _opts Subscription options.
       /// \return true when successfully subscribed or false otherwise.
-      /// \sa SubscribeImpl
-      public: template <typename ...Args>
-      bool Subscribe(Args && ...args);
+      public: template<typename MessageT>
+      bool Subscribe(
+          const std::string &_topic,
+          void(*_callback)(const MessageT &_msg, const MessageInfo &_info),
+          const SubscribeOptions &_opts = SubscribeOptions());
+
+      /// \brief Subscribe to a topic registering a callback.
+      /// Note that this callback includes message information.
+      /// In this version the callback is a lambda function.
+      /// \param[in] _topic Topic to be subscribed.
+      /// \param[in] _callback Lambda function with the following parameters:
+      ///   * _msg Protobuf message containing a new topic update.
+      ///   * _info Message information (e.g.: topic name).
+      /// \param[in] _opts Subscription options.
+      /// \return true when successfully subscribed or false otherwise.
+      public: template<typename MessageT>
+      bool Subscribe(
+          const std::string &_topic,
+          std::function<void(const MessageT &_msg,
+                             const MessageInfo &_info)> _callback,
+          const SubscribeOptions &_opts = SubscribeOptions());
+
+      /// \brief Subscribe to a topic registering a callback.
+      /// Note that this callback includes message information.
+      /// In this version the callback is a member function.
+      /// \param[in] _topic Topic to be subscribed.
+      /// \param[in] _callback Pointer to the callback function with the
+      /// following parameters:
+      ///   * _msg Protobuf message containing a new topic update.
+      ///   * _info Message information (e.g.: topic name).
+      /// \param[in] _obj Instance containing the member function.
+      /// \param[in] _opts Subscription options.
+      /// \return true when successfully subscribed or false otherwise.
+      public: template<typename ClassT, typename MessageT>
+      bool Subscribe(
+          const std::string &_topic,
+          void(ClassT::*_callback)(const MessageT &_msg,
+                                   const MessageInfo &_info),
+          ClassT *_obj,
+          const SubscribeOptions &_opts = SubscribeOptions());
 
       /// \brief Create a subscriber to a topic registering a callback
       /// This is function is overloaded with different variants of callback

--- a/include/gz/transport/Node.hh
+++ b/include/gz/transport/Node.hh
@@ -86,6 +86,7 @@ namespace gz
     class GZ_TRANSPORT_VISIBLE Node
     {
       class PublisherPrivate;
+      class SubscriberPrivate;
 
       /// \brief A class that is used to store information about an
       /// advertised publisher. An instance of this class is returned
@@ -198,6 +199,71 @@ namespace gz
 #endif
       };
 
+      /// \brief A class that is used to store information about an
+      /// subscriber. An instance of this class is returned
+      /// from Node::CreateSubscribe. When the object is destroyed,
+      /// the corresponding subscription handler is removed from the node.
+      ///
+      /// ## Pseudo code example ##
+      ///
+      ///    std::function<void(const msgs::Int32 &)> cb =
+      ///      [](const msgs::Int32 &)
+      ///    {
+      ///      // Do something
+      ///    };
+      ///    Node::Subscriber sub = myNode.CreateSubscriber("topic_name", cb);
+      public: class GZ_TRANSPORT_VISIBLE Subscriber
+      {
+        /// \brief Default constructor.
+        public: Subscriber();
+
+        /// \brief Constructor
+        /// \param[in] _topic Subscribed topic name
+        /// \param[in] _nUuid Node to which this subscriber belongs
+        /// \param[in] _nOpts Node options for the node
+        /// \param[in] _hUuid Subscriber's handler UUID
+        public: Subscriber(const std::string &_topic,
+                           const std::string &_nUuid,
+                           const NodeOptions &_nOpts,
+                           const std::string &_hUuid);
+
+        /// \brief Destructor.
+        /// Unsubscribe to the topic and remove the subcription handler
+        public: virtual ~Subscriber();
+
+        /// \brief Unsubscribe from the topic.
+        /// \return True if the topic was successfully unsubscribed
+        public: bool Unsubscribe();
+
+        /// \brief Allows this class to be evaluated as a boolean.
+        /// \return True if valid
+        /// \sa Valid
+        public: operator bool();
+
+        /// \brief Allows this class to be evaluated as a boolean (const).
+        /// \return True if valid
+        /// \sa Valid
+        public: operator bool() const;
+
+        /// \brief Return true if valid information, such as a non-empty
+        /// topic name, node and handler UUIDs.
+        /// \return True if this object has a valid subscription.
+        public: bool Valid() const;
+
+        /// \internal
+        /// \brief Smart pointer to private data.
+#ifdef _WIN32
+// Disable warning C4251 which is triggered by
+// std::shared_ptr
+#pragma warning(push)
+#pragma warning(disable: 4251)
+#endif
+        private: std::shared_ptr<SubscriberPrivate> dataPtr;
+#ifdef _WIN32
+#pragma warning(pop)
+#endif
+      };
+
       public: Node();
 
       /// \brief Constructor.
@@ -241,101 +307,44 @@ namespace gz
       public: std::vector<std::string> AdvertisedTopics() const;
 
       /// \brief Subscribe to a topic registering a callback.
-      /// Note that this callback does not include any message information.
-      /// In this version the callback is a free function.
-      /// \param[in] _topic Topic to be subscribed.
-      /// \param[in] _callback Pointer to the callback function with the
-      /// following parameters:
-      ///   * _msg Protobuf message containing a new topic update.
-      /// \param[in] _opts Subscription options.
-      /// \return true when successfully subscribed or false otherwise.
-      public: template<typename MessageT>
-      bool Subscribe(
-          const std::string &_topic,
-          void(*_callback)(const MessageT &_msg),
-          const SubscribeOptions &_opts = SubscribeOptions());
-
-      /// \brief Subscribe to a topic registering a callback.
-      /// Note that this callback does not include any message information.
-      /// In this version the callback is a lambda function.
-      /// \param[in] _topic Topic to be subscribed.
-      /// \param[in] _callback Lambda function with the following parameters:
-      ///   * _msg Protobuf message containing a new topic update.
-      /// \param[in] _opts Subscription options.
-      /// \return true when successfully subscribed or false otherwise.
-      public: template<typename MessageT>
-      bool Subscribe(
-          const std::string &_topic,
-          std::function<void(const MessageT &_msg)> _callback,
-          const SubscribeOptions &_opts = SubscribeOptions());
-
-      /// \brief Subscribe to a topic registering a callback.
-      /// Note that this callback does not include any message information.
-      /// In this version the callback is a member function.
-      /// \param[in] _topic Topic to be subscribed.
-      /// \param[in] _callback Pointer to the callback function with the
-      /// following parameters:
-      ///   * _msg Protobuf message containing a new topic update.
-      /// \param[in] _obj Instance containing the member function.
-      /// \param[in] _opts Subscription options.
-      /// \return true when successfully subscribed or false otherwise.
-      public: template<typename ClassT, typename MessageT>
-      bool Subscribe(
-          const std::string &_topic,
-          void(ClassT::*_callback)(const MessageT &_msg),
-          ClassT *_obj,
-          const SubscribeOptions &_opts = SubscribeOptions());
-
-      /// \brief Subscribe to a topic registering a callback.
-      /// Note that this callback includes message information.
-      /// In this version the callback is a free function.
-      /// \param[in] _topic Topic to be subscribed.
-      /// \param[in] _callback Pointer to the callback function with the
-      /// following parameters:
+      /// This is function is overloaded with different variants of callback
+      /// functions.
+      /// Supported function callbacks are:
+      ///   * free function
+      ///   * member function
+      ///   * lambda function
+      /// The callback function can contain one (_msg) or both (_msg, _info) of
+      /// the following parameters:
       ///   * _msg Protobuf message containing a new topic update.
       ///   * _info Message information (e.g.: topic name).
-      /// \param[in] _opts Subscription options.
+      /// \param[in] args Arguments to be forwarded to SubscribeImpl
       /// \return true when successfully subscribed or false otherwise.
-      public: template<typename MessageT>
-      bool Subscribe(
-          const std::string &_topic,
-          void(*_callback)(const MessageT &_msg, const MessageInfo &_info),
-          const SubscribeOptions &_opts = SubscribeOptions());
+      /// \sa SubscribeImpl
+      public: template <typename ...Args>
+      bool Subscribe(Args && ...args);
 
-      /// \brief Subscribe to a topic registering a callback.
-      /// Note that this callback includes message information.
-      /// In this version the callback is a lambda function.
-      /// \param[in] _topic Topic to be subscribed.
-      /// \param[in] _callback Lambda function with the following parameters:
+      /// \brief Create a subscriber to a topic registering a callback
+      /// This is function is overloaded with different variants of callback
+      /// functions. It returns a Node::Subscriber object that maintains the
+      /// subscription while the object is alive. When the subscriber object
+      /// goes out of scope, it automatically unsubscribes to the topic,
+      /// removing just one single subscription handler from the node that it
+      /// belongs to.
+      /// Supported function callbacks are:
+      ///   * free function
+      ///   * member function
+      ///   * lambda function
+      /// The callback function can contain one (_msg) or both (_msg, _info) of
+      /// the following parameters:
       ///   * _msg Protobuf message containing a new topic update.
       ///   * _info Message information (e.g.: topic name).
-      /// \param[in] _opts Subscription options.
-      /// \return true when successfully subscribed or false otherwise.
-      public: template<typename MessageT>
-      bool Subscribe(
-          const std::string &_topic,
-          std::function<void(const MessageT &_msg,
-                             const MessageInfo &_info)> _callback,
-          const SubscribeOptions &_opts = SubscribeOptions());
-
-      /// \brief Subscribe to a topic registering a callback.
-      /// Note that this callback includes message information.
-      /// In this version the callback is a member function.
       /// \param[in] _topic Topic to be subscribed.
-      /// \param[in] _callback Pointer to the callback function with the
-      /// following parameters:
-      ///   * _msg Protobuf message containing a new topic update.
-      ///   * _info Message information (e.g.: topic name).
-      /// \param[in] _obj Instance containing the member function.
-      /// \param[in] _opts Subscription options.
+      /// \param[in] args Arguments to be forwarded to SubscribeImpl
       /// \return true when successfully subscribed or false otherwise.
-      public: template<typename ClassT, typename MessageT>
-      bool Subscribe(
-          const std::string &_topic,
-          void(ClassT::*_callback)(const MessageT &_msg,
-                                   const MessageInfo &_info),
-          ClassT *_obj,
-          const SubscribeOptions &_opts = SubscribeOptions());
+      /// \sa SubscribeImpl
+      public: template <typename ...Args>
+      Node::Subscriber CreateSubscriber(const std::string &_topic,
+                                        Args && ...args);
 
       /// \brief Get the list of topics subscribed by this node. Note that
       /// we might be interested in one topic but we still don't know the
@@ -796,6 +805,103 @@ namespace gz
       /// \param[in] _fullyQualifiedTopic Fully qualified topic name
       /// \return True on success.
       private: bool SubscribeHelper(const std::string &_fullyQualifiedTopic);
+
+      /// \brief Subscribe to a topic registering a callback.
+      /// Note that this callback does not include any message information.
+      /// In this version the callback is a free function.
+      /// \param[in] _topic Topic to be subscribed.
+      /// \param[in] _callback Pointer to the callback function with the
+      /// following parameters:
+      ///   * _msg Protobuf message containing a new topic update.
+      /// \param[in] _opts Subscription options.
+      /// \return true when successfully subscribed or false otherwise.
+      private: template<typename MessageT>
+      std::shared_ptr<SubscriptionHandler<MessageT>> SubscribeImpl(
+          const std::string &_topic,
+          void(*_callback)(const MessageT &_msg),
+          const SubscribeOptions &_opts = SubscribeOptions());
+
+      /// \brief Subscribe to a topic registering a callback.
+      /// Note that this callback does not include any message information.
+      /// In this version the callback is a lambda function.
+      /// \param[in] _topic Topic to be subscribed.
+      /// \param[in] _callback Lambda function with the following parameters:
+      ///   * _msg Protobuf message containing a new topic update.
+      /// \param[in] _opts Subscription options.
+      /// \return true when successfully subscribed or false otherwise.
+      private: template<typename MessageT>
+      std::shared_ptr<SubscriptionHandler<MessageT>> SubscribeImpl(
+          const std::string &_topic,
+          std::function<void(const MessageT &_msg)> _callback,
+          const SubscribeOptions &_opts = SubscribeOptions());
+
+      /// \brief Subscribe to a topic registering a callback.
+      /// Note that this callback does not include any message information.
+      /// In this version the callback is a member function.
+      /// \param[in] _topic Topic to be subscribed.
+      /// \param[in] _callback Pointer to the callback function with the
+      /// following parameters:
+      ///   * _msg Protobuf message containing a new topic update.
+      /// \param[in] _obj Instance containing the member function.
+      /// \param[in] _opts Subscription options.
+      /// \return true when successfully subscribed or false otherwise.
+      private: template<typename ClassT, typename MessageT>
+      std::shared_ptr<SubscriptionHandler<MessageT>> SubscribeImpl(
+          const std::string &_topic,
+          void(ClassT::*_callback)(const MessageT &_msg),
+          ClassT *_obj,
+          const SubscribeOptions &_opts = SubscribeOptions());
+
+      /// \brief Subscribe to a topic registering a callback.
+      /// Note that this callback includes message information.
+      /// In this version the callback is a free function.
+      /// \param[in] _topic Topic to be subscribed.
+      /// \param[in] _callback Pointer to the callback function with the
+      /// following parameters:
+      ///   * _msg Protobuf message containing a new topic update.
+      ///   * _info Message information (e.g.: topic name).
+      /// \param[in] _opts Subscription options.
+      /// \return true when successfully subscribed or false otherwise.
+      private: template<typename MessageT>
+      std::shared_ptr<SubscriptionHandler<MessageT>> SubscribeImpl(
+          const std::string &_topic,
+          void(*_callback)(const MessageT &_msg, const MessageInfo &_info),
+          const SubscribeOptions &_opts = SubscribeOptions());
+
+      /// \brief Subscribe to a topic registering a callback.
+      /// Note that this callback includes message information.
+      /// In this version the callback is a lambda function.
+      /// \param[in] _topic Topic to be subscribed.
+      /// \param[in] _callback Lambda function with the following parameters:
+      ///   * _msg Protobuf message containing a new topic update.
+      ///   * _info Message information (e.g.: topic name).
+      /// \param[in] _opts Subscription options.
+      /// \return true when successfully subscribed or false otherwise.
+      private: template<typename MessageT>
+      std::shared_ptr<SubscriptionHandler<MessageT>> SubscribeImpl(
+          const std::string &_topic,
+          std::function<void(const MessageT &_msg,
+                             const MessageInfo &_info)> _callback,
+          const SubscribeOptions &_opts = SubscribeOptions());
+
+      /// \brief Subscribe to a topic registering a callback.
+      /// Note that this callback includes message information.
+      /// In this version the callback is a member function.
+      /// \param[in] _topic Topic to be subscribed.
+      /// \param[in] _callback Pointer to the callback function with the
+      /// following parameters:
+      ///   * _msg Protobuf message containing a new topic update.
+      ///   * _info Message information (e.g.: topic name).
+      /// \param[in] _obj Instance containing the member function.
+      /// \param[in] _opts Subscription options.
+      /// \return true when successfully subscribed or false otherwise.
+      private: template<typename ClassT, typename MessageT>
+      std::shared_ptr<SubscriptionHandler<MessageT>> SubscribeImpl(
+          const std::string &_topic,
+          void(ClassT::*_callback)(const MessageT &_msg,
+                                   const MessageInfo &_info),
+          ClassT *_obj,
+          const SubscribeOptions &_opts = SubscribeOptions());
 
 #ifdef _WIN32
 // Disable warning C4251 which is triggered by

--- a/include/gz/transport/NodeShared.hh
+++ b/include/gz/transport/NodeShared.hh
@@ -34,10 +34,12 @@
 #include <thread>
 #include <vector>
 #include <map>
+#include <unordered_set>
 
 #include "gz/transport/config.hh"
 #include "gz/transport/Export.hh"
 #include "gz/transport/HandlerStorage.hh"
+#include "gz/transport/NodeOptions.hh"
 #include "gz/transport/Publisher.hh"
 #include "gz/transport/RepHandler.hh"
 #include "gz/transport/ReqHandler.hh"
@@ -297,6 +299,61 @@ namespace gz
       /// \return The relay addresses.
       public: std::vector<std::string> GlobalRelays() const;
 
+      /// \brief Unsubscribe a node from a topic.
+      /// If the handler UUID argument is empty, all subscription handlers in
+      /// the node for the specified topic are removed
+      /// \param[in] _topic Topic name to be unsubscribed.
+      /// \param[in] _nUuid Node UUID.
+      /// \param[in] _nOpt Node options.
+      /// \param[in] _hUuid Hander UUID.
+      /// \return True when successfully unsubscribed or false otherwise.
+      public: bool Unsubscribe(const std::string &_topic,
+                               const std::string &_nUuid,
+                               const NodeOptions &_nOpt,
+                               const std::string &_hUuid = "");
+
+      /// \brief Get the set of topics subscribed by a node.
+      /// \param[in] _nUuid Node UUID.
+      /// \return The set of subscribed topics.
+      private: std::unordered_set<std::string> &TopicsSubscribed(
+               const std::string &_nUuid) const;
+
+      /// \brief Remove a subscribed topic for a node
+      /// \param[in] _topic Topic to remove.
+      /// \param[in] _nUuid Node UUID.
+      /// \return True if the topic is successfully removed, false otherwise.
+      private: bool RemoveSubscribedTopic(const std::string &_topic,
+                                          const std::string &_nUuid);
+
+      /// \brief Helper function to remove handlers from the shared publish
+      /// queue for a node. This is called when the node unsubscribes to a topic
+      /// \param[in] _topic Topic that the node unsubscribed to.
+      /// \param[in] _nUuid Node UUID.
+      /// \return True on success.
+      public: bool RemoveHandlersFromPubQueue(const std::string &_topic,
+                                              const std::string &_nUuid);
+
+      /// \brief Helper function to remove one handler from the shared publish
+      /// queue for a node. This is called when the node unsubscribes to a
+      /// topic for a single handler.
+      /// \param[in] _topic Topic that the node unsubscribed to.
+      /// \param[in] _nUuid Node UUID.
+      /// \param[in] _hUuid Handler UUID.
+      /// \return True on success.
+      public: bool RemoveHandlerFromPubQueue(const std::string &_topic,
+                                             const std::string &_nUuid,
+                                             const std::string &_hUuid);
+
+      /// \brief Helper function for Subscribe. This adds the fully qualified
+      /// topic name to a map of node to topic names, which helps track
+      /// a list of topics subscribed by a node.
+      /// \param[in] _fullyQualifiedTopic Fully qualified topic name
+      /// \param[in] _nUuid Node UUID.
+      /// \return True on success.
+      /// \sa TopicUtils::FullyQualifiedName
+      public: bool SubscribeHelper(const std::string &_fullyQualifiedTopic,
+                                   const std::string &_nUuid);
+
       /// \brief Constructor.
       protected: NodeShared();
 
@@ -384,6 +441,16 @@ namespace gz
         public: bool HasSubscriber(
             const std::string &_fullyQualifiedTopic) const;
 
+        /// \brief Returns true if this wrapper contains any subscriber that
+        /// matches the given fully-qualified topic name and node UUID.
+        /// The message type name of the subscriber is irrelevant.
+        /// \param[in] _fullyQualifiedTopic Fully-qualified topic name
+        /// \param[in] _nUuid Node UUID
+        /// \return True if this contains a matching subscriber, otherwise false
+        public: bool HasSubscriberForNode(
+            const std::string &_fullyQualifiedTopic, const std::string &_nUuid)
+            const;
+
         /// \brief Get a set of node UUIDs for subscribers in this wrapper that
         /// match the topic and message type criteria.
         /// \param[in] _fullyQualifiedTopic Fully-qualified topic name that the
@@ -405,6 +472,19 @@ namespace gz
         public: bool RemoveHandlersForNode(
             const std::string &_fullyQualifiedTopic,
             const std::string &_nUuid);
+
+        /// \brief Remove one handler for the given topic name that belong to
+        /// a specific node.
+        /// \param[in] _fullyQualifiedTopic The fully-qualified name of the
+        /// topic whose subscribers should be removed.
+        /// \param[in] _nUuid The UUID of the node whose subscribers should be
+        /// removed.
+        /// \param[in] _hUuid The UUID of the handler to remove.
+        /// \return True if the subscriber was removed.
+        public: bool RemoveHandler(
+            const std::string &_fullyQualifiedTopic,
+            const std::string &_nUuid,
+            const std::string &_hUuid);
 
         /// \brief Convert all the HandlerStorages into a vector of publishers.
         /// \param[in] _addr The pub/sub address.

--- a/include/gz/transport/detail/Node.hh
+++ b/include/gz/transport/detail/Node.hh
@@ -39,10 +39,66 @@ namespace gz
     }
 
     //////////////////////////////////////////////////
-    template <typename ...Args>
-    bool Node::Subscribe(Args && ...args)
+    template<typename MessageT>
+    bool Node::Subscribe(
+        const std::string &_topic,
+        void(*_cb)(const MessageT &_msg),
+        const SubscribeOptions &_opts)
     {
-      return this->SubscribeImpl(std::forward<Args>(args)...) != nullptr;
+      return this->SubscribeImpl(_topic, _cb, _opts) != nullptr;
+    }
+
+    //////////////////////////////////////////////////
+    template<typename MessageT>
+    bool Node::Subscribe(
+        const std::string &_topic,
+        std::function<void(const MessageT &_msg)> _cb,
+        const SubscribeOptions &_opts)
+    {
+      return this->SubscribeImpl(_topic, _cb, _opts) != nullptr;
+    }
+
+    //////////////////////////////////////////////////
+    template<typename ClassT, typename MessageT>
+    bool Node::Subscribe(
+        const std::string &_topic,
+        void(ClassT::*_cb)(const MessageT &_msg),
+        ClassT *_obj,
+        const SubscribeOptions &_opts)
+    {
+      return this->SubscribeImpl(_topic, _cb, _obj, _opts) != nullptr;
+    }
+
+    //////////////////////////////////////////////////
+    template<typename MessageT>
+    bool Node::Subscribe(
+        const std::string &_topic,
+        void(*_cb)(const MessageT &_msg, const MessageInfo &_info),
+        const SubscribeOptions &_opts)
+    {
+      return this->SubscribeImpl(_topic, _cb, _opts) != nullptr;
+    }
+
+    //////////////////////////////////////////////////
+    template<typename MessageT>
+    bool Node::Subscribe(
+        const std::string &_topic,
+        std::function<void(const MessageT &_msg,
+                           const MessageInfo &_info)> _cb,
+        const SubscribeOptions &_opts)
+    {
+      return this->SubscribeImpl(_topic, _cb, _opts) != nullptr;
+    }
+
+    //////////////////////////////////////////////////
+    template<typename ClassT, typename MessageT>
+    bool Node::Subscribe(
+        const std::string &_topic,
+        void(ClassT::*_cb)(const MessageT &_msg, const MessageInfo &_info),
+        ClassT *_obj,
+        const SubscribeOptions &_opts)
+    {
+      return this->SubscribeImpl(_topic, _cb, _obj, _opts) != nullptr;
     }
 
     //////////////////////////////////////////////////

--- a/src/Node.cc
+++ b/src/Node.cc
@@ -204,8 +204,96 @@ namespace gz
       /// \brief Mutex to protect the node::publisher from race conditions.
       public: mutable std::mutex mutex;
     };
+
+    //////////////////////////////////////////////////
+    /// \internal
+    /// \brief Private data for Node::Subscriber class.
+    class Node::SubscriberPrivate
+    {
+      /// \brief Constructor
+      public: SubscriberPrivate()
+        : shared(NodeShared::Instance())
+      {
+      }
+
+      /// \brief Check if this subscriber is valid
+      /// \return True if topic, node and handler ids are not empty.
+      public: bool Valid()
+      {
+        return !this->topic.empty() && !this->hUuid.empty() &&
+               !this->nUuid.empty();
+      }
+
+      /// \brief Pointer to the object shared between all the nodes within the
+      /// same process.
+      public: NodeShared *shared = nullptr;
+
+      /// \brief Topic name
+      public: std::string topic;
+
+      /// \brief Node UUID
+      public: std::string nUuid;
+
+      /// \brief Node options
+      public: NodeOptions nOpts;
+
+      /// \brief Handler UUID
+      public: std::string hUuid;
+    };
     }
   }
+}
+
+//////////////////////////////////////////////////
+Node::Subscriber::Subscriber()
+  : dataPtr(std::make_shared<SubscriberPrivate>())
+{
+}
+
+//////////////////////////////////////////////////
+Node::Subscriber::Subscriber(const std::string &_topic,
+                             const std::string &_nUuid,
+                             const NodeOptions &_nOpts,
+                             const std::string &_hUuid)
+  : dataPtr(std::make_shared<SubscriberPrivate>())
+{
+  this->dataPtr->topic = _topic;
+  this->dataPtr->nUuid = _nUuid;
+  this->dataPtr->nOpts = _nOpts;
+  this->dataPtr->hUuid = _hUuid;
+}
+
+//////////////////////////////////////////////////
+Node::Subscriber::~Subscriber()
+{
+  this->Unsubscribe();
+}
+
+//////////////////////////////////////////////////
+bool Node::Subscriber::Unsubscribe()
+{
+  if (!this->Valid())
+    return false;
+  return this->dataPtr->shared->Unsubscribe(this->dataPtr->topic,
+      this->dataPtr->nUuid, this->dataPtr->nOpts, this->dataPtr->hUuid);
+}
+
+//////////////////////////////////////////////////
+Node::Subscriber::operator bool()
+{
+  return this->Valid();
+}
+
+//////////////////////////////////////////////////
+Node::Subscriber::operator bool() const
+{
+  return this->Valid();
+}
+
+//////////////////////////////////////////////////
+bool Node::Subscriber::Valid() const
+{
+  return this->dataPtr->Valid();
 }
 
 //////////////////////////////////////////////////
@@ -585,7 +673,7 @@ std::vector<std::string> Node::SubscribedTopics() const
   std::lock_guard<std::recursive_mutex> lk(this->dataPtr->shared->mutex);
 
   // I'm a real subscriber if I have interest in a topic and I know a publisher.
-  for (auto topic : this->dataPtr->topicsSubscribed)
+  for (auto topic : this->TopicsSubscribed())
   {
     // Remove the partition information from the topic.
     topic.erase(0, topic.find_last_of("@") + 1);
@@ -598,71 +686,8 @@ std::vector<std::string> Node::SubscribedTopics() const
 //////////////////////////////////////////////////
 bool Node::Unsubscribe(const std::string &_topic)
 {
-  // Topic remapping.
-  std::string topic = _topic;
-  this->Options().TopicRemap(_topic, topic);
-
-  std::string fullyQualifiedTopic;
-  if (!TopicUtils::FullyQualifiedName(this->Options().Partition(),
-    this->Options().NameSpace(), _topic, fullyQualifiedTopic))
-  {
-    std::cerr << "Topic [" << _topic << "] is not valid." << std::endl;
-    return false;
-  }
-
-  // Remove handlers from shared pubQueue to avoid invoking callbacks after
-  // unsuscribing to the topic
-  if (!this->dataPtr->RemoveHandlersFromPubQueue(topic))
-  {
-    std::cerr << "Error removing subscription handlers from publish queue "
-              << "when unsubscribing from Topic [" << _topic << "]"
-              <<  std::endl;
-  }
-
-  std::lock_guard<std::recursive_mutex> lk(this->dataPtr->shared->mutex);
-
-  // Remove the subscribers for the given topic that belong to this node.
-  this->dataPtr->shared->localSubscribers.RemoveHandlersForNode(
-        fullyQualifiedTopic, this->dataPtr->nUuid);
-
-  // Remove the topic from the list of subscribed topics in this node.
-  this->dataPtr->topicsSubscribed.erase(fullyQualifiedTopic);
-
-  // Remove the filter for this topic if I am the last subscriber.
-  if (!this->dataPtr->shared->localSubscribers
-      .HasSubscriber(fullyQualifiedTopic))
-  {
-#ifdef GZ_CPPZMQ_POST_4_7_0
-    this->dataPtr->shared->dataPtr->subscriber->set(
-      zmq::sockopt::unsubscribe, fullyQualifiedTopic);
-#else
-    this->dataPtr->shared->dataPtr->subscriber->setsockopt(
-      ZMQ_UNSUBSCRIBE, fullyQualifiedTopic.data(), fullyQualifiedTopic.size());
-#endif
-  }
-
-  // Notify to the publishers that I am no longer interested in the topic.
-  MsgAddresses_M addresses;
-  this->dataPtr->shared->dataPtr->msgDiscovery->Publishers(
-    fullyQualifiedTopic, addresses);
-
-  for (auto &proc : addresses)
-  {
-    std::string dstPUuid = proc.first;
-    MessagePublisher pub(fullyQualifiedTopic, this->dataPtr->shared->myAddress,
-      dstPUuid, this->dataPtr->shared->pUuid, this->dataPtr->nUuid,
-      kGenericMessageType, AdvertiseMessageOptions());
-
-    this->Shared()->dataPtr->msgDiscovery->Unregister(pub);
-  }
-
-  MessagePublisher pub(fullyQualifiedTopic, this->dataPtr->shared->myAddress,
-    "", this->dataPtr->shared->pUuid, this->dataPtr->nUuid,
-    kGenericMessageType, AdvertiseMessageOptions());
-
-  this->Shared()->dataPtr->msgDiscovery->Unregister(pub);
-
-  return true;
+  return this->dataPtr->shared->Unsubscribe(
+      _topic, this->dataPtr->nUuid, this->Options());
 }
 
 //////////////////////////////////////////////////
@@ -801,7 +826,7 @@ bool Node::SubscribeRaw(
   this->dataPtr->shared->localSubscribers.raw.AddHandler(
         fullyQualifiedTopic, this->dataPtr->nUuid, handlerPtr);
 
-  return this->dataPtr->SubscribeHelper(fullyQualifiedTopic);
+  return this->SubscribeHelper(fullyQualifiedTopic);
 }
 
 //////////////////////////////////////////////////
@@ -881,7 +906,7 @@ const std::string &Node::NodeUuid() const
 //////////////////////////////////////////////////
 std::unordered_set<std::string> &Node::TopicsSubscribed() const
 {
-  return this->dataPtr->topicsSubscribed;
+  return this->dataPtr->shared->TopicsSubscribed(this->dataPtr->nUuid);
 }
 
 //////////////////////////////////////////////////
@@ -1052,67 +1077,16 @@ Node::Publisher Node::Advertise(const std::string &_topic,
   return Publisher(publisher);
 }
 
-//////////////////////////////////////////////////
-bool NodePrivate::SubscribeHelper(const std::string &_fullyQualifiedTopic)
+/////////////////////////////////////////////////
+bool Node::SubscribeHelper(const std::string &_fullyQualifiedTopic)
 {
-  // Add the topic to the list of subscribed topics (if it was not before).
-  this->topicsSubscribed.insert(_fullyQualifiedTopic);
-
-  // Discover the list of nodes that publish on the topic.
-  if (!this->shared->dataPtr->msgDiscovery->Discover(_fullyQualifiedTopic))
+  if (!this->dataPtr->shared->SubscribeHelper(_fullyQualifiedTopic,
+                                              this->dataPtr->nUuid))
   {
     std::cerr << "Node::Subscribe(): Error discovering topic ["
               << _fullyQualifiedTopic
               << "]. Did you forget to start the discovery service?"
               << std::endl;
-    return false;
-  }
-
-  return true;
-}
-
-/////////////////////////////////////////////////
-bool Node::SubscribeHelper(const std::string &_fullyQualifiedTopic)
-{
-  return this->dataPtr->SubscribeHelper(_fullyQualifiedTopic);
-}
-
-//////////////////////////////////////////////////
-bool NodePrivate::RemoveHandlersFromPubQueue(const std::string &_topic)
-{
-  // Remove from pubQueue
-  std::unique_lock<std::mutex> queueLock(
-      this->shared->dataPtr->pubThreadMutex);
-  for (auto &msgDetails : this->shared->dataPtr->pubQueue)
-  {
-    // check if there is a pub queue with message details that has topic
-    // which the node unsubscribes to
-    if (msgDetails->info.Topic() != _topic)
-      continue;
-
-    // remove local handler if it is a handler for this node
-    for (auto handlerIt = msgDetails->localHandlers.begin();
-         handlerIt != msgDetails->localHandlers.end();)
-    {
-      if ((*handlerIt)->NodeUuid() == this->nUuid)
-      {
-        msgDetails->localHandlers.erase(handlerIt);
-      }
-      else
-        ++handlerIt;
-    }
-
-    // remove raw handler if it is a handler for this node
-    for (auto handlerIt = msgDetails->rawHandlers.begin();
-         handlerIt != msgDetails->rawHandlers.end();)
-    {
-      if ((*handlerIt)->NodeUuid() == this->nUuid)
-      {
-        msgDetails->rawHandlers.erase(handlerIt);
-      }
-      else
-        ++handlerIt;
-    }
   }
   return true;
 }

--- a/src/NodePrivate.hh
+++ b/src/NodePrivate.hh
@@ -44,21 +44,6 @@ namespace gz
       /// \brief Destructor.
       public: virtual ~NodePrivate() = default;
 
-      /// \brief Helper function for Subscribe.
-      /// \param[in] _fullyQualifiedTopic Fully qualified topic name
-      /// \return True on success.
-      /// \sa TopicUtils::FullyQualifiedName
-      public: bool SubscribeHelper(const std::string &_fullyQualifiedTopic);
-
-      /// \brief Helper function to remove handlers from the shared publish
-      /// queue. This is called when the node unsubscribes to a topic
-      /// \param[in] _topic Topic that the node unsubscribed to.
-      /// \return True on success.
-      public: bool RemoveHandlersFromPubQueue(const std::string &_topic);
-
-      /// \brief The list of topics subscribed by this node.
-      public: std::unordered_set<std::string> topicsSubscribed;
-
       /// \brief The list of service calls advertised by this node.
       public: std::unordered_set<std::string> srvsAdvertised;
 

--- a/src/NodeShared.cc
+++ b/src/NodeShared.cc
@@ -1535,6 +1535,14 @@ bool NodeShared::HandlerWrapper::HasSubscriber(
 }
 
 //////////////////////////////////////////////////
+bool NodeShared::HandlerWrapper::HasSubscriberForNode(
+    const std::string &_fullyQualifiedTopic, const std::string &_nUuid) const
+{
+  return this->normal.HasHandlersForNode(_fullyQualifiedTopic, _nUuid)
+      || this->raw.HasHandlersForNode(_fullyQualifiedTopic, _nUuid);
+}
+
+//////////////////////////////////////////////////
 template <typename HandlerT>
 static void AppendNodeUuids(const HandlerStorage<HandlerT> &_handlerStorage,
                             const std::string &_fullyQualifiedTopic,
@@ -1582,6 +1590,16 @@ bool NodeShared::HandlerWrapper::RemoveHandlersForNode(
   removed |= this->raw.RemoveHandlersForNode(_fullyQualifiedTopic, _nUuid);
 
   return removed;
+}
+
+//////////////////////////////////////////////////
+bool NodeShared::HandlerWrapper::RemoveHandler(
+    const std::string &_fullyQualifiedTopic,
+    const std::string &_nUuid,
+    const std::string &_hUuid)
+{
+  return this->normal.RemoveHandler(_fullyQualifiedTopic, _nUuid, _hUuid)
+      || this->raw.RemoveHandler(_fullyQualifiedTopic, _nUuid, _hUuid);
 }
 
 //////////////////////////////////////////////////
@@ -1968,4 +1986,217 @@ std::vector<std::string> NodeShared::GlobalRelays() const {
   srvRelaySet.merge(msgRelaySet);
 
   return std::vector<std::string>(srvRelaySet.cbegin(), srvRelaySet.cend());
+}
+
+//////////////////////////////////////////////////
+bool NodeShared::Unsubscribe(const std::string &_topic,
+  const std::string &_nUuid,
+  const NodeOptions &_nOpt,
+  const std::string &_hUuid)
+{
+  // Topic remapping.
+  std::string topic = _topic;
+  _nOpt.TopicRemap(_topic, topic);
+
+  std::string fullyQualifiedTopic;
+  if (!TopicUtils::FullyQualifiedName(_nOpt.Partition(),
+    _nOpt.NameSpace(), _topic, fullyQualifiedTopic))
+  {
+    std::cerr << "Topic [" << _topic << "] is not valid." << std::endl;
+    return false;
+  }
+
+  // Remove handlers from shared pubQueue to avoid invoking callbacks after
+  // unsuscribing to the topic
+  if ((_hUuid.empty() && !this->RemoveHandlersFromPubQueue(topic, _nUuid)) ||
+      (!_hUuid.empty() &&
+       !this->RemoveHandlerFromPubQueue(topic, _nUuid, _hUuid)))
+  {
+    std::cerr << "Error removing subscription handlers from publish queue "
+              << "when unsubscribing from Topic [" << _topic << "]"
+              <<  std::endl;
+  }
+
+  std::lock_guard<std::recursive_mutex> lk(this->mutex);
+
+  // Remove the subscribers for the given topic that belong to this node.
+  if (_hUuid.empty())
+  {
+    this->localSubscribers.RemoveHandlersForNode(
+          fullyQualifiedTopic, _nUuid);
+  }
+  else
+  {
+    this->localSubscribers.RemoveHandler(
+          fullyQualifiedTopic, _nUuid, _hUuid);
+  }
+
+  // Check if there are still local subscribers in this node. If so then we
+  // are done here. Otherwise, let others know that this node is no longer
+  // interested in the topic
+  if (this->localSubscribers.HasSubscriberForNode(fullyQualifiedTopic, _nUuid))
+    return true;
+
+  // No more susbcribers so remove the topic from the list of subscribed topics
+  // in this node.
+  this->RemoveSubscribedTopic(fullyQualifiedTopic, _nUuid);
+
+  // Remove the filter for this topic if I am the last subscriber.
+  if (!this->localSubscribers.HasSubscriber(fullyQualifiedTopic))
+  {
+#ifdef GZ_CPPZMQ_POST_4_7_0
+    this->dataPtr->subscriber->set(
+      zmq::sockopt::unsubscribe, fullyQualifiedTopic);
+#else
+    this->dataPtr->subscriber->setsockopt(
+      ZMQ_UNSUBSCRIBE, fullyQualifiedTopic.data(), fullyQualifiedTopic.size());
+#endif
+  }
+
+  // Notify to the publishers that I am no longer interested in the topic.
+  MsgAddresses_M addresses;
+  this->dataPtr->msgDiscovery->Publishers(
+    fullyQualifiedTopic, addresses);
+
+  for (auto &proc : addresses)
+  {
+    std::string dstPUuid = proc.first;
+    MessagePublisher pub(fullyQualifiedTopic, this->myAddress,
+      dstPUuid, this->pUuid, _nUuid,
+      kGenericMessageType, AdvertiseMessageOptions());
+
+    this->dataPtr->msgDiscovery->Unregister(pub);
+  }
+
+  MessagePublisher pub(fullyQualifiedTopic, this->myAddress,
+    "", this->pUuid, _nUuid,
+    kGenericMessageType, AdvertiseMessageOptions());
+
+  this->dataPtr->msgDiscovery->Unregister(pub);
+
+  return true;
+}
+
+//////////////////////////////////////////////////
+std::unordered_set<std::string> &NodeShared::TopicsSubscribed(
+    const std::string &_nUuid) const
+{
+  std::lock_guard<std::recursive_mutex> lk(this->mutex);
+  return this->dataPtr->topicsSubscribed[_nUuid];
+}
+
+//////////////////////////////////////////////////
+bool NodeShared::RemoveSubscribedTopic(
+    const std::string &_topic,
+    const std::string &_nUuid)
+{
+  std::lock_guard<std::recursive_mutex> lk(this->mutex);
+  if (this->dataPtr->topicsSubscribed.find(_nUuid) ==
+      this->dataPtr->topicsSubscribed.end())
+  {
+    return false;
+  }
+  return this->dataPtr->topicsSubscribed.at(_nUuid).erase(_topic) > 0;
+}
+
+//////////////////////////////////////////////////
+bool NodeShared::SubscribeHelper(const std::string &_fullyQualifiedTopic,
+                                 const std::string &_nUuid)
+{
+  {
+    std::lock_guard<std::recursive_mutex> lk(this->mutex);
+    // Add the topic to the list of subscribed topics (if it was not before).
+    this->dataPtr->topicsSubscribed[_nUuid].insert(_fullyQualifiedTopic);
+  }
+
+  // Discover the list of nodes that publish on the topic.
+  return !this->dataPtr->msgDiscovery->Discover(_fullyQualifiedTopic);
+}
+
+//////////////////////////////////////////////////
+bool NodeShared::RemoveHandlersFromPubQueue(const std::string &_topic,
+                                            const std::string &_nUuid)
+{
+  // Remove from pubQueue
+  std::unique_lock<std::mutex> queueLock(
+      this->dataPtr->pubThreadMutex);
+  for (auto &msgDetails : this->dataPtr->pubQueue)
+  {
+    // check if there is a pub queue with message details that has topic
+    // which the node unsubscribes to
+    if (msgDetails->info.Topic() != _topic)
+      continue;
+
+    // remove local handler if it is a handler for this node
+    for (auto handlerIt = msgDetails->localHandlers.begin();
+         handlerIt != msgDetails->localHandlers.end();)
+    {
+      if ((*handlerIt)->NodeUuid() == _nUuid)
+      {
+        msgDetails->localHandlers.erase(handlerIt);
+      }
+      else
+        ++handlerIt;
+    }
+
+    // remove raw handler if it is a handler for this node
+    for (auto handlerIt = msgDetails->rawHandlers.begin();
+         handlerIt != msgDetails->rawHandlers.end();)
+    {
+      if ((*handlerIt)->NodeUuid() == _nUuid)
+        msgDetails->rawHandlers.erase(handlerIt);
+      else
+        ++handlerIt;
+    }
+  }
+
+  return true;
+}
+
+//////////////////////////////////////////////////
+bool NodeShared::RemoveHandlerFromPubQueue(const std::string &_topic,
+                                           const std::string &_nUuid,
+                                           const std::string &_hUuid)
+{
+  // Remove from pubQueue
+  std::unique_lock<std::mutex> queueLock(
+      this->dataPtr->pubThreadMutex);
+  for (auto &msgDetails : this->dataPtr->pubQueue)
+  {
+    // check if there is a pub queue with message details that has topic
+    // which the node unsubscribes to
+    if (msgDetails->info.Topic() != _topic)
+      continue;
+
+    // remove local handler if it is a handler for this node
+    for (auto handlerIt = msgDetails->localHandlers.begin();
+         handlerIt != msgDetails->localHandlers.end();)
+    {
+      if ((*handlerIt)->NodeUuid() == _nUuid &&
+          _hUuid == (*handlerIt)->HandlerUuid())
+      {
+        msgDetails->localHandlers.erase(handlerIt);
+      }
+      else
+      {
+        ++handlerIt;
+      }
+    }
+
+    // remove raw handler if it is a handler for this node
+    for (auto handlerIt = msgDetails->rawHandlers.begin();
+         handlerIt != msgDetails->rawHandlers.end();)
+    {
+      if ((*handlerIt)->NodeUuid() == _nUuid &&
+          _hUuid == (*handlerIt)->HandlerUuid())
+      {
+        msgDetails->rawHandlers.erase(handlerIt);
+      }
+      else
+      {
+        ++handlerIt;
+      }
+    }
+  }
+  return true;
 }

--- a/src/NodeShared.cc
+++ b/src/NodeShared.cc
@@ -2110,7 +2110,7 @@ bool NodeShared::SubscribeHelper(const std::string &_fullyQualifiedTopic,
   }
 
   // Discover the list of nodes that publish on the topic.
-  return !this->dataPtr->msgDiscovery->Discover(_fullyQualifiedTopic);
+  return this->dataPtr->msgDiscovery->Discover(_fullyQualifiedTopic);
 }
 
 //////////////////////////////////////////////////

--- a/src/NodeSharedPrivate.hh
+++ b/src/NodeSharedPrivate.hh
@@ -25,6 +25,8 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "gz/transport/Discovery.hh"
@@ -202,6 +204,10 @@ namespace gz
       public: std::map<std::string,
               std::function<void(const TopicStatistics &_stats)>>
                 enabledTopicStatistics;
+
+      /// \brief A map of node UUID and its subscribed topics
+      public: std::unordered_map<std::string, std::unordered_set<std::string>>
+              topicsSubscribed;
     };
     }
   }

--- a/src/Node_TEST.cc
+++ b/src/Node_TEST.cc
@@ -947,6 +947,223 @@ TEST(NodeTest, PubSubSameThreadLambdaMessageInfo)
 }
 
 //////////////////////////////////////////////////
+/// \brief Test the bool operator of the Node::Subscriber class
+TEST(NodeSubTest, BoolOperatorTest)
+{
+  transport::Node node;
+  transport::Node::Subscriber sub;
+  const transport::Node::Subscriber sub_const;
+  EXPECT_FALSE(sub);
+  EXPECT_FALSE(sub_const);
+
+  std::function<void(const msgs::Int32 &)> cb =
+    [](const msgs::Int32 &) {};
+  sub = node.CreateSubscriber(g_topic, cb);
+  EXPECT_TRUE(sub);
+
+  const transport::Node::Subscriber sub2_const =
+      node.CreateSubscriber(g_topic, cb);
+  EXPECT_TRUE(sub2_const);
+}
+
+//////////////////////////////////////////////////
+/// \brief Subscribe to a topic using CreateSubscriber API
+TEST(NodeTest, PubSubWithCreateSubscriber)
+{
+  reset();
+
+  msgs::Int32 msg;
+  msg.set_data(data);
+
+  transport::Node node;
+
+  auto pub = node.Advertise<msgs::Int32>(g_topic);
+  EXPECT_TRUE(pub);
+
+  std::mutex mutex;
+  std::condition_variable condition;
+
+  bool executed = false;
+  std::function<void(const msgs::Int32&)> subCb =
+    [&executed, &mutex, &condition](const msgs::Int32 &_msg)
+  {
+    EXPECT_EQ(_msg.data(), data);
+    std::lock_guard<std::mutex> lk(mutex);
+    executed = true;
+    condition.notify_all();
+  };
+
+  {
+    transport::Node::Subscriber sub = node.CreateSubscriber(g_topic, subCb);
+    EXPECT_TRUE(sub);
+
+    // Give some time to the subscribers.
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    // Publish a message.
+    EXPECT_TRUE(pub.Publish(msg));
+
+    // The local publish is asynchronous, which means we need to wait
+    // for the callback.
+    std::unique_lock<std::mutex> lk(mutex);
+    condition.wait(lk, [&executed]{return executed;});
+
+    EXPECT_TRUE(executed);
+  }
+
+  // Publish another message.
+  EXPECT_TRUE(pub.Publish(msg));
+
+  // The subscriber went out of scope so it should have already unsubscribed
+  // to the topic. The callback should not be invoked.
+  std::unique_lock<std::mutex> lk(mutex);
+  condition.wait_for(lk, std::chrono::milliseconds(300),
+                     [&executed]{return executed;});
+
+  reset();
+}
+
+//////////////////////////////////////////////////
+/// \brief Subscribe to a topic using dfferent Subscribe APIs
+TEST(NodeTest, PubSubWithMixedSubscribeAPIs)
+{
+  reset();
+
+  msgs::Int32 msg;
+  msg.set_data(data);
+
+  transport::Node node;
+
+  auto pub = node.Advertise<msgs::Int32>(g_topic);
+  EXPECT_TRUE(pub);
+
+  // Subscriber1: Subscribe to topic using Subscribe(...)
+  std::mutex mutex;
+  std::condition_variable condition;
+  bool executed = false;
+  std::function<void(const msgs::Int32&)> subCb =
+    [&executed, &mutex, &condition](const msgs::Int32 &_msg)
+  {
+    EXPECT_EQ(_msg.data(), data);
+    std::lock_guard<std::mutex> lk(mutex);
+    executed = true;
+    condition.notify_all();
+  };
+  EXPECT_TRUE(node.Subscribe(g_topic, subCb));
+
+  // Subscriber2: Subscribe to topic using CreateSubscriber(...)
+  std::mutex mutex2;
+  std::condition_variable condition2;
+  bool executed2 = false;
+  std::function<void(const msgs::Int32&)> subCb2 =
+    [&executed2, &mutex2, &condition2](const msgs::Int32 &_msg)
+  {
+    EXPECT_EQ(_msg.data(), data);
+    std::lock_guard<std::mutex> lk2(mutex2);
+    executed2 = true;
+    condition2.notify_all();
+  };
+  transport::Node::Subscriber sub2 = node.CreateSubscriber(g_topic, subCb2);
+  EXPECT_TRUE(sub2);
+
+  // Subscriber3: Subscribe to topic using CreateSubscriber(...)
+  std::mutex mutex3;
+  std::condition_variable condition3;
+  bool executed3 = false;
+  std::function<void(const msgs::Int32&)> subCb3 =
+    [&executed3, &mutex3, &condition3](const msgs::Int32 &_msg)
+  {
+    EXPECT_EQ(_msg.data(), data);
+    std::lock_guard<std::mutex> lk2(mutex3);
+    executed3 = true;
+    condition3.notify_all();
+  };
+  transport::Node::Subscriber sub3 = node.CreateSubscriber(g_topic, subCb3);
+  EXPECT_TRUE(sub3);
+
+  // Give some time to the subscribers.
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+  // Publish a message.
+  EXPECT_TRUE(pub.Publish(msg));
+
+  // The local publish is asynchronous, which means we need to wait
+  // for the callback.
+  {
+    std::unique_lock<std::mutex> lk(mutex);
+    condition.wait(lk, [&executed]{return executed;});
+    EXPECT_TRUE(executed);
+
+    std::unique_lock<std::mutex> lk2(mutex2);
+    condition2.wait(lk2, [&executed2]{return executed2;});
+    EXPECT_TRUE(executed2);
+
+    std::unique_lock<std::mutex> lk3(mutex3);
+    condition3.wait(lk3, [&executed3]{return executed3;});
+    EXPECT_TRUE(executed3);
+  }
+
+  executed = false;
+  executed2 = false;
+  executed3 = false;
+
+  // Manually unsubscribe Subscriber2 and verify that the other subscribers
+  // still receive messages
+  EXPECT_TRUE(sub2.Unsubscribe());
+
+  // Publish another message.
+  EXPECT_TRUE(pub.Publish(msg));
+
+  {
+    // Subscriber1 should still receive msgs
+    std::unique_lock<std::mutex> lk(mutex);
+    condition.wait(lk, [&executed]{return executed;});
+    EXPECT_TRUE(executed);
+
+    // Subscriber2 should no longer receive msgs
+    std::unique_lock<std::mutex> lk2(mutex2);
+    condition2.wait_for(lk2, std::chrono::milliseconds(300),
+                        [&executed2]{return executed2;});
+    EXPECT_FALSE(executed2);
+
+    // Subscriber3 should still receive msgs
+    std::unique_lock<std::mutex> lk3(mutex3);
+    condition.wait(lk3, [&executed3]{return executed3;});
+    EXPECT_TRUE(executed3);
+  }
+
+  executed = false;
+  executed2 = false;
+  executed3 = false;
+
+  // Unsubscribe node from topic and verify all subscribers no longer receive
+  // messages
+  EXPECT_TRUE(node.Unsubscribe(g_topic));
+
+  // Publish another message.
+  EXPECT_TRUE(pub.Publish(msg));
+
+  {
+    std::unique_lock<std::mutex> lk(mutex);
+    condition.wait_for(lk, std::chrono::milliseconds(300),
+                       [&executed]{return executed;});
+    EXPECT_FALSE(executed);
+
+    std::unique_lock<std::mutex> lk2(mutex2);
+    condition2.wait_for(lk2, std::chrono::milliseconds(300),
+                        [&executed2]{return executed2;});
+    EXPECT_FALSE(executed2);
+
+    std::unique_lock<std::mutex> lk3(mutex3);
+    condition3.wait_for(lk3, std::chrono::milliseconds(300),
+                        [&executed3]{return executed3;});
+    EXPECT_FALSE(executed3);
+  }
+
+  reset();
+}
+
+//////////////////////////////////////////////////
 /// \brief Advertise two topics with the same name. It's not possible to do it
 /// within the same node but it's valid on separate nodes.
 TEST(NodeTest, AdvertiseTwoEqualTopics)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,6 +20,7 @@ target_compile_definitions(test_config INTERFACE
   "PUB_THROTTLED_EXE=\"$<TARGET_FILE:pub_aux_throttled>\""
   "SCOPED_TOPIC_SUBSCRIBER_EXE=\"$<TARGET_FILE:scopedTopicSubscriber_aux>\""
   "TWO_PROCS_PUBLISHER_EXE=\"$<TARGET_FILE:twoProcsPublisher_aux>\""
+  "TWO_PROCS_PUB_SUB_MIXED_SUBSCRIBERS_EXE=\"$<TARGET_FILE:twoProcsPubSubMixedSubscribers_aux>\""
   "TWO_PROCS_PUB_SUB_SINGLE_SUBSCRIBER_EXE=\"$<TARGET_FILE:twoProcsPubSubSingleSubscriber_aux>\""
   "TWO_PROCS_PUB_SUB_SUBSCRIBER_EXE=\"$<TARGET_FILE:twoProcsPubSubSubscriber_aux>\""
   "TWO_PROCS_SRV_CALL_REPLIER_EXE=\"$<TARGET_FILE:twoProcsSrvCallReplier_aux>\""

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -41,6 +41,7 @@ set(auxiliary_files
   pub_aux_throttled
   scopedTopicSubscriber_aux
   twoProcsPublisher_aux
+  twoProcsPubSubMixedSubscribers_aux
   twoProcsPubSubSingleSubscriber_aux
   twoProcsPubSubSubscriber_aux
   twoProcsSrvCallReplier_aux

--- a/test/integration/test_executables/twoProcsPubSubMixedSubscribers_aux.cc
+++ b/test/integration/test_executables/twoProcsPubSubMixedSubscribers_aux.cc
@@ -1,0 +1,182 @@
+/*
+ * Copyright (C) 2025 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#include <gz/msgs/statistic.pb.h>
+#include <gz/msgs/vector3d.pb.h>
+
+#include <atomic>
+#include <chrono>
+#include <string>
+
+#include "gz/transport/Node.hh"
+
+#include <gz/utils/Environment.hh>
+
+#include "gtest/gtest.h"
+#include "test_config.hh"
+
+using namespace gz;
+
+static std::atomic<bool> cbExecuted;
+static std::atomic<bool> cbRawExecuted;
+static std::atomic<bool> cbCreateSubExecuted;
+static std::atomic<bool> cbCreateSub2Executed;
+static std::string g_topic = "/foo"; // NOLINT(*)
+static std::string data = "bar"; // NOLINT(*)
+
+//////////////////////////////////////////////////
+/// \brief Function is called every time a topic update is received.
+void cb(const msgs::Vector3d &_msg)
+{
+  EXPECT_DOUBLE_EQ(_msg.x(), 1.0);
+  EXPECT_DOUBLE_EQ(_msg.y(), 2.0);
+  EXPECT_DOUBLE_EQ(_msg.z(), 3.0);
+  cbExecuted = true;
+}
+
+//////////////////////////////////////////////////
+void cbRaw(const char *_msgData, const size_t _size,
+           const transport::MessageInfo &_info)
+{
+  msgs::Vector3d v;
+
+  EXPECT_TRUE(v.GetTypeName() == _info.Type());
+
+  EXPECT_TRUE(v.ParseFromArray(_msgData, _size));
+
+  EXPECT_DOUBLE_EQ(v.x(), 1.0);
+  EXPECT_DOUBLE_EQ(v.y(), 2.0);
+  EXPECT_DOUBLE_EQ(v.z(), 3.0);
+
+  cbRawExecuted = true;
+}
+
+//////////////////////////////////////////////////
+/// \brief Function is called every time a topic update is received.
+void cbCreateSub(const msgs::Vector3d &_msg)
+{
+  EXPECT_DOUBLE_EQ(_msg.x(), 1.0);
+  EXPECT_DOUBLE_EQ(_msg.y(), 2.0);
+  EXPECT_DOUBLE_EQ(_msg.z(), 3.0);
+  cbCreateSubExecuted = true;
+}
+
+//////////////////////////////////////////////////
+/// \brief Function is called every time a topic update is received.
+void cbCreateSub2(const msgs::Vector3d &_msg)
+{
+  EXPECT_DOUBLE_EQ(_msg.x(), 1.0);
+  EXPECT_DOUBLE_EQ(_msg.y(), 2.0);
+  EXPECT_DOUBLE_EQ(_msg.z(), 3.0);
+  cbCreateSub2Executed = true;
+}
+
+//////////////////////////////////////////////////
+void runSubscriber()
+{
+  cbExecuted = false;
+  cbRawExecuted = false;
+  cbCreateSubExecuted = false;
+  cbCreateSub2Executed = false;
+
+  transport::Node node;
+
+  // Subscribe to topic using a mix of Subscribe / CreateSubscriber APIs
+  EXPECT_TRUE(node.Subscribe(g_topic, cb));
+  EXPECT_TRUE(node.SubscribeRaw(g_topic, cbRaw,
+                                msgs::Vector3d().GetTypeName()));
+  transport::Node::Subscriber sub = node.CreateSubscriber(g_topic, cbCreateSub);
+  EXPECT_TRUE(sub);
+  transport::Node::Subscriber sub2 = node.CreateSubscriber(g_topic,
+      cbCreateSub2);
+  EXPECT_TRUE(sub2);
+
+  int interval = 100;
+
+  // Wait until we've received at least one message in each callback.
+  while (!cbExecuted || !cbRawExecuted ||
+         !cbCreateSubExecuted || !cbCreateSub2Executed)
+  {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    if (--interval == 0)
+      break;
+  }
+
+  // Check that the message was received.
+  EXPECT_TRUE(cbExecuted);
+  EXPECT_TRUE(cbRawExecuted);
+  EXPECT_TRUE(cbCreateSubExecuted);
+  EXPECT_TRUE(cbCreateSub2Executed);
+
+  // Reset the test flags
+  cbExecuted = false;
+  cbRawExecuted = false;
+  cbCreateSubExecuted = false;
+  cbCreateSub2Executed = false;
+
+  // Only unsubscribe 'sub'
+  EXPECT_TRUE(sub.Unsubscribe());
+
+  // Wait a small amount of time so that the master process can send some new
+  // messages.
+  std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+
+  // Check that messages are received by subscribers except sub
+  EXPECT_TRUE(cbExecuted);
+  EXPECT_TRUE(cbRawExecuted);
+  EXPECT_FALSE(cbCreateSubExecuted);
+  EXPECT_TRUE(cbCreateSub2Executed);
+
+  // Reset the test flags
+  cbExecuted = false;
+  cbRawExecuted = false;
+  cbCreateSubExecuted = false;
+  cbCreateSub2Executed = false;
+
+  // Unsubscribe from all topics
+  EXPECT_TRUE(node.Unsubscribe(g_topic));
+
+  // Wait for messages
+  std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+
+  EXPECT_FALSE(cbExecuted);
+  EXPECT_FALSE(cbRawExecuted);
+  EXPECT_FALSE(cbCreateSubExecuted);
+  EXPECT_FALSE(cbCreateSub2Executed);
+}
+
+//////////////////////////////////////////////////
+TEST(twoProcPubSub, PubSubTwoProcsTwoNodesSubscriber)
+{
+  runSubscriber();
+}
+
+//////////////////////////////////////////////////
+int main(int argc, char **argv)
+{
+  if (argc != 2)
+  {
+    std::cerr << "Partition name has not be passed as argument" << std::endl;
+    return -1;
+  }
+
+  // Set the partition name for this test.
+  gz::utils::setenv("GZ_PARTITION", argv[1]);
+  gz::utils::setenv("GZ_TRANSPORT_TOPIC_STATISTICS", "1");
+
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/test/integration/twoProcsPubSub.cc
+++ b/test/integration/twoProcsPubSub.cc
@@ -523,6 +523,41 @@ TEST(twoProcPubSub, PubSubTwoProcsScopedPub)
 }
 
 //////////////////////////////////////////////////
+/// \brief Two different nodes running in two different processes. In the
+/// subscriber process there are three subscribers created using different
+/// APIs. All should receive the message. After some time twoo them unsubscribe.
+/// After that check that only one remaining subscriber receives the message.
+TEST(twoProcPubSub, PubSubTwoProcsMixedSubscribers)
+{
+  transport::Node node;
+  auto pub = node.Advertise<msgs::Vector3d>(g_topic);
+  EXPECT_TRUE(pub);
+
+  // No subscribers yet.
+  EXPECT_FALSE(pub.HasConnections());
+
+  auto pi = gz::utils::Subprocess(
+    {test_executables::kTwoProcsPubSubMixedSubscribers, partition});
+
+  msgs::Vector3d msg;
+  msg.set_x(1.0);
+  msg.set_y(2.0);
+  msg.set_z(3.0);
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+  // Now, we should have subscribers.
+  EXPECT_TRUE(pub.HasConnections());
+
+  // Publish messages for a few seconds
+  for (auto i = 0; i < 10; ++i)
+  {
+    EXPECT_TRUE(pub.Publish(msg));
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+  }
+}
+
+//////////////////////////////////////////////////
 int main(int argc, char **argv)
 {
   // Get a random partition name.

--- a/test/test_config.hh.in
+++ b/test/test_config.hh.in
@@ -55,6 +55,10 @@ constexpr const char * kScopedTopicSubscriber = SCOPED_TOPIC_SUBSCRIBER_EXE;
 constexpr const char * kTwoProcsPublisher = TWO_PROCS_PUBLISHER_EXE;
 #endif  // TWO_PROCS_PUBLISHER_EXE
 
+#ifdef TWO_PROCS_PUB_SUB_MIXED_SUBSCRIBERS_EXE
+constexpr const char * kTwoProcsPubSubMixedSubscribers = TWO_PROCS_PUB_SUB_MIXED_SUBSCRIBERS_EXE;
+#endif  // TWO_PROCS_PUB_SUB_MIXED_SUBSCRIBERS_EXE
+
 #ifdef TWO_PROCS_PUB_SUB_SINGLE_SUBSCRIBER_EXE
 constexpr const char * kTwoProcsPubSubSingleSubscriber = TWO_PROCS_PUB_SUB_SINGLE_SUBSCRIBER_EXE;
 #endif  // TWO_PROCS_PUB_SUB_SINGLE_SUBSCRIBER_EXE


### PR DESCRIPTION


# 🎉 New feature

## Summary
Backport the new `Node::CreateSubscriber` API function added in #608.

This PR does not backport the refactoring of the `Node::Subscribe` functions as that introduces a break change as mentioned in https://github.com/gazebosim/gz-sim/pull/2894

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

