### PR TITLE
Set GZ_IP for gz_src_TEST

### DIFF
--- a/src/cmd/CMakeLists.txt
+++ b/src/cmd/CMakeLists.txt
@@ -90,6 +90,14 @@ if (TARGET UNIT_gz_TEST)
   )
 endif()
 
+if (TARGET UNIT_gz_src_TEST)
+  set(_env_vars)
+  list(APPEND _env_vars "GZ_IP=127.0.0.1")
+  set_tests_properties(UNIT_gz_src_TEST
+    PROPERTIES ENVIRONMENT "${_env_vars}"
+  )
+endif()
+
 #===============================================================================
 # Generate the ruby script for internal testing.
 # Note that the major version of the library is included in the name.


### PR DESCRIPTION
# 🦟 Bug fix

Similar to #595 but for UNIT_gz_src_TEST

## Summary

I noticed that `UNIT_gz_src_TEST` has been failing with networking error messages and applies the `GZ_IP=127.0.0.1` fix from #595 to that test as well.

Example failures:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_transport-ci-gz-transport14-homebrew-arm64&build=5)](https://build.osrfoundation.org/job/gz_transport-ci-gz-transport14-homebrew-arm64/5/) https://build.osrfoundation.org/job/gz_transport-ci-gz-transport14-homebrew-arm64/5/testReport/junit/(root)/UNIT_gz_src_TEST/test_ran/
* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_transport-ci-gz-transport13-homebrew-arm64&build=4)](https://build.osrfoundation.org/job/gz_transport-ci-gz-transport13-homebrew-arm64/4/) https://build.osrfoundation.org/job/gz_transport-ci-gz-transport13-homebrew-arm64/4/testReport/junit/(root)/gzTest/cmdTopicInfo/

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
