### PR TITLE
Initialize move constructor

### DIFF
--- a/src/Node.cc
+++ b/src/Node.cc
@@ -326,6 +326,7 @@ bool Node::Subscriber::Valid() const
 
 //////////////////////////////////////////////////
 Node::Subscriber::Subscriber(Node::Subscriber &&_other)
+  : dataPtr(std::make_shared<SubscriberPrivate>())
 {
   *this = std::move(_other);
 }

--- a/src/Node_TEST.cc
+++ b/src/Node_TEST.cc
@@ -973,6 +973,15 @@ TEST(NodeSubTest, BoolOperatorTest)
 }
 
 //////////////////////////////////////////////////
+/// \brief Exercise the Subscriber move constructor.
+TEST(NodeTest, MoveSubscriber)
+{
+  transport::Node node;
+  std::vector<transport::Node::Subscriber> subscribers;
+  subscribers.emplace_back(node.CreateSubscriber(g_topic, cb));
+}
+
+//////////////////////////////////////////////////
 /// \brief Subscribe to a topic using CreateSubscriber API
 TEST(NodeTest, PubSubWithCreateSubscriber)
 {


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes #717 

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

Properly initializes the move constructor.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.