### PR TITLE
Zenoh - Part 7: Enable pub sub tests and remove hardcoded block

### DIFF
--- a/src/Discovery.hh
+++ b/src/Discovery.hh
@@ -302,7 +302,7 @@ namespace gz
         };
 
         MessagePublisher pub(
-          "@" + partition + "@" + topic, "", "", pUUID, nUUID, msgType,
+          "@" + partition + "@" + topic, "", this->pUuid, pUUID, nUUID, msgType,
           AdvertiseMessageOptions());
 
         {

--- a/src/NodeShared.cc
+++ b/src/NodeShared.cc
@@ -583,12 +583,6 @@ NodeShared::SubscriberInfo NodeShared::CheckSubscriberInfo(
   info.haveRemote = this->remoteSubscribers.HasTopic(
         _topic, _msgType);
 
-  if (this->GzImplementation() == "zenoh")
-  {
-    // For now we fake that there are always remote subscribers.
-    info.haveRemote = true;
-  }
-
   return info;
 }
 

--- a/src/Node_TEST.cc
+++ b/src/Node_TEST.cc
@@ -539,8 +539,6 @@ TEST(NodePubTest, BoolOperatorTest)
 /// \brief A message should not be published if it is not advertised before.
 TEST(NodeTest, PubWithoutAdvertise)
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
-
   reset();
 
   msgs::Int32 msg;
@@ -651,8 +649,6 @@ TEST(NodeTest, PubSubSameThread)
 /// \brief A thread can create a node, and send and receive messages.
 TEST(NodeTest, PubSubSameThreadGenericCb)
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
-
   reset();
 
   msgs::Int32 msg;
@@ -697,8 +693,6 @@ TEST(NodeTest, PubSubSameThreadGenericCb)
 /// information.
 TEST(NodeTest, PubSubSameThreadMessageInfo)
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
-
   reset();
 
   msgs::Int32 msg;
@@ -781,8 +775,6 @@ TEST(NodeTest, RawPubSubSameThreadMessageInfo)
 //////////////////////////////////////////////////
 TEST(NodeTest, RawPubRawSubSameThreadMessageInfo)
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
-
   reset();
 
   msgs::Int32 msg;
@@ -825,8 +817,6 @@ TEST(NodeTest, RawPubRawSubSameThreadMessageInfo)
 //////////////////////////////////////////////////
 TEST(NodeTest, PubRawSubSameThreadMessageInfo)
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
-
   reset();
 
   msgs::Int32 msg;
@@ -915,8 +905,6 @@ TEST(NodeTest, PubSubSameThreadLambda)
 /// information.
 TEST(NodeTest, PubSubSameThreadLambdaMessageInfo)
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
-
   reset();
 
   msgs::Int32 msg;
@@ -1044,8 +1032,6 @@ TEST(NodeTest, PubSubWithCreateSubscriber)
 /// \brief Subscribe to a topic using dfferent Subscribe APIs
 TEST(NodeTest, PubSubWithMixedSubscribeAPIs)
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
-
   reset();
 
   msgs::Int32 msg;
@@ -1380,8 +1366,6 @@ TEST(NodeTest, ClassMemberCallbackMessage)
 /// publish. This test uses a callback that accepts message information.
 TEST(NodeTest, ClassMemberCallbackMessageInfo)
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
-
   MyTestClass client;
   client.SubscribeWithMessageInfo();
 
@@ -2159,8 +2143,6 @@ TEST(NodeTest, PubSubWrongTypesOnPublish)
 /// the advertised types.
 TEST(NodeTest, PubSubWrongTypesOnSubscription)
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
-
   reset();
 
   msgs::Vector3d msgV;
@@ -2193,8 +2175,6 @@ TEST(NodeTest, PubSubWrongTypesOnSubscription)
 /// advertised type). Check that only the good callback is executed.
 TEST(NodeTest, PubSubWrongTypesTwoSubscribers)
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
-
   reset();
 
   msgs::Int32 msg;
@@ -2269,8 +2249,6 @@ TEST(NodeTest, SubThrottled)
 /// publishes at a throttled frequency .
 TEST(NodeTest, PubThrottled)
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
-
   reset();
 
   msgs::Int32 msg;
@@ -2309,8 +2287,6 @@ TEST(NodeTest, PubThrottled)
 /// is set to true.
 TEST(NodeTest, IgnoreLocalMessages)
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
-
   reset();
 
   msgs::Int32 msg;
@@ -2508,8 +2484,6 @@ TEST(NodeTest, SrvWithoutInputTwoRequestsOneWrong)
 /// verifies that TopicList() returns the list of all the topics advertised.
 TEST(NodeTest, TopicList)
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
-
   std::vector<std::string> topics;
   transport::Node node1;
   transport::Node node2;
@@ -2540,8 +2514,6 @@ TEST(NodeTest, TopicList)
 /// Topic remapping is enabled.
 TEST(NodeTest, TopicListRemap)
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
-
   std::vector<std::string> topics;
   transport::NodeOptions nodeOptions;
   nodeOptions.AddTopicRemap(g_topic, g_topic_remap);

--- a/test/integration/twoProcsPubSub.cc
+++ b/test/integration/twoProcsPubSub.cc
@@ -107,8 +107,6 @@ void cbRaw(const char * /*_msgData*/, const size_t /*_size*/,
 /// node receives the message.
 TEST(twoProcPubSub, PubSubTwoProcsThreeNodes)
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
-
   transport::Node node;
   auto pub = node.Advertise<msgs::Vector3d>(g_topic);
   EXPECT_TRUE(pub);
@@ -142,8 +140,6 @@ TEST(twoProcPubSub, PubSubTwoProcsThreeNodes)
 /// of Publish(~).
 TEST(twoProcPubSub, RawPubSubTwoProcsThreeNodes)
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
-
   transport::Node node;
   auto pub = node.Advertise<msgs::Vector3d>(g_topic);
   EXPECT_TRUE(pub);
@@ -174,6 +170,8 @@ TEST(twoProcPubSub, RawPubSubTwoProcsThreeNodes)
           std::string(msg.GetTypeName())));
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
   }
+
+  reset();
 }
 
 //////////////////////////////////////////////////
@@ -392,8 +390,6 @@ TEST(twoProcPubSub, PubThrottled)
 /// using a callback that accepts message information.
 TEST(twoProcPubSub, PubSubMessageInfo)
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
-
   auto pi = gz::utils::Subprocess(
     {test_executables::kTwoProcsPublisher, partition});
   reset();
@@ -549,8 +545,6 @@ TEST(twoProcPubSub, PubSubTwoProcsScopedPub)
 /// After that check that only one remaining subscriber receives the message.
 TEST(twoProcPubSub, PubSubTwoProcsMixedSubscribers)
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
-
   transport::Node node;
   auto pub = node.Advertise<msgs::Vector3d>(g_topic);
   EXPECT_TRUE(pub);


### PR DESCRIPTION
# 🎉 New feature

This PR removes some hardcoded block that was telling gz transport that there was always a remote subscriber. It enables most of the pub/sub tests.

### How to test the req/rep?

The tests should pass.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.**
