### PR TITLE
Zenoh - Part 5: Implement graph cache for async services

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -52,6 +52,15 @@ release will remove the deprecated code.
 
 ### Breaking Changes
 
+1. The `RepHandler.hh::IRepHandler` constructor now
+   requires two parameters (process UUID, and  node UUID). The new signature is:
+   ```cpp
+   IRepHandler(
+     const std::string &_pUuid,
+     const std::string &_nUuid);
+   ```
+   * [GitHub pull request 657](https://github.com/gazebosim/gz-transport/pull/657)
+
 1. The `SubscriptionHandler.hh::SubscriptionHandlerBase` constructor now
    requires a new parameter (process UUID). The new signature is:
    ```cpp

--- a/include/gz/transport/RepHandler.hh
+++ b/include/gz/transport/RepHandler.hh
@@ -61,7 +61,10 @@ namespace gz::transport
   class GZ_TRANSPORT_VISIBLE IRepHandler
   {
     /// \brief Constructor.
-    public: IRepHandler();
+    /// \param[in] _pUuid Process UUID.
+    /// \param[in] _nUuid Node UUID.
+    public: explicit IRepHandler(const std::string &_pUuid,
+                                 const std::string &_nUuid);
 
     /// \brief Destructor.
     public: virtual ~IRepHandler();
@@ -126,7 +129,7 @@ namespace gz::transport
     : public IRepHandler
   {
     // Documentation inherited.
-    public: RepHandler() = default;
+    using IRepHandler::IRepHandler;
 
     /// \brief Set the callback for this handler.
     /// \param[in] _cb The callback with the following parameters:

--- a/include/gz/transport/SubscriptionHandler.hh
+++ b/include/gz/transport/SubscriptionHandler.hh
@@ -116,7 +116,7 @@ namespace gz::transport
 #pragma warning(disable: 4251)
 #endif
     /// \brief Private data.
-    protected: SubscriptionHandlerBasePrivate *dataPtr;
+    protected: std::unique_ptr<SubscriptionHandlerBasePrivate> dataPtr;
 #ifdef _WIN32
 #pragma warning(pop)
 #endif

--- a/include/gz/transport/TopicUtils.hh
+++ b/include/gz/transport/TopicUtils.hh
@@ -247,7 +247,7 @@ namespace gz::transport
     /// qualified topic name.
     public: static const uint16_t kMaxNameLength = 65535;
 
-    /// \param The separator used within the liveliness token.
+    /// \brief The separator used within the liveliness token.
     public: static constexpr const char *kTokenSeparator = "@";
 
     /// \brief A common prefix for all liveliness tokens.

--- a/include/gz/transport/TopicUtils.hh
+++ b/include/gz/transport/TopicUtils.hh
@@ -164,6 +164,76 @@ namespace gz::transport
       std::string &_entityType,
       std::string &_msgType);
 
+    /// \brief Decompose a Zenoh liveliness token into its components.
+    ///
+    /// Given a Zenoh liveliness token with the following syntax:
+    ///
+    /// \<PREFIX\>\@\<PARTITION\>\@\<NAMESPACE\>/\<TOPIC\>@\<ProcUUID\>
+    /// \@\<NodeUUID\>\@\<EntityType\>\@\<ReqType\>\@\<RepType\>
+    ///
+    /// The _prefix output argument will be set to \<PREFIX\>, the _partition
+    /// output argument will be set to \<PARTITION\>, the
+    /// _namespaceAndTopic output argument will be set to
+    /// \<NAMESPACE\>/\<TOPIC\>, the _pUUID output argument will be set to
+    /// \<ProcUUID\>, the _nUUID output argument will be set to
+    /// \<NodeUUID\>, the _entityType output argument will be set to
+    /// \<EntityType\>, the _reqType output argument will be set to
+    /// \<ReqType\>, the _repType output argument will be set to
+    /// \<RepType\>.
+    ///
+    /// \param[in] _token The Zenoh liveliness token.
+    /// \param[out] _prefix The prefix component.
+    /// \param[out] _partition The partition component.
+    /// \param[out] _namespaceAndTopic The namespace and topic name component.
+    /// Note that there is no way to distinguish between where a namespace
+    /// ends and a topic name begins, since topic names may contain slashes.
+    /// \param[out] _pUUID The process UUID component.
+    /// \param[out] _nUUID The node UUID component.
+    /// \param[out] _entityType The entity type (pub, sub) component.
+    /// \param[out] _reqType The service request message type.
+    /// \param[out] _repType The service response message type.
+    /// \return True if all the components were set.
+    public: static bool DecomposeLivelinessToken(
+      const std::string &_token,
+      std::string &_prefix,
+      std::string &_partition,
+      std::string &_namespaceAndTopic,
+      std::string &_pUUID,
+      std::string &_nUUID,
+      std::string &_entityType,
+      std::string &_reqType,
+      std::string &_repType);
+
+    /// \brief Create a liveliness token.
+    /// \param[in] _fullyQualifiedTopic The fully qualified topic.
+    /// \param[in] _pUuid The process UUID.
+    /// \param[in] _nUuid The node UUID.
+    /// \param[in] _entityType The entity type (pub, sub, srv).
+    /// \param[in] _msgTypeName The message type.
+    /// \return The liveliness token.
+    public: static std::string CreateLivelinessToken(
+      const std::string &_fullyQualifiedTopic,
+      const std::string &_pUuid,
+      const std::string &_nUuid,
+      const std::string &_entityType,
+      const std::string &_msgTypeName);
+
+    /// \brief Create a liveliness token.
+    /// \param[in] _fullyQualifiedTopic The fully qualified topic.
+    /// \param[in] _pUuid The process UUID.
+    /// \param[in] _nUuid The node UUID.
+    /// \param[in] _entityType The entity type (pub, sub, srv).
+    /// \param[in] _reqTypeName The service request type.
+    /// \param[in] _repTypeName The service response type.
+    /// \return The liveliness token.
+    public: static std::string CreateLivelinessToken(
+      const std::string &_fullyQualifiedTopic,
+      const std::string &_pUuid,
+      const std::string &_nUuid,
+      const std::string &_entityType,
+      const std::string &_reqTypeName,
+      const std::string &_repTypeName);
+
     /// \brief Convert a topic name to a valid topic. The input topic is
     /// modified by:
     /// * turning white space into `_`.
@@ -176,6 +246,12 @@ namespace gz::transport
     /// allowed in a namespace, a partition name, a topic name, and a fully
     /// qualified topic name.
     public: static const uint16_t kMaxNameLength = 65535;
+
+    /// \param The separator used within the liveliness token.
+    public: static constexpr const char *kTokenSeparator = "@";
+
+    /// \brief A common prefix for all liveliness tokens.
+    public: static constexpr const char *kTokenPrefix = "gz";
   };
   }
 }

--- a/include/gz/transport/TransportTypes.hh
+++ b/include/gz/transport/TransportTypes.hh
@@ -137,7 +137,7 @@ namespace gz::transport
   using SrvDiscoveryCallback =
     std::function<void(const ServicePublisher &_publisher)>;
 
-  /// \def ZenohLivelinessCallback
+  /// \def LivelinessCallback
   /// \brief Function for receiving a Zenoh liveliness callback.
   using LivelinessCallback =
     std::function<void(const zenoh::Sample &_sample)>;

--- a/include/gz/transport/TransportTypes.hh
+++ b/include/gz/transport/TransportTypes.hh
@@ -36,6 +36,12 @@
 #include "gz/transport/config.hh"
 #include "gz/transport/Publisher.hh"
 
+namespace zenoh
+{
+  /// \brief Forward declaration.
+  class Sample;
+}
+
 namespace gz::transport
 {
   // Inline bracket to help doxygen filtering.
@@ -130,6 +136,11 @@ namespace gz::transport
   /// publisher.
   using SrvDiscoveryCallback =
     std::function<void(const ServicePublisher &_publisher)>;
+
+  /// \def ZenohLivelinessCallback
+  /// \brief Function for receiving a Zenoh liveliness callback.
+  using LivelinessCallback =
+    std::function<void(const zenoh::Sample &_sample)>;
 
   /// \def MsgCallback
   /// \brief User callback used for receiving messages:

--- a/include/gz/transport/detail/Node.hh
+++ b/include/gz/transport/detail/Node.hh
@@ -293,7 +293,8 @@ namespace gz
 
       // Create a new service reply handler.
       std::shared_ptr<RepHandler<RequestT, ReplyT>> repHandlerPtr(
-        new RepHandler<RequestT, ReplyT>());
+        new RepHandler<RequestT, ReplyT>(this->Shared()->pUuid,
+          this->NodeUuid()));
 
       // Insert the callback into the handler.
       std::string impl = this->Shared()->GzImplementation();

--- a/src/HandlerStorage_TEST.cc
+++ b/src/HandlerStorage_TEST.cc
@@ -87,7 +87,7 @@ TEST(RepStorageTest, RepStorageAPI)
   // Create a REP handler.
   std::shared_ptr<transport::RepHandler<msgs::Vector3d,
     msgs::Int32>> rep1HandlerPtr(new transport::RepHandler<
-      msgs::Vector3d, msgs::Int32>());
+      msgs::Vector3d, msgs::Int32>(pUuid1, nUuid1));
 
   rep1HandlerPtr->SetCallback(cb1);
 
@@ -131,7 +131,7 @@ TEST(RepStorageTest, RepStorageAPI)
   // Create another REP handler without a callback for node1.
   std::shared_ptr<transport::RepHandler<msgs::Int32,
     msgs::Int32>> rep2HandlerPtr(new transport::RepHandler
-      <msgs::Int32, msgs::Int32>());
+      <msgs::Int32, msgs::Int32>(pUuid1, nUuid1));
 
   // Insert the handler.
   reps.AddHandler(topic, nUuid1, rep2HandlerPtr);
@@ -139,7 +139,7 @@ TEST(RepStorageTest, RepStorageAPI)
   // Create another REP handler without a callback for node1.
   std::shared_ptr<transport::RepHandler<msgs::Int32,
     msgs::Int32>> rep5HandlerPtr(new transport::RepHandler
-      <msgs::Int32, msgs::Int32>());
+      <msgs::Int32, msgs::Int32>(pUuid1, nUuid1));
 
   // Insert the handler.
   reps.AddHandler(topic, nUuid1, rep5HandlerPtr);
@@ -148,7 +148,7 @@ TEST(RepStorageTest, RepStorageAPI)
   // Create a REP handler without a callback for node2.
   std::shared_ptr<transport::RepHandler<msgs::Int32,
     msgs::Int32>> rep3HandlerPtr(new transport::RepHandler
-      <msgs::Int32, msgs::Int32>());
+      <msgs::Int32, msgs::Int32>(pUuid1, nUuid1));
 
   // Insert the handler and check operations.
   reps.AddHandler(topic, nUuid2, rep3HandlerPtr);
@@ -197,7 +197,7 @@ TEST(RepStorageTest, RepStorageAPI)
   // Insert another handler, remove it, and check that the map is empty.
   std::shared_ptr<transport::RepHandler<msgs::Int32,
     msgs::Int32>> rep4HandlerPtr(new transport::RepHandler
-      <msgs::Int32, msgs::Int32>());
+      <msgs::Int32, msgs::Int32>(pUuid1, nUuid1));
 
   // Insert the handler.
   reps.AddHandler(topic, nUuid1, rep3HandlerPtr);

--- a/src/Node.cc
+++ b/src/Node.cc
@@ -1183,13 +1183,11 @@ Node::Publisher Node::Advertise(const std::string &_topic,
     auto zPub = this->Shared()->dataPtr->session->declare_publisher(
      zenoh::KeyExpr(fullyQualifiedTopic));
 
-    auto zToken = this->Shared()->dataPtr->session->liveliness_declare_token(
-      "gz" +
-      fullyQualifiedTopic + "@" +
-      this->Shared()->pUuid + "@" +
-      this->NodeUuid() + "@" +
-      "pub@" +
+    std::string token = TopicUtils::CreateLivelinessToken(
+      fullyQualifiedTopic, this->Shared()->pUuid, this->NodeUuid(), "pub",
       _msgTypeName);
+    auto zToken =
+      this->Shared()->dataPtr->session->liveliness_declare_token(token);
 
     return Publisher(publisher, std::move(zPub), std::move(zToken));
   }

--- a/src/NodeShared.cc
+++ b/src/NodeShared.cc
@@ -330,7 +330,13 @@ NodeShared::NodeShared()
 #ifdef HAVE_ZENOH
   else if (this->GzImplementation() == "zenoh")
   {
-    this->dataPtr->msgDiscovery->Start(this->Session());
+    this->dataPtr->msgDiscovery->Start(this->Session(),
+      std::bind(&MsgDiscovery::LivelinessMsgDataHandler,
+            this->dataPtr->msgDiscovery.get(), std::placeholders::_1));
+
+    this->dataPtr->srvDiscovery->Start(this->Session(),
+      std::bind(&SrvDiscovery::LivelinessSrvDataHandler,
+            this->dataPtr->srvDiscovery.get(), std::placeholders::_1));
   }
 #endif
 

--- a/src/SubscriptionHandler.cc
+++ b/src/SubscriptionHandler.cc
@@ -17,6 +17,7 @@
 
 #include "gz/transport/config.hh"
 #include "gz/transport/SubscriptionHandler.hh"
+#include "gz/transport/TopicUtils.hh"
 
 #ifdef HAVE_ZENOH
 #include <zenoh.hxx>
@@ -181,14 +182,10 @@ namespace gz::transport
       _session->declare_subscriber(
         _topic, dataHandler, zenoh::closures::none));
 
+    std::string token = TopicUtils::CreateLivelinessToken(
+      _topic, this->ProcUuid(), this->NodeUuid(), "sub", this->TypeName());
     this->dataPtr->zToken = std::make_unique<zenoh::LivelinessToken>(
-      _session->liveliness_declare_token(
-        "gz" +
-        _topic + "@" +
-        this->ProcUuid() + "@" +
-        this->NodeUuid() + "@" +
-        "sub@" +
-        this->TypeName()));
+      _session->liveliness_declare_token(token));
   }
 #endif
 
@@ -251,14 +248,10 @@ namespace gz::transport
       _session->declare_subscriber(
         keyexpr, dataHandler, zenoh::closures::none));
 
+    std::string token = TopicUtils::CreateLivelinessToken(
+      _topic, this->ProcUuid(), this->NodeUuid(), "sub", this->TypeName());
     this->dataPtr->zToken = std::make_unique<zenoh::LivelinessToken>(
-        _session->liveliness_declare_token(
-          "gz" +
-          _topic + "@" +
-          this->ProcUuid() + "@" +
-          this->NodeUuid() + "@" +
-          "sub@" +
-          this->TypeName()));
+        _session->liveliness_declare_token(token));
 
     this->SetCallback(std::move(_cb));
   }

--- a/src/SubscriptionHandler.cc
+++ b/src/SubscriptionHandler.cc
@@ -93,8 +93,6 @@ namespace gz::transport
   /////////////////////////////////////////////////
   SubscriptionHandlerBase::~SubscriptionHandlerBase()
   {
-    if (dataPtr)
-      delete dataPtr;
   }
 
   /////////////////////////////////////////////////

--- a/src/TopicUtils.cc
+++ b/src/TopicUtils.cc
@@ -241,6 +241,99 @@ bool TopicUtils::DecomposeLivelinessToken(
 }
 
 //////////////////////////////////////////////////
+bool TopicUtils::DecomposeLivelinessToken(
+    const std::string &_token,
+    std::string &_prefix,
+    std::string &_partition,
+    std::string &_namespaceAndTopic,
+    std::string &_pUUID,
+    std::string &_nUUID,
+    std::string &_entityType,
+    std::string &_reqType,
+    std::string &_repType)
+{
+  auto nDelims = static_cast<int>(
+    std::count(_token.begin(), _token.end(), '@'));
+  if (nDelims != 7)
+    return false;
+
+  std::string token = _token;
+
+  std::size_t firstAt = token.find_first_of("@");
+  if ( firstAt == 0)
+    return false;
+
+  std::string possiblePrefix = token.substr(0, firstAt);
+  token.erase(0, firstAt + 1);
+
+  firstAt = token.find_first_of("@");
+  if ( firstAt == 0)
+    return false;
+
+  // Partition
+  std::string possiblePartition = token.substr(0, firstAt);
+  token.erase(0, firstAt + 1);
+
+  firstAt = token.find_first_of("@");
+  if ( firstAt == 0)
+    return false;
+
+  // Topic
+  std::string possibleTopic = token.substr(0, firstAt);
+  token.erase(0, firstAt + 1);
+
+  firstAt = token.find_first_of("@");
+  if ( firstAt == 0)
+    return false;
+
+  // Process UUID
+  std::string possibleProcUUID = token.substr(0, firstAt);
+  token.erase(0, firstAt + 1);
+
+  firstAt = token.find_first_of("@");
+  if ( firstAt == 0)
+    return false;
+
+  // Node UUID
+  std::string possibleNodeUUID = token.substr(0, firstAt);
+  token.erase(0, firstAt + 1);
+
+  firstAt = token.find_first_of("@");
+  if ( firstAt == 0)
+    return false;
+
+  // Entity type
+  std::string possibleEntityType = token.substr(0, firstAt);
+  token.erase(0, firstAt + 1);
+
+  firstAt = token.find_first_of("@");
+  if ( firstAt == 0)
+    return false;
+
+  // ReqType
+  std::string possibleReqType = token.substr(0, firstAt);;
+  token.erase(0, firstAt + 1);
+
+  // RepType
+  std::string possibleRepType = token;
+
+  if (!IsValidPartition(possiblePartition) || !IsValidTopic(possibleTopic))
+  {
+    return false;
+  }
+
+  _prefix = possiblePrefix;
+  _partition = possiblePartition;
+  _namespaceAndTopic = possibleTopic;
+  _pUUID = possibleProcUUID;
+  _nUUID = possibleNodeUUID;
+  _entityType = possibleEntityType;
+  _reqType = possibleReqType;
+  _repType = possibleRepType;
+  return true;
+}
+
+//////////////////////////////////////////////////
 std::string TopicUtils::AsValidTopic(const std::string &_topic)
 {
   std::string validTopic{_topic};
@@ -257,4 +350,40 @@ std::string TopicUtils::AsValidTopic(const std::string &_topic)
   }
 
   return validTopic;
+}
+
+//////////////////////////////////////////////////
+std::string TopicUtils::CreateLivelinessToken(
+  const std::string &_fullyQualifiedTopic,
+  const std::string &_pUuid,
+  const std::string &_nUuid,
+  const std::string &_entityType,
+  const std::string &_msgTypeName)
+{
+  return
+    kTokenPrefix +
+    _fullyQualifiedTopic + kTokenSeparator +
+    _pUuid + kTokenSeparator +
+    _nUuid + kTokenSeparator +
+    _entityType + kTokenSeparator +
+    _msgTypeName;
+}
+
+//////////////////////////////////////////////////
+std::string TopicUtils::CreateLivelinessToken(
+  const std::string &_fullyQualifiedTopic,
+  const std::string &_pUuid,
+  const std::string &_nUuid,
+  const std::string &_entityType,
+  const std::string &_reqTypeName,
+  const std::string &_repTypeName)
+{
+  return
+    kTokenPrefix +
+    _fullyQualifiedTopic + kTokenSeparator +
+    _pUuid + kTokenSeparator +
+    _nUuid + kTokenSeparator +
+    _entityType + kTokenSeparator +
+    _reqTypeName + kTokenSeparator +
+    _repTypeName;
 }

--- a/src/TopicUtils_TEST.cc
+++ b/src/TopicUtils_TEST.cc
@@ -117,8 +117,8 @@ TEST(TopicUtilsTest, decomposeFullyQualifiedTopic)
 }
 
 //////////////////////////////////////////////////
-/// \brief Decompose liveliness token.
-TEST(TopicUtilsTest, decomposeLivelinessToken)
+/// \brief Decompose msg liveliness token.
+TEST(TopicUtilsTest, decomposeMsgLivelinessToken)
 {
   std::string prefix;
   std::string partition;
@@ -141,8 +141,35 @@ TEST(TopicUtilsTest, decomposeLivelinessToken)
 }
 
 //////////////////////////////////////////////////
+/// \brief Decompose srv liveliness token.
+TEST(TopicUtilsTest, decomposeSrvLivelinessToken)
+{
+  std::string prefix;
+  std::string partition;
+  std::string topic;
+  std::string pUUID;
+  std::string nUUID;
+  std::string entityType;
+  std::string reqType;
+  std::string repType;
+
+  EXPECT_TRUE(transport::TopicUtils::DecomposeLivelinessToken(
+    "gz@/cold:caguero@/foo@ProcessUUID@NodeUUID@srv@gz.msgs.StringMsg"
+    "@gz.msgs.Int32",
+    prefix, partition, topic, pUUID, nUUID, entityType, reqType, repType));
+  EXPECT_EQ(std::string("gz"), prefix);
+  EXPECT_EQ(std::string("/cold:caguero"), partition);
+  EXPECT_EQ(std::string("/foo"), topic);
+  EXPECT_EQ(std::string("ProcessUUID"), pUUID);
+  EXPECT_EQ(std::string("NodeUUID"), nUUID);
+  EXPECT_EQ(std::string("srv"), entityType);
+  EXPECT_EQ(std::string("gz.msgs.StringMsg"), reqType);
+  EXPECT_EQ(std::string("gz.msgs.Int32"), repType);
+}
+
+//////////////////////////////////////////////////
 /// \brief Check the partition.
-TEST(TopicUtilsTest, tesPartitions)
+TEST(TopicUtilsTest, testPartitions)
 {
   EXPECT_TRUE(transport::TopicUtils::IsValidPartition("/abcde"));
   EXPECT_TRUE(transport::TopicUtils::IsValidPartition("abcde"));
@@ -313,4 +340,23 @@ TEST(TopicUtilsTest, asValidTopic)
     EXPECT_TRUE(empty.empty());
     EXPECT_FALSE(transport::TopicUtils::IsValidTopic(empty));
   }
+}
+
+//////////////////////////////////////////////////
+TEST(TopicUtilsTest, CreateMsgLivelinessToken)
+{
+  std::string token = transport::TopicUtils::CreateLivelinessToken(
+    "@/hostname:user", "processUUID", "nodeUUID", "pub", "gz::msgs::StringMsg");
+  EXPECT_EQ(
+    "gz@/hostname:user@processUUID@nodeUUID@pub@gz::msgs::StringMsg", token);
+}
+
+//////////////////////////////////////////////////
+TEST(TopicUtilsTest, CreateSrvLivelinessToken)
+{
+  std::string token = transport::TopicUtils::CreateLivelinessToken(
+    "@/hostname:user", "processUUID", "nodeUUID", "pub", "gz::msgs::StringMsg",
+    "gz::msgs::Empty");
+  EXPECT_EQ("gz@/hostname:user@processUUID@nodeUUID@pub@gz::msgs::StringMsg"
+    "@gz::msgs::Empty", token);
 }


### PR DESCRIPTION
Adds Zenoh graph cache support for async services.

### How to test it

Compile the examples and run a service provider:

```
GZ_TRANSPORT_IMPLEMENTATION=zenoh ./responser
```
and
```
GZ_TRANSPORT_IMPLEMENTATION=zenoh gz service -l
```
You should see the service `/echo`.

You can repeat the previous examples replacing `zenoh` with `zeromq` to verify that nothing is broken.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.**