### PR TITLE
Check message creation in zenoh before running local callback

### DIFF
--- a/src/SubscriptionHandler.cc
+++ b/src/SubscriptionHandler.cc
@@ -175,7 +175,8 @@ namespace gz::transport
 
         auto output = this->CreateMsg(
           _sample.get_payload().as_string(), msgType);
-        this->RunLocalCallback(*output, msgInfo);
+        if (output)
+          this->RunLocalCallback(*output, msgInfo);
       }
       else
       {


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes [this issue](https://github.com/gazebosim/gazebo_test_cases/issues/2271#issuecomment-3232013675).

This patch avoids a crash when the `CreateMessage()` function wasn't able to create a message. When using zenoh, we weren't checking whether the message was successfully created or not.

Note that `CreateMessage()` doesn't have to always create a message, there are situations where it's not possible to do. The most common case is when the publisher publishes a custom message and the subscriber doesn't have access to that message definition. This is what happens in the reported issue, `gz topic echo` shouldn't work (unless it has access to the `.desc` message files) but in any case it should not crash.

### How to test it?

Compile the examples:
```
cd <jetty_ws>/src/gz-transport/example
mkdir build && cd build
make -j
```

In terminal 1:
```
./publisher_custom_msg
```

In terminal 2:
```
gz topic -e -t /foo
```
No output should appear on the terminal but nothing should crash.

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.