### PR TITLE
Fix compatibility with protobuf v30 (cpp 6.30.0) regression

### DIFF
--- a/test/integration/test_executables/twoProcsPubSubMixedSubscribers_aux.cc
+++ b/test/integration/test_executables/twoProcsPubSubMixedSubscribers_aux.cc
@@ -97,7 +97,7 @@ void runSubscriber()
   // Subscribe to topic using a mix of Subscribe / CreateSubscriber APIs
   EXPECT_TRUE(node.Subscribe(g_topic, cb));
   EXPECT_TRUE(node.SubscribeRaw(g_topic, cbRaw,
-                                msgs::Vector3d().GetTypeName()));
+                                std::string(msgs::Vector3d().GetTypeName())));
   transport::Node::Subscriber sub = node.CreateSubscriber(g_topic, cbCreateSub);
   EXPECT_TRUE(sub);
   transport::Node::Subscriber sub2 = node.CreateSubscriber(g_topic,


### PR DESCRIPTION
# 🦟 Bug fix

https://github.com/gazebosim/gz-transport/pull/615 fixed compatibility with protobuf v30, but https://github.com/gazebosim/gz-transport/pull/608 reintroduced an incompatibility, that is fixed by this PR.

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

