### PR TITLE
[Bazel] Bump libzmq dep to 4.3.5.bcr.3

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   test:
-    uses: bazel-contrib/.github/.github/workflows/bazel.yaml@v7
+    uses: bazel-contrib/.github/.github/workflows/bazel.yaml@v7.2.2
     with:
       folders: |
         [

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
 bazel_dep(name = "cppzmq", version = "4.10.0.bcr.1")
 bazel_dep(name = "googletest", version = "1.14.0")
 bazel_dep(name = "libuuid", version = "2.39.3.bcr.1")
-bazel_dep(name = "libzmq", version = "4.3.5.bcr.2")
+bazel_dep(name = "libzmq", version = "4.3.5.bcr.3")
 bazel_dep(name = "protobuf", version = "29.4", repo_name = "com_google_protobuf")
 bazel_dep(name = "rules_license", version = "1.0.0")
 bazel_dep(name = "rules_proto", version = "7.1.0")


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
This fixes clang build under `--copt=-Werror --per_file_copt=+external/.*@-Wno-everything`. Verified with
```
$ bazel build --copt=-Werror --per_file_copt=+external/.*@-Wno-everything --action_env=CC=/usr/bin/clang :all
```

The `--per_file_copt` setting excludes warnings from external dependencies from causing build failure. However, `libzmq` in particular uses `rules_foreign_cc:cmake` to build, which does not respect the `--per_file_copt` setting. There was one error from `-Wmissing-braces` in `libzmq` that was fixed in [BCR ](https://github.com/bazelbuild/bazel-central-registry/pull/4630).

This PR updates the `libzmq` dep version to fix the build.

Also requires in a version bump for bazel-contrib/.github/.github/workflows/bazel.yaml which we use for bazel CI since there is an error with `rules_java` brought in transitively with the libzmq update. Now, Bazel 8.x CI uses bazel 8.0.0 instead of 8.0.0rc1.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

