### PR TITLE
Add cmake option to disable building gz-transport with zenoh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
           cppcheck-enabled: true
           cpplint-enabled: true
           doxygen-enabled: true
+          cmake-args: '-DGZ_TRANSPORT_ENABLE_ZENOH=OFF'
   noble-ci-zenoh:
     runs-on: ubuntu-latest
     name: Ubuntu Noble CI - Zenoh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,6 @@ on:
       - 'ign-transport[0-9]?'
       - 'gz-transport[0-9]?'
       - 'main'
-      - 'iche033/zenoh_main_enable_zenoh'
 
 jobs:
   noble-ci:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
       - 'ign-transport[0-9]?'
       - 'gz-transport[0-9]?'
       - 'main'
+      - 'iche033/zenoh_main_enable_zenoh'
 
 jobs:
   noble-ci:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,34 +97,38 @@ gz_find_package(CPPZMQ REQUIRED PRIVATE
 
 ########################################
 # Find Zenoh
-gz_find_package(zenohc PRIVATE QUIET)
-gz_find_package(zenohcxx PRIVATE QUIET)
+option(GZ_TRANSPORT_ENABLE_ZENOH "Enable gz-transport zenoh implementation" ON)
 
-# If both zenohc and zenohcpp packages are not found then
-# look for these pacakages installed by ROS 2 zenoh_cpp_vendor package
-if (NOT zenohc_FOUND AND NOT zenohcxx_FOUND)
-  # Set CMAKE_PREFIX_PATH in order to find ROS 2 packages from plain cmake
-  # package, see https://github.com/ament/ament_cmake/issues/304
-  set(ros2_zenoh_cmake_path "/opt/ros/$ENV{ROS_DISTRO}/opt/zenoh_cpp_vendor/lib/cmake")
-  if (EXISTS ${ros2_zenoh_cmake_path})
-    list(PREPEND CMAKE_PREFIX_PATH ${ros2_zenoh_cmake_path})
-    gz_find_package(zenohc PRIVATE QUIET)
-    gz_find_package(zenohcxx PRIVATE QUIET)
-  endif()
-endif ()
+if (ENABLE_ZENOH)
+  gz_find_package(zenohc PRIVATE QUIET)
+  gz_find_package(zenohcxx PRIVATE QUIET)
 
-if (NOT zenohcxx_FOUND)
-  message (STATUS "Looking for zenohcxx - not found")
-  set (HAVE_ZENOH OFF CACHE BOOL "HAVE ZENOH" FORCE)
-elseif (NOT zenohc_FOUND)
-  message (STATUS "Looking for zenohc - not found")
-  set (HAVE_ZENOH OFF CACHE BOOL "HAVE ZENOH" FORCE)
-else ()
-  message (STATUS "Looking for zenohcxx and zenohc - found")
-  set (HAVE_ZENOH ON CACHE BOOL "HAVE ZENOH" FORCE)
-  list(APPEND EXTRA_TEST_LIB_DEPS "zenohcxx::zenohc")
-  list(APPEND GZ_TRANSPORT_IMPLEMENTATION_LIST "zenoh")
-endif ()
+  # If both zenohc and zenohcpp packages are not found then
+  # look for these pacakages installed by ROS 2 zenoh_cpp_vendor package
+  if (NOT zenohc_FOUND AND NOT zenohcxx_FOUND)
+    # Set CMAKE_PREFIX_PATH in order to find ROS 2 packages from plain cmake
+    # package, see https://github.com/ament/ament_cmake/issues/304
+    set(ros2_zenoh_cmake_path "/opt/ros/$ENV{ROS_DISTRO}/opt/zenoh_cpp_vendor/lib/cmake")
+    if (EXISTS ${ros2_zenoh_cmake_path})
+      list(PREPEND CMAKE_PREFIX_PATH ${ros2_zenoh_cmake_path})
+      gz_find_package(zenohc PRIVATE QUIET)
+      gz_find_package(zenohcxx PRIVATE QUIET)
+    endif()
+  endif ()
+
+  if (NOT zenohcxx_FOUND)
+    message (STATUS "Looking for zenohcxx - not found")
+    set (HAVE_ZENOH OFF CACHE BOOL "HAVE ZENOH" FORCE)
+  elseif (NOT zenohc_FOUND)
+    message (STATUS "Looking for zenohc - not found")
+    set (HAVE_ZENOH OFF CACHE BOOL "HAVE ZENOH" FORCE)
+  else ()
+    message (STATUS "Looking for zenohcxx and zenohc - found")
+    set (HAVE_ZENOH ON CACHE BOOL "HAVE ZENOH" FORCE)
+    list(APPEND EXTRA_TEST_LIB_DEPS "zenohcxx::zenohc")
+    list(APPEND GZ_TRANSPORT_IMPLEMENTATION_LIST "zenoh")
+  endif ()
+endif()
 
 #--------------------------------------
 # Find uuid

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,7 +99,7 @@ gz_find_package(CPPZMQ REQUIRED PRIVATE
 # Find Zenoh
 option(GZ_TRANSPORT_ENABLE_ZENOH "Enable gz-transport zenoh implementation" ON)
 
-if (ENABLE_ZENOH)
+if (GZ_TRANSPORT_ENABLE_ZENOH)
   gz_find_package(zenohc PRIVATE QUIET)
   gz_find_package(zenohcxx PRIVATE QUIET)
 


### PR DESCRIPTION
# 🎉 New feature


## Summary

Adds a cmake option, `GZ_TRANSPORT_ENABLE_ZENOH`, for disabling building the zenoh implementation. The variable is `ON` by default (zenoh will be built if available).

We currently have 2 noble github ci actions
* `Ubuntu Noble CI`: Builds gz-transport with zeromq and zenoh. Runs tests using **zeromq**
* `Ubuntu Noble CI -Zenoh`: Builds gz-transport zeromq and zenoh. Runs tests using **zenoh**

I updated the `Ubuntu Noble CI` job to disable building gz-transport with zenoh by setting `GZ_TRANSPORT_ENABLE_ZENOH=OFF` so that we can catch build errors when zenoh is not available.

See example [github action runs](https://github.com/gazebosim/gz-transport/actions/runs/16331997700). In the `Ubuntu Noble CI` build, cmake no longer tries to find zenoh and continues building gz-transport with zeromq only.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
