### PR TITLE
Fix deadlock in service requests when running local callbacks

### DIFF
--- a/include/gz/transport/detail/Node.hh
+++ b/include/gz/transport/detail/Node.hh
@@ -576,19 +576,24 @@ namespace gz::transport
     reqHandlerPtr->SetMessage(&_request);
     reqHandlerPtr->SetResponse(&_reply);
 
-    std::unique_lock<std::recursive_mutex> lk(this->Shared()->mutex);
+    bool localResponserFound;
+    IRepHandlerPtr repHandler;
+    {
+      std::lock_guard<std::recursive_mutex> lk(this->Shared()->mutex);
+      localResponserFound = this->Shared()->repliers.FirstHandler(
+          fullyQualifiedTopic, std::string(_request.GetTypeName()),
+          std::string(_reply.GetTypeName()), repHandler);
+    }
 
     // If the responser is within my process.
-    IRepHandlerPtr repHandler;
-    if (this->Shared()->repliers.FirstHandler(fullyQualifiedTopic,
-      std::string(_request.GetTypeName()),
-      std::string(_reply.GetTypeName()), repHandler))
+    if (localResponserFound)
     {
       // There is a responser in my process, let's use it.
       _result = repHandler->RunLocalCallback(_request, _reply);
       return true;
     }
 
+    std::unique_lock<std::recursive_mutex> lk(this->Shared()->mutex);
     // Store the request handler.
     this->Shared()->requests.AddHandler(
       fullyQualifiedTopic, this->NodeUuid(), reqHandlerPtr);


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

There scope of the mutex lock is unnecessarily large which causes deadlocks in service requests when running local callbacks. This PR uses the same approach as the `Node::Request` shown below to reduce the scope of the mutex:

https://github.com/gazebosim/gz-transport/blob/68a3fb272aa2ca16e037e85940441e5b6be85779/include/gz/transport/detail/Node.hh#L427-L466

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
