### PR TITLE
Enable more zenoh tests on twoProcsPubSub.cc

### DIFF
--- a/include/gz/transport/TopicStorage.hh
+++ b/include/gz/transport/TopicStorage.hh
@@ -203,7 +203,7 @@ namespace gz::transport
     /// \param[out] _info Map of publishers requested.
     /// \return true if at least there is one publisher stored.
     public: bool Publishers(const std::string &_topic,
-                           std::map<std::string, std::vector<T>> &_info) const
+                            std::map<std::string, std::vector<T>> &_info) const
     {
       if (!this->HasTopic(_topic))
         return false;

--- a/src/Discovery.hh
+++ b/src/Discovery.hh
@@ -332,12 +332,12 @@ namespace gz
           {
             if (entityType == "MP")
             {
-              this->info.DelPublisherByNode("@" + partition + "@" + pub.Topic(),
-                pub.PUuid(), pub.NUuid());
+              this->info.DelPublisherByNode(
+                pub.Topic(), pub.PUuid(), pub.NUuid());
             }
             else if (entityType == "MS" && this->pUuid != pUUID)
             {
-              this->remoteSubscribers.DelPublisherByNode("@" + partition + "@" +
+              this->remoteSubscribers.DelPublisherByNode(
                 pub.Topic(), pub.PUuid(), pub.NUuid());
               if (this->unregistrationCb)
                 this->unregistrationCb(pub);
@@ -399,8 +399,8 @@ namespace gz
           {
             if (entityType == "SS")
             {
-              this->info.DelPublisherByNode("@" + partition + "@" + pub.Topic(),
-                pub.PUuid(), pub.NUuid());
+              this->info.DelPublisherByNode(
+                pub.Topic(), pub.PUuid(), pub.NUuid());
             }
             if (this->verbose)
             {

--- a/test/integration/twoProcsPubSub.cc
+++ b/test/integration/twoProcsPubSub.cc
@@ -376,8 +376,6 @@ TEST(twoProcPubSub, TopicList)
 /// about the topic.
 TEST(twoProcPubSub, TopicInfo)
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
-
   auto pi = gz::utils::Subprocess(
     {test_executables::kTwoProcsPublisher, partition});
 
@@ -414,8 +412,6 @@ TEST(twoProcPubSub, TopicInfo)
 /// check returns the correct result.
 TEST(twoProcPubSub, PubSubTwoProcsScopedPub)
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
-
   transport::Node node;
 
   for (auto j = 0; j < 2; ++j)
@@ -432,10 +428,6 @@ TEST(twoProcPubSub, PubSubTwoProcsScopedPub)
     {
       auto pub = node.Advertise<msgs::Vector3d>(g_topic);
       EXPECT_TRUE(pub);
-
-      // No subscribers yet right after pub comes up because it takes time for
-      // it to discover subscribers on the network
-      EXPECT_FALSE(pub.HasConnections());
 
       std::this_thread::sleep_for(std::chrono::milliseconds(100));
 


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes  `twoProcPubSub.TopicInfo` and `twoProcPubSub.PubSubTwoProcsScopedPub` tests.

As described in #681,  `twoProcPubSub.TopicInfo`: `Node::TopicInfo` returned more publishers than expected. We weren't properly removing the publishers from the data structure because the topic wasn't correctly formed.

In `twoProcPubSub.PubSubTwoProcsScopedPub`,  `Publisher::HasConnections` was returning an unexpected true. This was a wrong assumption in the test, because the remote subscriber is already registered in the network (Zenoh) before the call to `Advertise()`. 

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.