### PR TITLE
parameters Client_TEST: check more APIs, more error output

### DIFF
--- a/parameters/src/Client_TEST.cc
+++ b/parameters/src/Client_TEST.cc
@@ -63,34 +63,39 @@ TEST_F(ParametersClientTest, Parameter)
     ParametersClient client;
     {
       msgs::Boolean msg;
-      EXPECT_TRUE(client.Parameter("parameter1", msg));
+      ParameterResult result = client.Parameter("parameter1", msg);
+      EXPECT_TRUE(result) << result;
       EXPECT_EQ(msg.data(), false);
     }
     {
       std::unique_ptr<google::protobuf::Message> msg;
-      EXPECT_TRUE(client.Parameter("parameter2", msg));
+      ParameterResult result = client.Parameter("parameter2", msg);
+      EXPECT_TRUE(result) << result;
       ASSERT_NE(nullptr, msg);
       auto downcastedMsg = dynamic_cast<msgs::StringMsg *>(msg.get());
       EXPECT_EQ(downcastedMsg->data(), "");
     }
     {
       msgs::Boolean msg;
-      auto ret = client.Parameter("parameter3", msg);
-      EXPECT_FALSE(ret);
-      EXPECT_EQ(ret.ResultType(), ParameterResultType::InvalidType);
-      EXPECT_EQ(ret.ParamName(), "parameter3");
+      auto result = client.Parameter("parameter3", msg);
+      EXPECT_FALSE(result) << result;
+      EXPECT_EQ(result.ResultType(), ParameterResultType::InvalidType)
+          << result;
+      EXPECT_EQ(result.ParamName(), "parameter3") << result;
     }
   }
   {
     ParametersClient client{"/ns"};
     {
       msgs::Boolean msg;
-      EXPECT_TRUE(client.Parameter("another_param1", msg));
+      auto result = client.Parameter("another_param1", msg);
+      EXPECT_TRUE(result) << result;
       EXPECT_EQ(msg.data(), false);
     }
     {
       msgs::StringMsg msg;
-      EXPECT_TRUE(client.Parameter("another_param2", msg));
+      auto result = client.Parameter("another_param2", msg);
+      EXPECT_TRUE(result) << result;
       EXPECT_EQ(msg.data(), "bsd");
     }
   }
@@ -103,34 +108,46 @@ TEST_F(ParametersClientTest, SetParameter)
     ParametersClient client;
     msgs::StringMsg msg;
     msg.set_data("testing");
-    client.SetParameter("parameter2", msg);
+    {
+      auto result = client.SetParameter("parameter2", msg);
+      EXPECT_TRUE(result) << result;
+    }
     msgs::StringMsg msg_got;
-    EXPECT_TRUE(registry_.Parameter("parameter2", msg_got));
+    {
+      auto result = registry_.Parameter("parameter2", msg_got);
+      EXPECT_TRUE(result) << result;
+    }
     EXPECT_EQ(msg_got.data(), "testing");
   }
   {
     ParametersClient client;
     msgs::Boolean msg;
-    auto ret = client.SetParameter("parameter2", msg);
-    EXPECT_FALSE(ret);
-    EXPECT_EQ(ret.ResultType(), ParameterResultType::InvalidType);
-    EXPECT_EQ(ret.ParamName(), "parameter2");
+    auto result = client.SetParameter("parameter2", msg);
+    EXPECT_FALSE(result) << result;
+    EXPECT_EQ(result.ResultType(), ParameterResultType::InvalidType) << result;
+    EXPECT_EQ(result.ParamName(), "parameter2") << result;
   }
   {
     ParametersClient client;
     msgs::Boolean msg;
-    auto ret = client.SetParameter("parameter_doesnt_exist", msg);
-    EXPECT_FALSE(ret);
-    EXPECT_EQ(ret.ResultType(), ParameterResultType::NotDeclared);
-    EXPECT_EQ(ret.ParamName(), "parameter_doesnt_exist");
+    auto result = client.SetParameter("parameter_doesnt_exist", msg);
+    EXPECT_FALSE(result) << result;
+    EXPECT_EQ(result.ResultType(), ParameterResultType::NotDeclared) << result;
+    EXPECT_EQ(result.ParamName(), "parameter_doesnt_exist") << result;
   }
   {
     ParametersClient client{"/ns"};
     msgs::Boolean msg;
     msg.set_data(true);
-    client.SetParameter("another_param1", msg);
+    {
+      auto result = client.SetParameter("another_param1", msg);
+      EXPECT_TRUE(result) << result;
+    }
     msgs::Boolean msg_got;
-    EXPECT_TRUE(registry_other_ns_.Parameter("another_param1", msg_got));
+    {
+      auto result = registry_other_ns_.Parameter("another_param1", msg_got);
+      EXPECT_TRUE(result) << result;
+    }
     EXPECT_EQ(msg_got.data(), true);
   }
 }
@@ -142,25 +159,37 @@ TEST_F(ParametersClientTest, DeclareParameter)
     ParametersClient client;
     msgs::StringMsg msg;
     msg.set_data("declaring");
-    client.DeclareParameter("new_parameter", msg);
+    {
+      auto result = client.DeclareParameter("new_parameter", msg);
+      EXPECT_TRUE(result) << result;
+    }
     msgs::StringMsg msg_got;
-    EXPECT_TRUE(registry_.Parameter("new_parameter", msg_got));
+    {
+      auto result = registry_.Parameter("new_parameter", msg_got);
+      EXPECT_TRUE(result) << result;
+    }
     EXPECT_EQ(msg_got.data(), "declaring");
   }
   {
     ParametersClient client;
     msgs::Boolean msg;
-    auto ret = client.DeclareParameter("parameter1", msg);
-    EXPECT_FALSE(ret);
-    EXPECT_EQ(ret.ResultType(), ParameterResultType::AlreadyDeclared);
+    auto result = client.DeclareParameter("parameter1", msg);
+    EXPECT_FALSE(result);
+    EXPECT_EQ(result.ResultType(), ParameterResultType::AlreadyDeclared);
   }
   {
     ParametersClient client{"/ns"};
     msgs::Boolean msg;
     msg.set_data(true);
     msgs::Boolean msg_got;
-    client.DeclareParameter("new_parameter", msg);
-    EXPECT_TRUE(registry_other_ns_.Parameter("new_parameter", msg_got));
+    {
+      auto result = client.DeclareParameter("new_parameter", msg);
+      EXPECT_TRUE(result) << result;
+    }
+    {
+      auto result = registry_other_ns_.Parameter("new_parameter", msg_got);
+      EXPECT_TRUE(result) << result;
+    }
     EXPECT_EQ(msg_got.data(), true);
   }
 }


### PR DESCRIPTION
# 🦟 Bug fix

Part of https://github.com/gazebosim/gz-transport/issues/435.

## Summary

While fixing https://github.com/gazebosim/gz-transport/issues/435, it was hard to identify the reason for failures in the parameters `Client_TEST`. This checks the return value of more API calls and prints the `ParameterResult` value when test expectations fail to provide diagnostic info for debugging.

There are several places where `ParameterResult` values are stored in variables named `ret`, and for consistency, I renamed these variables to `result`.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
