### PR TITLE
Fix topic info in generic subscription callback using zenoh

### DIFF
--- a/include/gz/transport/SubscriptionHandler.hh
+++ b/include/gz/transport/SubscriptionHandler.hh
@@ -168,7 +168,7 @@ namespace gz::transport
     /// \param[in] _topic The topic.
     public: void CreateGenericZenohSubscriber(
       std::shared_ptr<zenoh::Session> _session,
-      const std::string &_topic);
+      const FullyQualifiedTopic &_fullyQualifiedTopic);
 #endif
   };
 
@@ -225,10 +225,10 @@ namespace gz::transport
     /// \param[in] _topic The topic associated to this callback.
     public: void SetCallback(const MsgCallback<T> &_cb,
                              std::shared_ptr<zenoh::Session> _session,
-                             const std::string &_topic)
+                             const FullyQualifiedTopic &_fullyQualifiedTopic)
     {
       this->SetCallback(std::move(_cb));
-      this->CreateGenericZenohSubscriber(_session, _topic);
+      this->CreateGenericZenohSubscriber(_session, _fullyQualifiedTopic);
     }
 #endif
 
@@ -356,10 +356,10 @@ namespace gz::transport
     /// \param[in] _topic The topic associated to this callback.
     public: void SetCallback(const MsgCallback<ProtoMsg> &_cb,
                              std::shared_ptr<zenoh::Session> _session,
-                             const std::string &_topic)
+                             const FullyQualifiedTopic &_fullyQualifiedTopic)
     {
       this->SetCallback(std::move(_cb));
-      this->CreateGenericZenohSubscriber(_session, _topic);
+      this->CreateGenericZenohSubscriber(_session, _fullyQualifiedTopic);
     }
 #endif
 

--- a/include/gz/transport/detail/Node.hh
+++ b/include/gz/transport/detail/Node.hh
@@ -148,9 +148,10 @@ namespace gz::transport
     std::string topic = _topic;
     this->Options().TopicRemap(_topic, topic);
 
-    std::string fullyQualifiedTopic;
-    if (!TopicUtils::FullyQualifiedName(this->Options().Partition(),
-      this->Options().NameSpace(), topic, fullyQualifiedTopic))
+    FullyQualifiedTopic fullyQualifiedTopic(
+      this->Options().Partition(), this->Options().NameSpace(), topic);
+
+    if (!fullyQualifiedTopic.FullTopic())
     {
       std::cerr << "Topic [" << topic << "] is not valid." << std::endl;
       return nullptr;
@@ -184,9 +185,9 @@ namespace gz::transport
     // it will recover the subscription handler associated to the topic and
     // will invoke the callback.
     this->Shared()->localSubscribers.normal.AddHandler(
-      fullyQualifiedTopic, this->NodeUuid(), subscrHandlerPtr);
+      *fullyQualifiedTopic.FullTopic(), this->NodeUuid(), subscrHandlerPtr);
 
-    if (!this->SubscribeHelper(fullyQualifiedTopic))
+    if (!this->SubscribeHelper(*fullyQualifiedTopic.FullTopic()))
       return nullptr;
 
     return subscrHandlerPtr;

--- a/src/Node_TEST.cc
+++ b/src/Node_TEST.cc
@@ -126,12 +126,15 @@ void rawCbInfo(const char *_msgData, const size_t _size,
 
 //////////////////////////////////////////////////
 /// \brief A generic callback.
-void genericCb(const transport::ProtoMsg &_msg)
+void genericCb(const transport::ProtoMsg &_msg,
+               const transport::MessageInfo &_info)
 {
   std::string content;
   ASSERT_TRUE(google::protobuf::TextFormat::PrintToString(_msg, &content));
   EXPECT_TRUE(content.find(std::to_string(data)) != std::string::npos);
   genericCbExecuted = true;
+
+  EXPECT_EQ(_info.Topic().find("@"), std::string::npos);
 }
 
 //////////////////////////////////////////////////

--- a/src/SubscriptionHandler.cc
+++ b/src/SubscriptionHandler.cc
@@ -155,10 +155,10 @@ namespace gz::transport
   /////////////////////////////////////////////////
   void ISubscriptionHandler::CreateGenericZenohSubscriber(
     std::shared_ptr<zenoh::Session> _session,
-    const std::string &_topic)
+    const FullyQualifiedTopic &_fullyQualifiedTopic)
   {
     MessageInfo msgInfo;
-    msgInfo.SetTopic(_topic);
+    msgInfo.SetTopic(_fullyQualifiedTopic.Topic());
     msgInfo.SetType(this->TypeName());
     auto dataHandler = [this, msgInfo](const zenoh::Sample &_sample)
     {
@@ -186,10 +186,11 @@ namespace gz::transport
 
     this->dataPtr->zSub = std::make_unique<zenoh::Subscriber<void>>(
       _session->declare_subscriber(
-        _topic, dataHandler, zenoh::closures::none));
+        *_fullyQualifiedTopic.FullTopic(), dataHandler, zenoh::closures::none));
 
     std::string token = TopicUtils::CreateLivelinessToken(
-      _topic, this->ProcUuid(), this->NodeUuid(), "MS", this->TypeName());
+      *_fullyQualifiedTopic.FullTopic(), this->ProcUuid(), this->NodeUuid(),
+      "MS", this->TypeName());
 
     if (token.empty())
       return;

--- a/test/integration/twoProcsPubSub.cc
+++ b/test/integration/twoProcsPubSub.cc
@@ -79,10 +79,13 @@ void cbInfo(const msgs::Int32 &_msg,
 
 //////////////////////////////////////////////////
 /// \brief A generic callback.
-void genericCb(const transport::ProtoMsg &/*_msg*/)
+void genericCb(const transport::ProtoMsg &/*_msg*/,
+               const transport::MessageInfo &_info)
 {
   genericCbExecuted = true;
   ++counter;
+
+  EXPECT_EQ(_info.Topic().find("@"), std::string::npos);
 }
 
 //////////////////////////////////////////////////

--- a/test/integration/twoProcsPubSub.cc
+++ b/test/integration/twoProcsPubSub.cc
@@ -210,9 +210,10 @@ TEST(twoProcPubSub, PubSubWrongTypesTwoRawSubscribers)
   };
 
   auto genericCb = [&](const char *, const size_t /*_size*/,
-                       const transport::MessageInfo &)
+                       const transport::MessageInfo &_info)
   {
     genericRawCbExecuted = true;
+    EXPECT_EQ(_info.Topic().find("@"), std::string::npos);
   };
 
   transport::Node node1;


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes the topic info in the generic subscription callback. When asking for `Topic()`, the returned string was containing the partition name and it shouldn't. This only happens using `zenoh`.

E.g.:
```
./publisher
```
and
```
./subscriber_generic 
Topic: [@/flaco:caguero@/foo]
data: "HELLO"
```

However, topic should be just `/foo`. This patch fixes the issue.

Note: The ABI checker job is expected to fail.

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.