### PR TITLE
BugFix :  Failure to catch after throwing an error causes a crash

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-    "ros.distro": "rolling",
-    "files.associations": {
-        "stdexcept": "cpp"
-    }
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "ros.distro": "rolling",
+    "files.associations": {
+        "stdexcept": "cpp"
+    }
+}

--- a/parameters/src/cmd/ParamCommandAPI.cc
+++ b/parameters/src/cmd/ParamCommandAPI.cc
@@ -42,15 +42,22 @@ extern "C" void cmdParametersList(const char * _ns)
 
   std::cout << std::endl << "Listing parameters, registry namespace [" << _ns
             << "]..." << std::endl << std::endl;
-
-  auto res = client.ListParameters();
-  if (!res.parameter_declarations_size()) {
-    std::cout << "No parameters available" << std::endl;
-    return;
-  }
-  for (const auto & decl : res.parameter_declarations()) {
-    std::cout << decl.name() << "            [" << decl.type() << "]"
-              << std::endl;
+  try {
+    auto res = client.ListParameters();
+    if (!res.parameter_declarations_size()) {
+      std::cout << "No parameters available" << std::endl;
+      return;
+    }
+    for (const auto & decl : res.parameter_declarations()) {
+      std::cout << decl.name() << "            [" << decl.type() << "]"
+                << std::endl;
+    }
+  } catch (const std::runtime_error& e) {
+    std::cerr << "Error listing parameters: " << e.what() << std::endl;
+    std::cerr << "\nPossible causes:" << std::endl;
+    std::cerr << "1. Parameter server not running" << std::endl;
+    std::cerr << "2. Invalid namespace: '" << _ns << "'" << std::endl;
+    std::cerr << "3. Network communication issue" << std::endl;
   }
 }
 


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #661 

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->
You can reproduce the crash according to #661 
Before the fix: gazebo crashes with a stack trace.
After the fix: gazebo prints a user-friendly error message and exits without crashing.
## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers


