### PR TITLE
Zenoh - Part 10: Fixes and enable more tests

### DIFF
--- a/log/test/integration/recorder.cc
+++ b/log/test/integration/recorder.cc
@@ -76,7 +76,7 @@ void VerifyMessage(const gz::transport::log::Message &_msg,
 TEST(recorder,
   GZ_UTILS_TEST_DISABLED_ON_MAC(BeginRecordingTopicsBeforeAdvertisement))
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
+  //CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
 
   // Remember to include a leading slash so that the VerifyTopic lambda below
   // will work correctly. gz-transport automatically adds a leading slash to

--- a/src/Node.cc
+++ b/src/Node.cc
@@ -1145,7 +1145,7 @@ Node::Publisher Node::Advertise(const std::string &_topic,
   auto currentTopics = this->AdvertisedTopics();
 
   if (std::find(currentTopics.begin(), currentTopics.end(),
-        fullyQualifiedTopic) != currentTopics.end())
+        _topic) != currentTopics.end())
   {
     std::cerr << "Topic [" << topic << "] already advertised. You cannot"
       << " advertise the same topic twice on the same node."

--- a/src/Node_TEST.cc
+++ b/src/Node_TEST.cc
@@ -1173,8 +1173,6 @@ TEST(NodeTest, PubSubWithMixedSubscribeAPIs)
 /// within the same node but it's valid on separate nodes.
 TEST(NodeTest, AdvertiseTwoEqualTopics)
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
-
   transport::Node node1;
   transport::Node node2;
 

--- a/src/cmd/gz_TEST.cc
+++ b/src/cmd/gz_TEST.cc
@@ -124,8 +124,6 @@ exec_with_retry(const std::vector<std::string> &_args,
 /// \brief Check 'gz topic -l' running the advertiser on a different process.
 TEST(gzTest, GZ_UTILS_TEST_DISABLED_ON_MAC(TopicList))
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
-
   auto proc = gz::utils::Subprocess({
     test_executables::kTwoProcsPublisher, g_partition});
 
@@ -141,8 +139,6 @@ TEST(gzTest, GZ_UTILS_TEST_DISABLED_ON_MAC(TopicList))
 /// \brief Check 'gz topic -l' running a subscriber on a different process.
 TEST(gzTest, TopicListSub)
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
-
   transport::Node node;
   node.Subscribe("/foo", topicCB);
   node.Subscribe("/bar", genericCb);
@@ -166,8 +162,6 @@ TEST(gzTest, TopicListSub)
 /// \brief Check 'gz topic -i' running the advertiser on a different process.
 TEST(gzTest, TopicInfo)
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
-
   // Launch a new publisher process that advertises a topic.
   auto proc = gz::utils::Subprocess({
     test_executables::kTwoProcsPublisher, g_partition});
@@ -189,8 +183,6 @@ TEST(gzTest, TopicInfo)
 /// process.
 TEST(gzTest, ServiceList)
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
-
   // Launch a new responser process that advertises a service.
   auto proc = gz::utils::Subprocess({
     test_executables::kTwoProcsSrvCallReplier, g_partition});
@@ -207,8 +199,6 @@ TEST(gzTest, ServiceList)
 /// \brief Check 'gz service -i' running the advertiser on a different process.
 TEST(gzTest, ServiceInfo)
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
-
   // Launch a new responser process that advertises a service.
   auto proc = gz::utils::Subprocess(
     {test_executables::kTwoProcsSrvCallReplier, g_partition});
@@ -226,8 +216,6 @@ TEST(gzTest, ServiceInfo)
 /// \brief Check 'gz topic -l' running the advertiser on the same process.
 TEST(gzTest, TopicListSameProc)
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
-
   transport::Node node;
 
   msgs::Vector3d msg;
@@ -251,8 +239,6 @@ TEST(gzTest, TopicListSameProc)
 /// \brief Check 'gz topic -i' running the advertiser on the same process.
 TEST(gzTest, TopicInfoSameProc)
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
-
   transport::Node node;
 
   msgs::Vector3d msg;
@@ -277,8 +263,6 @@ TEST(gzTest, TopicInfoSameProc)
 /// \brief Check 'gz service -l' running the advertiser on the same process.
 TEST(gzTest, ServiceListSameProc)
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
-
   transport::Node node;
   EXPECT_TRUE(node.Advertise("/foo", srvEcho));
 
@@ -294,8 +278,6 @@ TEST(gzTest, ServiceListSameProc)
 /// \brief Check 'gz service -i' running the advertiser on the same process.
 TEST(gzTest, ServiceInfoSameProc)
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
-
   transport::Node node;
   EXPECT_TRUE(node.Advertise("/foo", srvEcho));
 
@@ -312,8 +294,6 @@ TEST(gzTest, ServiceInfoSameProc)
 /// \brief Check 'gz topic -p' to send a message.
 TEST(gzTest, TopicPublish)
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
-
   transport::Node node;
   g_topicCBStr = "bad_value";
   EXPECT_TRUE(node.Subscribe("/bar", topicCB));
@@ -366,8 +346,6 @@ TEST(gzTest, TopicPublish)
 /// \brief Check 'gz service -r' to request a two-way service.
 TEST(gzTest, ServiceRequest)
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
-
   transport::Node node;
 
   // Advertise a service.
@@ -392,8 +370,6 @@ TEST(gzTest, ServiceRequest)
 /// \brief Check 'gz service -r' to request a two-way service without timeout.
 TEST(gzTest, ServiceRequestNoTimeout)
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
-
   transport::Node node;
 
   // Advertise a service.
@@ -417,8 +393,6 @@ TEST(gzTest, ServiceRequestNoTimeout)
 /// \brief Check 'gz service -r' to request a one-way service.
 TEST(gzTest, ServiceOnewayRequest)
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
-
   g_topicCBStr = "bad_value";
   transport::Node node;
 
@@ -442,8 +416,6 @@ TEST(gzTest, ServiceOnewayRequest)
 /// \brief Check 'gz service -r' to request a service without input args.
 TEST(gzTest, ServiceRequestNoInput)
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
-
   // Advertise a service.
   transport::Node node;
   std::string service = "/no_input";
@@ -461,8 +433,6 @@ TEST(gzTest, ServiceRequestNoInput)
 /// \brief Check 'gz topic -e' running the publisher on a separate process.
 TEST(gzTest, TopicEcho)
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
-
   // Launch a new publisher process that advertises a topic.
   auto proc = gz::utils::Subprocess(
     {test_executables::kTwoProcsPublisher, g_partition});
@@ -480,8 +450,6 @@ TEST(gzTest, TopicEcho)
 /// process.
 TEST(gzTest, TopicEchoNum)
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
-
   // Launch a new publisher process that advertises a topic.
   auto proc = gz::utils::Subprocess(
     {test_executables::kTwoProcsPublisher, g_partition});
@@ -516,8 +484,6 @@ TEST(gzTest, TopicEchoNum)
 /// consistent flags
 TEST(gzTest, GZ_UTILS_TEST_ENABLED_ONLY_ON_LINUX(ServiceHelpVsCompletionFlags))
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
-
   // Flags in help message
   auto helpOutput = custom_exec_str({"service",  "--help"});
 
@@ -551,8 +517,6 @@ TEST(gzTest, GZ_UTILS_TEST_ENABLED_ONLY_ON_LINUX(ServiceHelpVsCompletionFlags))
 /// consistent flags
 TEST(gzTest, GZ_UTILS_TEST_ENABLED_ONLY_ON_LINUX(TopicHelpVsCompletionFlags))
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
-
   // Flags in help message
   auto helpOutput = custom_exec_str({"topic",  "--help"});
 

--- a/src/cmd/gz_src_TEST.cc
+++ b/src/cmd/gz_src_TEST.cc
@@ -79,8 +79,6 @@ bool srvEcho(const msgs::Int32 &_req, msgs::Int32 &_rep)
 /// \brief Check cmdTopicInfo running the advertiser on a the same process.
 TEST(gzTest, cmdTopicInfo)
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
-
   std::stringstream stdOutBuffer;
   std::stringstream stdErrBuffer;
   redirectIO(stdOutBuffer, stdErrBuffer);
@@ -107,8 +105,6 @@ TEST(gzTest, cmdTopicInfo)
 /// \brief Check cmdServiceInfo running the advertiser on a the same process.
 TEST(gzTest, cmdServiceInfo)
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
-
   std::stringstream stdOutBuffer;
   std::stringstream stdErrBuffer;
   redirectIO(stdOutBuffer, stdErrBuffer);
@@ -133,8 +129,6 @@ TEST(gzTest, cmdServiceInfo)
 /// \brief Check cmdTopicPub running the advertiser on a the same process.
 TEST(gzTest, cmdTopicPub)
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
-
   std::stringstream stdOutBuffer;
   std::stringstream stdErrBuffer;
   redirectIO(stdOutBuffer, stdErrBuffer);
@@ -163,8 +157,6 @@ TEST(gzTest, cmdTopicPub)
 /// \brief Check cmdServiceReq running the advertiser on a the same process.
 TEST(gzTest, cmdServiceReq)
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
-
   std::stringstream  stdOutBuffer;
   std::stringstream  stdErrBuffer;
   redirectIO(stdOutBuffer, stdErrBuffer);
@@ -238,8 +230,6 @@ TEST(gzTest, cmdServiceReq)
 /// \brief Check cmdTopicEcho running the advertiser on a the same process.
 TEST(gzTest, cmdTopicEcho)
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
-
   std::stringstream  stdOutBuffer;
   std::stringstream  stdErrBuffer;
   redirectIO(stdOutBuffer, stdErrBuffer);
@@ -262,8 +252,6 @@ TEST(gzTest, cmdTopicEcho)
 /////////////////////////////////////////////////
 TEST(gzTest, cmdTopicEchoOutputFormats)
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
-
   std::stringstream  stdOutBuffer;
   std::stringstream  stdErrBuffer;
   redirectIO(stdOutBuffer, stdErrBuffer);

--- a/test/integration/twoProcsPubSub.cc
+++ b/test/integration/twoProcsPubSub.cc
@@ -179,8 +179,6 @@ TEST(twoProcPubSub, RawPubSubTwoProcsThreeNodes)
 /// the advertised types.
 TEST(twoProcPubSub, PubSubWrongTypesOnSubscription)
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
-
   auto pi = gz::utils::Subprocess(
     {test_executables::kTwoProcsPublisher, partition});
 
@@ -202,8 +200,6 @@ TEST(twoProcPubSub, PubSubWrongTypesOnSubscription)
 /// \brief Same as above, but using a raw subscription.
 TEST(twoProcPubSub, PubRawSubWrongTypesOnSubscription)
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
-
   auto pi = gz::utils::Subprocess(
     {test_executables::kTwoProcsPublisher, partition});
 
@@ -230,8 +226,6 @@ TEST(twoProcPubSub, PubRawSubWrongTypesOnSubscription)
 /// (correct and generic).
 TEST(twoProcPubSub, PubSubWrongTypesTwoSubscribers)
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
-
   auto pi = gz::utils::Subprocess(
     {test_executables::kTwoProcsPublisher, partition});
 
@@ -265,8 +259,6 @@ TEST(twoProcPubSub, PubSubWrongTypesTwoSubscribers)
 /// callbacks are executed (correct and generic).
 TEST(twoProcPubSub, PubSubWrongTypesTwoRawSubscribers)
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
-
   auto pi = gz::utils::Subprocess(
     {test_executables::kTwoProcsPublisher, partition});
 
@@ -412,8 +404,6 @@ TEST(twoProcPubSub, PubSubMessageInfo)
 /// available topics.
 TEST(twoProcPubSub, TopicList)
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
-
   auto pi = gz::utils::Subprocess(
     {test_executables::kTwoProcsPublisher, partition});
 
@@ -460,8 +450,6 @@ TEST(twoProcPubSub, TopicList)
 /// about the topic.
 TEST(twoProcPubSub, TopicInfo)
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
-
   auto pi = gz::utils::Subprocess(
     {test_executables::kTwoProcsPublisher, partition});
 
@@ -498,8 +486,6 @@ TEST(twoProcPubSub, TopicInfo)
 /// check returns the correct result.
 TEST(twoProcPubSub, PubSubTwoProcsScopedPub)
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
-
   transport::Node node;
 
   for (auto j = 0; j < 2; ++j)


### PR DESCRIPTION
# 🎉 Bug fix

This PR fixes some pub sub issues when subscribing to an existing topic but with different type. It also enables the remaining tests from the core library.

Right now, the Zenoh flavor runs the same tests that ZeroMQ checks, except within the `log` directory.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.**
