### PR TITLE
Instantiate zenoh session only if needed

### DIFF
--- a/src/NodeShared.cc
+++ b/src/NodeShared.cc
@@ -247,20 +247,6 @@ NodeShared::NodeShared()
     this->dataPtr->topicStatsEnabled = (gzStats == "1");
   }
 
-  // Set the Gz Transport implementation (ZeroMQ, Zenoh, ...).
-  std::string gzImpl;
-  if (env("GZ_TRANSPORT_IMPLEMENTATION", gzImpl) && !gzImpl.empty())
-  {
-    std::transform(gzImpl.begin(), gzImpl.end(), gzImpl.begin(), ::tolower);
-    if (gzImpl == "zeromq" || gzImpl == "zenoh")
-      this->dataPtr->gzImplementation = gzImpl;
-    else
-    {
-      std::cerr << "Unrecognized value in GZ_TRANSPORT_IMPLEMENTATION. ["
-                << gzImpl << "]. Ignoring this value" << std::endl;
-    }
-  }
-
   // My process UUID.
   Uuid uuid;
   this->pUuid = uuid.ToString();

--- a/src/NodeSharedPrivate.hh
+++ b/src/NodeSharedPrivate.hh
@@ -22,6 +22,7 @@
 #include <list>
 #include <map>
 #include <memory>
+#include <algorithm>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

This patch instantiates the Zenoh session only when it's needed (when setting GZ_TRANSPORT_IMPLEMENTATION=zenoh).

### How to test it?

You can use `gdb` to launch gz-sim server:
```
GZ_TRANSPORT_IMPLEMENTATION=zeromq gdb ./install/libexec/gz/sim10/gz-sim-server
r shapes.sdf
```

Then, `CTRL-C` the simulation, and check the running threads:
```
thread all apply bt
```

You shouldn't see any threads related with `zenoh`.

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.