### PR TITLE
Prepare for 15.0.0~pre2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ cmake_dependent_option(USE_DIST_PACKAGES_FOR_PYTHON
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-gz_configure_project(VERSION_SUFFIX pre1)
+gz_configure_project(VERSION_SUFFIX pre2)
 
 #============================================================================
 # Set project-specific options

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,26 @@
 
 1. **Baseline:** this includes all changes from 14.1.0 and earlier.
 
+1. Add null-check for gz param parameters in three functions to prevent crashes
+    * [Pull request #710](https://github.com/gazebosim/gz-transport/pull/710)
+
+1. Fix small typo in services tutorial
+    * [Pull request #703](https://github.com/gazebosim/gz-transport/pull/703)
+
+1. Fix Dockerfile and update relay tutorial
+    * [Pull request #702](https://github.com/gazebosim/gz-transport/pull/702)
+
+1. Update installation instructions for Ubuntu source
+    * [Pull request #700](https://github.com/gazebosim/gz-transport/pull/700)
+
+1. Update bazel module to use jetty release branches
+    * [Pull request #699](https://github.com/gazebosim/gz-transport/pull/699)
+
 1. Zenoh integration
+    * [Pull request #708](https://github.com/gazebosim/gz-transport/pull/708)
+    * [Pull request #707](https://github.com/gazebosim/gz-transport/pull/707)
+    * [Pull request #697](https://github.com/gazebosim/gz-transport/pull/697)
+    * [Pull request #696](https://github.com/gazebosim/gz-transport/pull/696)
     * [Pull request #691](https://github.com/gazebosim/gz-transport/pull/691)
     * [Pull request #686](https://github.com/gazebosim/gz-transport/pull/686)
     * [Pull request #684](https://github.com/gazebosim/gz-transport/pull/684)


### PR DESCRIPTION
<!-- For maintainers only -->

# 🎈 Release

Preparation for 15.0.0~pre2 prerelease.

Comparison to 15.0.0~pre1: https://github.com/gazebosim/gz-transport/compare/gz-transport15_15.0.0-pre1...caguero_15pre2


## Checklist
- [ ] Asked team if this is a good time for a release
- [x] There are no changes to be ported from the previous major version
- [x] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [x] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
