### PR TITLE
Add null-check for `gz param` parameters in three functions to prevent crashes

### DIFF
--- a/parameters/src/cmd/ParamCommandAPI.cc
+++ b/parameters/src/cmd/ParamCommandAPI.cc
@@ -38,6 +38,11 @@ using namespace transport;
 //////////////////////////////////////////////////
 extern "C" void cmdParametersList(const char * _ns)
 {
+  if (!_ns) 
+  {
+    std::cerr << "Error: Namespace is null" << std::endl;
+    return;
+  }
   parameters::ParametersClient client{_ns};
 
   std::cout << std::endl << "Listing parameters, registry namespace [" << _ns
@@ -63,6 +68,11 @@ extern "C" void cmdParametersList(const char * _ns)
 
 //////////////////////////////////////////////////
 extern "C" void cmdParameterGet(const char * _ns, const char *_paramName) {
+  if (!_ns || !_paramName) 
+  {
+    std::cerr << "Error: Namespace or parameter name is null" << std::endl;
+    return;
+  }
   parameters::ParametersClient client{_ns};
 
   std::cout << std::endl << "Getting parameter [" << _paramName
@@ -96,6 +106,16 @@ extern "C" void cmdParameterSet(
     const char * _ns, const char *_paramName, const char * _paramType,
     const char *_paramValue)
 {
+  if (!_ns || !_paramName) 
+  {
+    std::cerr << "Error: Namespace or parameter name is null" << std::endl;
+    return;
+  }
+  if (!_paramType || !_paramValue) 
+  {
+    std::cerr << "Error: Parameter type or value is null" << std::endl;
+    return;
+  }
   parameters::ParametersClient client{_ns};
 
   std::cout << std::endl << "Setting parameter [" << _paramName


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes gz-sim [Issue#3079](https://github.com/gazebosim/gz-sim/issues/3079)

## Summary
When using the `gz param` command, it crashes because subsequent parameters do not have validity checks.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
