### PR TITLE
Add move constructor / assignment operator to Node::Subscriber

### DIFF
--- a/include/gz/transport/Node.hh
+++ b/include/gz/transport/Node.hh
@@ -245,6 +245,10 @@ namespace gz
         /// \sa Valid
         public: operator bool() const;
 
+        /// \brief Move constructor
+        /// \param[in] _other The other Node::Subscriber
+        public: Subscriber(Subscriber &&_other);
+
         /// \brief Move assignment operator
         /// \param[in] _other The other Node::Subscriber
         /// \return Reference to this

--- a/include/gz/transport/Node.hh
+++ b/include/gz/transport/Node.hh
@@ -245,6 +245,11 @@ namespace gz
         /// \sa Valid
         public: operator bool() const;
 
+        /// \brief Move assignment operator
+        /// \param[in] _other The other Node::Subscriber
+        /// \return Reference to this
+        public: Node::Subscriber &operator=(Subscriber &&_other);
+
         /// \brief Return true if valid information, such as a non-empty
         /// topic name, node and handler UUIDs.
         /// \return True if this object has a valid subscription.

--- a/src/Node.cc
+++ b/src/Node.cc
@@ -298,6 +298,12 @@ bool Node::Subscriber::Valid() const
 }
 
 //////////////////////////////////////////////////
+Node::Subscriber::Subscriber(Node::Subscriber &&_other)
+{
+  *this = std::move(_other);
+}
+
+//////////////////////////////////////////////////
 Node::Subscriber &Node::Subscriber::operator=(Node::Subscriber &&_other)
 {
   this->dataPtr->topic = _other.dataPtr->topic;

--- a/src/Node.cc
+++ b/src/Node.cc
@@ -274,6 +274,7 @@ bool Node::Subscriber::Unsubscribe()
 {
   if (!this->Valid())
     return false;
+
   return this->dataPtr->shared->Unsubscribe(this->dataPtr->topic,
       this->dataPtr->nUuid, this->dataPtr->nOpts, this->dataPtr->hUuid);
 }
@@ -294,6 +295,21 @@ Node::Subscriber::operator bool() const
 bool Node::Subscriber::Valid() const
 {
   return this->dataPtr->Valid();
+}
+
+//////////////////////////////////////////////////
+Node::Subscriber &Node::Subscriber::operator=(Node::Subscriber &&_other)
+{
+  this->dataPtr->topic = _other.dataPtr->topic;
+  this->dataPtr->nUuid = _other.dataPtr->nUuid;
+  this->dataPtr->hUuid = _other.dataPtr->hUuid;
+  this->dataPtr->nOpts = _other.dataPtr->nOpts;
+
+  _other.dataPtr->topic.clear();
+  _other.dataPtr->nUuid.clear();
+  _other.dataPtr->hUuid.clear();
+  _other.dataPtr->nOpts = NodeOptions();
+  return *this;
 }
 
 //////////////////////////////////////////////////

--- a/src/Node.cc
+++ b/src/Node.cc
@@ -275,8 +275,16 @@ bool Node::Subscriber::Unsubscribe()
   if (!this->Valid())
     return false;
 
-  return this->dataPtr->shared->Unsubscribe(this->dataPtr->topic,
+  bool res = this->dataPtr->shared->Unsubscribe(this->dataPtr->topic,
       this->dataPtr->nUuid, this->dataPtr->nOpts, this->dataPtr->hUuid);
+
+  // Invalidate the subscriber
+  this->dataPtr->topic.clear();
+  this->dataPtr->nUuid.clear();
+  this->dataPtr->hUuid.clear();
+  this->dataPtr->nOpts = NodeOptions();
+
+  return res;
 }
 
 //////////////////////////////////////////////////
@@ -311,10 +319,13 @@ Node::Subscriber &Node::Subscriber::operator=(Node::Subscriber &&_other)
   this->dataPtr->hUuid = _other.dataPtr->hUuid;
   this->dataPtr->nOpts = _other.dataPtr->nOpts;
 
+  // Invalidate the other subscriber so it does not remove
+  // the subscription handler when it is destroyed.
   _other.dataPtr->topic.clear();
   _other.dataPtr->nUuid.clear();
   _other.dataPtr->hUuid.clear();
   _other.dataPtr->nOpts = NodeOptions();
+
   return *this;
 }
 

--- a/src/NodeShared.cc
+++ b/src/NodeShared.cc
@@ -2110,7 +2110,7 @@ bool NodeShared::SubscribeHelper(const std::string &_fullyQualifiedTopic,
   }
 
   // Discover the list of nodes that publish on the topic.
-  return !this->dataPtr->msgDiscovery->Discover(_fullyQualifiedTopic);
+  return this->dataPtr->msgDiscovery->Discover(_fullyQualifiedTopic);
 }
 
 //////////////////////////////////////////////////

--- a/src/Node_TEST.cc
+++ b/src/Node_TEST.cc
@@ -958,7 +958,11 @@ TEST(NodeSubTest, BoolOperatorTest)
 
   std::function<void(const msgs::Int32 &)> cb =
     [](const msgs::Int32 &) {};
+
   sub = node.CreateSubscriber(g_topic, cb);
+  EXPECT_TRUE(sub);
+
+  EXPECT_TRUE(sub.Unsubscribe());
   EXPECT_TRUE(sub);
 
   const transport::Node::Subscriber sub2_const =
@@ -994,7 +998,8 @@ TEST(NodeTest, PubSubWithCreateSubscriber)
   };
 
   {
-    transport::Node::Subscriber sub = node.CreateSubscriber(g_topic, subCb);
+    transport::Node::Subscriber sub;
+    sub = node.CreateSubscriber(g_topic, subCb);
     EXPECT_TRUE(sub);
 
     // Give some time to the subscribers.

--- a/src/Node_TEST.cc
+++ b/src/Node_TEST.cc
@@ -963,7 +963,7 @@ TEST(NodeSubTest, BoolOperatorTest)
   EXPECT_TRUE(sub);
 
   EXPECT_TRUE(sub.Unsubscribe());
-  EXPECT_TRUE(sub);
+  EXPECT_FALSE(sub);
 
   const transport::Node::Subscriber sub2_const =
       node.CreateSubscriber(g_topic, cb);


### PR DESCRIPTION
# 🦟 Bug fix


## Summary

Add move constructor / assignment operator to fix unintended topic unsubscription when following code is used to create a `Node::CreateSubscriber`:

```cpp
    gz::transport::Node::Subscriber sub;
    sub = node.CreateSubscriber(g_topic, subCb);
```

The above call invokes the move assignment operator. The tmp `Node::Subscriber` object returned by `CreateSubscriber` is destroyed causing it to call `Unsubscribe` in its destructor, which unintentionally removes the subscription handler from `NodeShared`. As the result the new `sub` object is never able to receive any messages.

This PR overrides the assignment operator to invalidate the `Node::Subscriber` object that is being moved so that it does not unsubscribe itself when destroyed.

I also ported the change that I made in https://github.com/gazebosim/gz-transport/pull/622  to fix the return value of `NodeShared::SubscribeHelper` function

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

