### PR TITLE
Install zenoh packages from packages.osrfoundation.org

### DIFF
--- a/.github/ci/before_cmake.sh
+++ b/.github/ci/before_cmake.sh
@@ -1,2 +1,0 @@
-# Set up ROS 2 env for finding zenoh vendor packages
-source /opt/ros/jazzy/setup.bash

--- a/.github/ci/packages-noble.apt
+++ b/.github/ci/packages-noble.apt
@@ -1,3 +1,3 @@
 cppzmq-dev
-ros-jazzy-ros-environment
-ros-jazzy-zenoh-cpp-vendor
+libzenohc-dev
+libzenohcpp-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,6 @@ on:
       - 'ign-transport[0-9]?'
       - 'gz-transport[0-9]?'
       - 'main'
-      - 'iche033/zenoh_actions'
 
 jobs:
   noble-ci:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
       - 'ign-transport[0-9]?'
       - 'gz-transport[0-9]?'
       - 'main'
+      - 'iche033/zenoh_actions'
 
 jobs:
   noble-ci:


### PR DESCRIPTION
# 🦟 Bug fix


## Summary

Switch to use the zenoh packages for packages.osroundation.org instead of using zenoh-cpp-vendor from ros repo

[github actions test builds](https://github.com/gazebosim/gz-transport/actions/runs/17245229762) are green

Related release-tools PR for jenkins noble build: https://github.com/gazebo-tooling/release-tools/pull/1384

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.


