### PR TITLE
Zenoh - Part 6: Implement synchronous/oneway/no_input services

### DIFF
--- a/include/gz/transport/ReqHandler.hh
+++ b/include/gz/transport/ReqHandler.hh
@@ -138,9 +138,8 @@ namespace gz::transport
     /// \brief Create a Zenoh get.
     /// \param[in] _session Zenoh session.
     /// \param[in] _service The service.
-    protected: void CreateZenohGet(
-      std::shared_ptr<zenoh::Session> _session,
-      const std::string &_service);
+    public: void CreateZenohGet(std::shared_ptr<zenoh::Session> _session,
+                                const std::string &_service);
 #endif
 
 #ifdef _WIN32

--- a/src/RepHandler.cc
+++ b/src/RepHandler.cc
@@ -92,8 +92,12 @@ namespace gz::transport
     auto onQuery = [this, _service](const zenoh::Query &_query)
     {
       std::string output;
-      this->RunCallback(_query.get_payload()->get().as_string(), output);
-      _query.reply(_service, output);
+      std::string input = "";
+      if (_query.get_payload())
+        input = _query.get_payload()->get().as_string();
+
+      if (this->RunCallback(input, output))
+        _query.reply(_service, output);
     };
 
     auto onDropQueryable = []() {};


### PR DESCRIPTION
# 🎉 New feature

This PR implements the rest of the services: synchronous, oneway and no_input.

### How to test the req/rep?

Compile the examples and try all these combinations:

```
responser / requester
responser / requester_async
responser / requester_raw
responser_oneway / requester_oneway
responser_no_input / requester_no_input
responser_no_input / requester_async_no_input
```

Here's an example:

```
GZ_TRANSPORT_IMPLEMENTATION=zenoh ./responser
```
and
```
GZ_TRANSPORT_IMPLEMENTATION=zenoh ./requester
```
You can repeat the previous examples replacing `zenoh` with `zeromq`.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.**
