### PR TITLE
Prepare for 15.0.0 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ cmake_dependent_option(USE_DIST_PACKAGES_FOR_PYTHON
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-gz_configure_project(VERSION_SUFFIX pre2)
+gz_configure_project(VERSION_SUFFIX)
 
 #============================================================================
 # Set project-specific options

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,8 +1,11 @@
 ## Gazebo Transport 15.X
 
-### Gazebo Transport 15.0.0 (2025-09-xx)
+### Gazebo Transport 15.0.0 (2025-09-30)
 
 1. **Baseline:** this includes all changes from 14.1.0 and earlier.
+
+1. [bazel] Enable unit tests
+    * [Pull request #715](https://github.com/gazebosim/gz-transport/pull/715)
 
 1. Add null-check for gz param parameters in three functions to prevent crashes
     * [Pull request #710](https://github.com/gazebosim/gz-transport/pull/710)


### PR DESCRIPTION


# 🎈 Release

Preparation for 15.0.0 release.

Comparison to 15.0.0~pre2: https://github.com/gazebosim/gz-transport/compare/gz-transport15_15.0.0-pre2...gz-transport15

## Checklist
- [ ] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [ ] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
