### PR TITLE
Fix Helpers_TEST on windows

### DIFF
--- a/src/Helpers_TEST.cc
+++ b/src/Helpers_TEST.cc
@@ -110,5 +110,5 @@ TEST(HelpersTest, TransportImplementation)
   if (found)
     EXPECT_TRUE(impl.empty());
   else
-    EXPECT_EQ("zenoh", impl);
+    EXPECT_EQ("zeromq", impl);
 }

--- a/src/Helpers_TEST.cc
+++ b/src/Helpers_TEST.cc
@@ -101,8 +101,14 @@ TEST(HelpersTest, TransportImplementation)
   impl = transport::getTransportImplementation();
   EXPECT_EQ("abc", impl);
 
+  // This call unsets the environment variable on Windows.
   ASSERT_TRUE(gz::utils::setenv("GZ_TRANSPORT_IMPLEMENTATION", ""));
 
   impl = transport::getTransportImplementation();
-  EXPECT_TRUE(impl.empty());
+  bool found;
+  gz::utils::env("GZ_TRANSPORT_IMPLEMENTATION", found);
+  if (found)
+    EXPECT_TRUE(impl.empty());
+  else
+    EXPECT_EQ("zenoh", impl);
 }

--- a/src/Helpers_TEST.cc
+++ b/src/Helpers_TEST.cc
@@ -105,9 +105,8 @@ TEST(HelpersTest, TransportImplementation)
   ASSERT_TRUE(gz::utils::setenv("GZ_TRANSPORT_IMPLEMENTATION", ""));
 
   impl = transport::getTransportImplementation();
-  bool found;
-  gz::utils::env("GZ_TRANSPORT_IMPLEMENTATION", found);
-  if (found)
+  std::string value;
+  if (gz::utils::env("GZ_TRANSPORT_IMPLEMENTATION", value, true))
     EXPECT_TRUE(impl.empty());
   else
     EXPECT_EQ("zeromq", impl);


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes a recent [test failure](https://build.osrfoundation.org/job/gz_transport-main-cnlwin/37/testReport/(root)/HelpersTest/TransportImplementation/) on Windows.

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.