### PR TITLE
[Bazel] Update gz-discovery-header deps

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -89,6 +89,9 @@ cc_library(
     name = "gz-transport-discovery-header",
     hdrs = ["src/Discovery.hh"],
     visibility = ["//:__subpackages__"],
+    deps = [
+        ":gz-transport",
+    ],
 )
 
 cc_binary(


### PR DESCRIPTION


# 🦟 Bug fix


## Summary

This should fix the bazel build in the gz-sim's [9 -> main forward merge](https://github.com/gazebosim/gz-sim/pull/3030) as it complains about missing headers.


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
