### PR TITLE
parameters: use gz.msgs instead of gz_msgs

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -69,6 +69,9 @@ release will remove the deprecated code.
    bool res = node.Subscribe(topic, topicCb);
    ```
 
+2. The `parameters` registry no longer replaces `gz.msgs` message namespaces
+   with `gz_msgs`.
+
 ## Gazebo Transport 11.X to 12.X
 
 ### Deprecated

--- a/parameters/src/Client.cc
+++ b/parameters/src/Client.cc
@@ -107,7 +107,7 @@ ParametersClient::Parameter(
       _parameterName};
   }
   auto gzType = *gzTypeOpt;
-  if (gzType != _parameter.GetDescriptor()->name()) {
+  if (gzType != _parameter.GetDescriptor()->full_name()) {
     return ParameterResult{
       ParameterResultType::InvalidType, _parameterName, gzType};
   }

--- a/parameters/src/Client_TEST.cc
+++ b/parameters/src/Client_TEST.cc
@@ -63,34 +63,39 @@ TEST_F(ParametersClientTest, Parameter)
     ParametersClient client;
     {
       msgs::Boolean msg;
-      EXPECT_TRUE(client.Parameter("parameter1", msg));
+      ParameterResult result = client.Parameter("parameter1", msg);
+      EXPECT_TRUE(result) << result;
       EXPECT_EQ(msg.data(), false);
     }
     {
       std::unique_ptr<google::protobuf::Message> msg;
-      EXPECT_TRUE(client.Parameter("parameter2", msg));
+      ParameterResult result = client.Parameter("parameter2", msg);
+      EXPECT_TRUE(result) << result;
       ASSERT_NE(nullptr, msg);
       auto downcastedMsg = dynamic_cast<msgs::StringMsg *>(msg.get());
       EXPECT_EQ(downcastedMsg->data(), "");
     }
     {
       msgs::Boolean msg;
-      auto ret = client.Parameter("parameter3", msg);
-      EXPECT_FALSE(ret);
-      EXPECT_EQ(ret.ResultType(), ParameterResultType::InvalidType);
-      EXPECT_EQ(ret.ParamName(), "parameter3");
+      auto result = client.Parameter("parameter3", msg);
+      EXPECT_FALSE(result) << result;
+      EXPECT_EQ(result.ResultType(), ParameterResultType::InvalidType)
+          << result;
+      EXPECT_EQ(result.ParamName(), "parameter3") << result;
     }
   }
   {
     ParametersClient client{"/ns"};
     {
       msgs::Boolean msg;
-      EXPECT_TRUE(client.Parameter("another_param1", msg));
+      auto result = client.Parameter("another_param1", msg);
+      EXPECT_TRUE(result) << result;
       EXPECT_EQ(msg.data(), false);
     }
     {
       msgs::StringMsg msg;
-      EXPECT_TRUE(client.Parameter("another_param2", msg));
+      auto result = client.Parameter("another_param2", msg);
+      EXPECT_TRUE(result) << result;
       EXPECT_EQ(msg.data(), "bsd");
     }
   }
@@ -103,34 +108,46 @@ TEST_F(ParametersClientTest, SetParameter)
     ParametersClient client;
     msgs::StringMsg msg;
     msg.set_data("testing");
-    client.SetParameter("parameter2", msg);
+    {
+      auto result = client.SetParameter("parameter2", msg);
+      EXPECT_TRUE(result) << result;
+    }
     msgs::StringMsg msg_got;
-    EXPECT_TRUE(registry_.Parameter("parameter2", msg_got));
+    {
+      auto result = registry_.Parameter("parameter2", msg_got);
+      EXPECT_TRUE(result) << result;
+    }
     EXPECT_EQ(msg_got.data(), "testing");
   }
   {
     ParametersClient client;
     msgs::Boolean msg;
-    auto ret = client.SetParameter("parameter2", msg);
-    EXPECT_FALSE(ret);
-    EXPECT_EQ(ret.ResultType(), ParameterResultType::InvalidType);
-    EXPECT_EQ(ret.ParamName(), "parameter2");
+    auto result = client.SetParameter("parameter2", msg);
+    EXPECT_FALSE(result) << result;
+    EXPECT_EQ(result.ResultType(), ParameterResultType::InvalidType) << result;
+    EXPECT_EQ(result.ParamName(), "parameter2") << result;
   }
   {
     ParametersClient client;
     msgs::Boolean msg;
-    auto ret = client.SetParameter("parameter_doesnt_exist", msg);
-    EXPECT_FALSE(ret);
-    EXPECT_EQ(ret.ResultType(), ParameterResultType::NotDeclared);
-    EXPECT_EQ(ret.ParamName(), "parameter_doesnt_exist");
+    auto result = client.SetParameter("parameter_doesnt_exist", msg);
+    EXPECT_FALSE(result) << result;
+    EXPECT_EQ(result.ResultType(), ParameterResultType::NotDeclared) << result;
+    EXPECT_EQ(result.ParamName(), "parameter_doesnt_exist") << result;
   }
   {
     ParametersClient client{"/ns"};
     msgs::Boolean msg;
     msg.set_data(true);
-    client.SetParameter("another_param1", msg);
+    {
+      auto result = client.SetParameter("another_param1", msg);
+      EXPECT_TRUE(result) << result;
+    }
     msgs::Boolean msg_got;
-    EXPECT_TRUE(registry_other_ns_.Parameter("another_param1", msg_got));
+    {
+      auto result = registry_other_ns_.Parameter("another_param1", msg_got);
+      EXPECT_TRUE(result) << result;
+    }
     EXPECT_EQ(msg_got.data(), true);
   }
 }
@@ -142,25 +159,37 @@ TEST_F(ParametersClientTest, DeclareParameter)
     ParametersClient client;
     msgs::StringMsg msg;
     msg.set_data("declaring");
-    client.DeclareParameter("new_parameter", msg);
+    {
+      auto result = client.DeclareParameter("new_parameter", msg);
+      EXPECT_TRUE(result) << result;
+    }
     msgs::StringMsg msg_got;
-    EXPECT_TRUE(registry_.Parameter("new_parameter", msg_got));
+    {
+      auto result = registry_.Parameter("new_parameter", msg_got);
+      EXPECT_TRUE(result) << result;
+    }
     EXPECT_EQ(msg_got.data(), "declaring");
   }
   {
     ParametersClient client;
     msgs::Boolean msg;
-    auto ret = client.DeclareParameter("parameter1", msg);
-    EXPECT_FALSE(ret);
-    EXPECT_EQ(ret.ResultType(), ParameterResultType::AlreadyDeclared);
+    auto result = client.DeclareParameter("parameter1", msg);
+    EXPECT_FALSE(result);
+    EXPECT_EQ(result.ResultType(), ParameterResultType::AlreadyDeclared);
   }
   {
     ParametersClient client{"/ns"};
     msgs::Boolean msg;
     msg.set_data(true);
     msgs::Boolean msg_got;
-    client.DeclareParameter("new_parameter", msg);
-    EXPECT_TRUE(registry_other_ns_.Parameter("new_parameter", msg_got));
+    {
+      auto result = client.DeclareParameter("new_parameter", msg);
+      EXPECT_TRUE(result) << result;
+    }
+    {
+      auto result = registry_other_ns_.Parameter("new_parameter", msg_got);
+      EXPECT_TRUE(result) << result;
+    }
     EXPECT_EQ(msg_got.data(), true);
   }
 }

--- a/parameters/src/Client_TEST.cc
+++ b/parameters/src/Client_TEST.cc
@@ -204,13 +204,13 @@ TEST_F(ParametersClientTest, ListParameters)
     bool foundParam2{false};
     bool foundParam3{false};
     for (auto decl : declarations.parameter_declarations()) {
-      if (decl.name() == "parameter1" && decl.type() == "gz_msgs.Boolean") {
+      if (decl.name() == "parameter1" && decl.type() == "gz.msgs.Boolean") {
         foundParam1 = true;
       }
-      if (decl.name() == "parameter2" && decl.type() == "gz_msgs.StringMsg") {
+      if (decl.name() == "parameter2" && decl.type() == "gz.msgs.StringMsg") {
         foundParam2 = true;
       }
-      if (decl.name() == "parameter3" && decl.type() == "gz_msgs.StringMsg") {
+      if (decl.name() == "parameter3" && decl.type() == "gz.msgs.StringMsg") {
         foundParam3 = true;
       }
     }
@@ -225,12 +225,12 @@ TEST_F(ParametersClientTest, ListParameters)
     bool foundParam2{false};
     for (auto decl : declarations.parameter_declarations()) {
       if (
-        decl.name() == "another_param1" && decl.type() == "gz_msgs.Boolean")
+        decl.name() == "another_param1" && decl.type() == "gz.msgs.Boolean")
       {
         foundParam1 = true;
       }
       if (
-        decl.name() == "another_param2" && decl.type() == "gz_msgs.StringMsg")
+        decl.name() == "another_param2" && decl.type() == "gz.msgs.StringMsg")
       {
         foundParam2 = true;
       }

--- a/parameters/src/Registry.cc
+++ b/parameters/src/Registry.cc
@@ -143,8 +143,8 @@ bool ParametersRegistryPrivate::ListParameters(const msgs::Empty &,
     for (const auto & paramPair : this->parametersMap) {
       auto * decl = _res.add_parameter_declarations();
       decl->set_name(paramPair.first);
-      decl->set_type(addGzMsgsPrefix(
-        std::string(paramPair.second->GetDescriptor()->name())));
+      decl->set_type(
+        std::string(paramPair.second->GetDescriptor()->full_name()));
     }
   }
   return true;
@@ -238,7 +238,7 @@ ParametersRegistry::DeclareParameter(
   const std::string & _parameterName,
   const google::protobuf::Message & _msg)
 {
-  auto protoType = addGzMsgsPrefix(std::string(_msg.GetDescriptor()->name()));
+  auto protoType = std::string(_msg.GetDescriptor()->full_name());
   auto newParam = gz::msgs::Factory::New(protoType);
   if (!newParam) {
     return ParameterResult{
@@ -264,13 +264,13 @@ ParametersRegistry::Parameter(
       ParameterResultType::NotDeclared,
       _parameterName};
   }
-  const auto & newProtoType = _parameter.GetDescriptor()->name();
-  const auto & protoType = it->second->GetDescriptor()->name();
+  const auto & newProtoType = _parameter.GetDescriptor()->full_name();
+  const auto & protoType = it->second->GetDescriptor()->full_name();
   if (newProtoType != protoType) {
     return ParameterResult{
       ParameterResultType::InvalidType,
       _parameterName,
-      addGzMsgsPrefix(std::string(protoType))};
+      std::string(protoType)};
   }
   _parameter.CopyFrom(*it->second);
   return ParameterResult{ParameterResultType::Success};
@@ -289,13 +289,13 @@ ParametersRegistry::Parameter(
       ParameterResultType::NotDeclared,
       _parameterName};
   }
-  const auto & protoType = it->second->GetDescriptor()->name();
+  const auto & protoType = it->second->GetDescriptor()->full_name();
   _parameter = gz::msgs::Factory::New(std::string(protoType));
   if (!_parameter) {
     return ParameterResult{
       ParameterResultType::InvalidType,
       _parameterName,
-      addGzMsgsPrefix(std::string(protoType))};
+      std::string(protoType)};
 
   }
   _parameter->CopyFrom(*it->second);
@@ -320,8 +320,7 @@ ParametersRegistry::SetParameter(
     return ParameterResult{
       ParameterResultType::InvalidType,
       _parameterName,
-      std::string(addGzMsgsPrefix(
-            std::string(it->second->GetDescriptor()->name())))};
+      std::string(it->second->GetDescriptor()->full_name())};
   }
   it->second = std::move(_value);
   return ParameterResult{ParameterResultType::Success};

--- a/parameters/src/Registry.cc
+++ b/parameters/src/Registry.cc
@@ -170,7 +170,7 @@ bool ParametersRegistryPrivate::SetParameter(
       return true;
     }
     auto requestedGzType = *requestedGzTypeOpt;
-    if (it->second->GetDescriptor()->name() != requestedGzType) {
+    if (it->second->GetDescriptor()->full_name() != requestedGzType) {
       _res.set_data(msgs::ParameterError::INVALID_TYPE);
       return true;
     }
@@ -192,7 +192,7 @@ bool ParametersRegistryPrivate::DeclareParameter(
     _res.set_data(msgs::ParameterError::INVALID_TYPE);
     return true;
   }
-  auto gzType = addGzMsgsPrefix(*gzTypeOpt);
+  auto gzType = *gzTypeOpt;
   auto paramValue = gz::msgs::Factory::New(gzType);
   if (!paramValue) {
     _res.set_data(msgs::ParameterError::INVALID_TYPE);

--- a/parameters/src/Registry_TEST.cc
+++ b/parameters/src/Registry_TEST.cc
@@ -66,7 +66,7 @@ TEST(ParametersRegistry, Parameter)
   EXPECT_FALSE(ret);
   EXPECT_EQ(ret.ResultType(), ParameterResultType::InvalidType);
   EXPECT_EQ(ret.ParamName(), "parameter1");
-  EXPECT_EQ(ret.ParamType(), "gz_msgs.Boolean");
+  EXPECT_EQ(ret.ParamType(), "gz.msgs.Boolean");
 }
 
 //////////////////////////////////////////////////
@@ -91,7 +91,7 @@ TEST(ParametersRegistry, SetParameter)
   EXPECT_FALSE(ret);
   EXPECT_EQ(ret.ResultType(), ParameterResultType::InvalidType);
   EXPECT_EQ(ret.ParamName(), "parameter1");
-  EXPECT_EQ(ret.ParamType(), "gz_msgs.Boolean");
+  EXPECT_EQ(ret.ParamType(), "gz.msgs.Boolean");
 }
 
 //////////////////////////////////////////////////
@@ -109,10 +109,10 @@ TEST(ParametersRegistry, ListParameters)
   bool foundParam1 = false;
   bool foundParam2 = false;
   for (auto decl : declarations.parameter_declarations()) {
-    if (decl.name() == "parameter1" && decl.type() == "gz_msgs.Boolean") {
+    if (decl.name() == "parameter1" && decl.type() == "gz.msgs.Boolean") {
       foundParam1 = true;
     }
-    if (decl.name() == "parameter2" && decl.type() == "gz_msgs.StringMsg") {
+    if (decl.name() == "parameter2" && decl.type() == "gz.msgs.StringMsg") {
       foundParam2 = true;
     }
   }

--- a/parameters/src/Utils.cc
+++ b/parameters/src/Utils.cc
@@ -46,5 +46,5 @@ transport::parameters::getGzTypeFromAnyProto(
   if (!ret.compare(0, sizeof(prefix), prefix)) {
     return std::nullopt;
   }
-  return ret.substr(sizeof(prefix) - 1);
+  return ret;
 }

--- a/parameters/src/Utils.cc
+++ b/parameters/src/Utils.cc
@@ -22,16 +22,6 @@
 #include <string>
 using namespace gz;
 //////////////////////////////////////////////////
-std::string
-transport::parameters::addGzMsgsPrefix(
-  const std::string &_gzType)
-{
-  std::ostringstream oss{"gz_msgs.", std::ios_base::ate};
-  oss << _gzType;
-  return oss.str();
-}
-
-//////////////////////////////////////////////////
 std::optional<std::string>
 transport::parameters::getGzTypeFromAnyProto(
   const google::protobuf::Any &_any)

--- a/parameters/src/Utils.hh
+++ b/parameters/src/Utils.hh
@@ -42,12 +42,6 @@ namespace gz
       // Inline bracket to help doxygen filtering.
       inline namespace GZ_TRANSPORT_VERSION_NAMESPACE {
 
-      /// \brief Return the protobuf type prefixed with "gz_msgs."
-      /// \param[in] _gzType Type name to be prefixed.
-      /// \return The protobuf type with the prefix added.
-      GZ_TRANSPORT_PARAMETERS_VISIBLE
-      std::string addGzMsgsPrefix(const std::string &_gzType);
-
       /// \brief Get the gz message type from a protobuf message.
       /// \param[in] _any Message to get the type.
       /// \return A string with the gazebo protobuf type,

--- a/parameters/src/Utils_TEST.cc
+++ b/parameters/src/Utils_TEST.cc
@@ -27,12 +27,6 @@ using namespace transport;
 using namespace transport::parameters;
 
 //////////////////////////////////////////////////
-TEST(ParametersUtils, addGzMsgsPrefix)
-{
-  EXPECT_EQ(addGzMsgsPrefix("asd"), "gz_msgs.asd");
-}
-
-//////////////////////////////////////////////////
 TEST(ParametersUtils, getGzTypeFromAnyProto)
 {
   google::protobuf::Any any;

--- a/parameters/src/Utils_TEST.cc
+++ b/parameters/src/Utils_TEST.cc
@@ -39,8 +39,8 @@ TEST(ParametersUtils, getGzTypeFromAnyProto)
 
   gz::msgs::Boolean boolMsg;
   any.PackFrom(boolMsg);
-  EXPECT_EQ(*getGzTypeFromAnyProto(any), "Boolean");
+  EXPECT_EQ(*getGzTypeFromAnyProto(any), "gz.msgs.Boolean");
   gz::msgs::StringMsg strMsg;
   any.PackFrom(strMsg);
-  EXPECT_EQ(*getGzTypeFromAnyProto(any), "StringMsg");
+  EXPECT_EQ(*getGzTypeFromAnyProto(any), "gz.msgs.StringMsg");
 }


### PR DESCRIPTION
# 🎉 New feature

Follow-up to https://github.com/gazebosim/gz-transport/pull/647.

## Summary

The use of non-qualified message names was removed from the parameters component in https://github.com/gazebosim/gz-transport/pull/647, some of which involved keeping `gz.msgs` namespaces instead of replacing them with `gz_msgs`. This goes further for consistency, using `gz.msgs` instead of `gz_msgs` in all parts of the `parameters` component, including removal of the helper function that prepends message types with `gz_msgs` and instead using the full name of descriptors.


## Test it

Check CI

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [X] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
