### PR TITLE
Add compatibility with protobuf 28

### DIFF
--- a/include/gz/transport/RepHandler.hh
+++ b/include/gz/transport/RepHandler.hh
@@ -138,7 +138,13 @@ namespace ignition::transport
         return false;
       }
 
-#if GOOGLE_PROTOBUF_VERSION >= 4022000
+
+#if GOOGLE_PROTOBUF_VERSION >= 5028000
+      const auto msgReq =
+        google::protobuf::DynamicCastMessage<Req>(&_msgReq);
+      auto msgRep =
+          google::protobuf::DynamicCastMessage<Rep>(&_msgRep);
+#elif GOOGLE_PROTOBUF_VERSION >= 4022000
       auto msgReq =
         google::protobuf::internal::DownCast<const Req*>(&_msgReq);
       auto msgRep = google::protobuf::internal::DownCast<Rep*>(&_msgRep);
@@ -150,6 +156,45 @@ namespace ignition::transport
         google::protobuf::internal::down_cast<const Req*>(&_msgReq);
       auto msgRep = google::protobuf::internal::down_cast<Rep*>(&_msgRep);
 #endif
+
+      // Verify the dynamically casted messages are valid
+      if (msgReq == nullptr || msgRep == nullptr)
+      {
+        if (msgReq == nullptr)
+        {
+          if (_msgReq.GetDescriptor() != nullptr)
+          {
+            std::cerr << "RepHandler::RunLocalCallback() error: "
+                      << "Failed to cast the request of the type "
+                      << _msgReq.GetDescriptor()->full_name()
+                      << " to the specified type" << '\n';
+          }
+          else
+          {
+            std::cerr << "RepHandler::RunLocalCallback() error: "
+                      << "Failed to cast the request of an unknown type"
+                      << " to the specified type" << '\n';
+          }
+        }
+        if (msgRep == nullptr)
+        {
+          if (_msgRep.GetDescriptor() != nullptr)
+          {
+            std::cerr << "RepHandler::RunLocalCallback() error: "
+                      << "Failed to cast the response of the type "
+                      << _msgRep.GetDescriptor()->full_name()
+                      << " to the specified type" << '\n';
+          }
+          else
+          {
+            std::cerr << "RepHandler::RunLocalCallback() error: "
+                      << "Failed to cast the response of an unknown type"
+                      << " to the specified type" << '\n';
+          }
+        }
+        std::cerr.flush();
+        return false;
+      }
 
       return this->cb(*msgReq, *msgRep);
     }

--- a/include/gz/transport/SubscriptionHandler.hh
+++ b/include/gz/transport/SubscriptionHandler.hh
@@ -209,13 +209,35 @@ namespace ignition::transport
       if (!this->UpdateThrottling())
         return true;
 
-#if GOOGLE_PROTOBUF_VERSION >= 4022000
+#if GOOGLE_PROTOBUF_VERSION >= 5028000
+      auto msgPtr = google::protobuf::DynamicCastMessage<T>(&_msg);
+#elif GOOGLE_PROTOBUF_VERSION >= 4022000
       auto msgPtr = google::protobuf::internal::DownCast<const T*>(&_msg);
 #elif GOOGLE_PROTOBUF_VERSION >= 3000000
       auto msgPtr = google::protobuf::down_cast<const T*>(&_msg);
 #else
       auto msgPtr = google::protobuf::internal::down_cast<const T*>(&_msg);
 #endif
+
+      // Verify the dynamically casted message is valid
+      if (msgPtr == nullptr)
+      {
+        if (_msg.GetDescriptor() != nullptr)
+        {
+          std::cerr << "SubscriptionHandler::RunLocalCallback() error: "
+                    << "Failed to cast the message of the type "
+                    << _msg.GetDescriptor()->full_name()
+                    << " to the specified type" << '\n';
+        }
+        else
+        {
+          std::cerr << "SubscriptionHandler::RunLocalCallback() error: "
+                    << "Failed to cast the message of an unknown type"
+                    << " to the specified type" << '\n';
+        }
+        std::cerr.flush();
+        return false;
+      }
 
       this->cb(*msgPtr, _info);
       return true;


### PR DESCRIPTION
# 🦟 Bug fix

Fixes compatibility of ign-transport11 with protobuf 28, backport of https://github.com/gazebosim/gz-transport/pull/541 .

## Summary


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

