### PR TITLE
Hide zmq header and cmake target

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -6,6 +6,14 @@ Deprecated code produces compile-time warnings. These warning serve as
 notification to users that their code should be upgraded. The next major
 release will remove the deprecated code.
 
+## Gazebo Transport 15.X to 16.X
+
+### Removed
+
+1. Removed zeromq from public header and CMake target. Specifically,
+    * Removed `zmq.hpp` include header in `include/gz/transport/Helpers.hh`,
+    * Made the `CPPZMQ::CPPCMQ` target in `src/CMakeLists.txt` `PRIVATE`.
+
 ## Gazebo Transport 14.X to 15.X
 
 ### Removed

--- a/include/gz/transport/Helpers.hh
+++ b/include/gz/transport/Helpers.hh
@@ -18,8 +18,6 @@
 #ifndef GZ_TRANSPORT_HELPERS_HH_
 #define GZ_TRANSPORT_HELPERS_HH_
 
-#include <zmq.hpp>
-
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
@@ -29,19 +27,6 @@
 
 #include "gz/transport/config.hh"
 #include "gz/transport/Export.hh"
-
-// Avoid using deprecated message send/receive function when possible.
-#if ZMQ_VERSION > ZMQ_MAKE_VERSION(4, 3, 1)
-  #define GZ_ZMQ_POST_4_3_1
-#endif
-
-// Avoid using deprecated set function when possible
-#if CPPZMQ_VERSION >= ZMQ_MAKE_VERSION(4, 7, 0)
-  // Ubuntu Focal (20.04) packages a different "4.7.0"
-  #ifndef UBUNTU_FOCAL
-    #define GZ_CPPZMQ_POST_4_7_0
-  #endif
-#endif
 
 namespace gz::transport
 {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,8 +10,8 @@ target_link_libraries(${PROJECT_LIBRARY_TARGET_NAME}
   PUBLIC
     gz-utils::gz-utils
     gz-msgs::gz-msgs
-    CPPZMQ::CPPZMQ
   PRIVATE
+    CPPZMQ::CPPZMQ
     ${ZeroMQ_TARGET}
 )
 

--- a/src/NodeShared.cc
+++ b/src/NodeShared.cc
@@ -80,7 +80,6 @@ bool userPass(std::string &_user, std::string &_pass)
 
 //////////////////////////////////////////////////
 // Helper to send messages
-#ifdef GZ_ZMQ_POST_4_3_1
 int sendHelper(zmq::socket_t &_pub, const std::string &_data,
     const zmq::send_flags &_type)
 {
@@ -92,13 +91,11 @@ int sendHelper(zmq::socket_t &_pub, const std::string &_data,
   else
     return *res;
 }
-#endif
 
 int sendHelper(zmq::socket_t &_pub, const std::string &_data, int _type)
 {
   zmq::message_t msg(_data.data(), _data.size());
 
-#ifdef GZ_ZMQ_POST_4_3_1
   zmq::send_flags flags = zmq::send_flags::none;
   switch (_type)
   {
@@ -114,9 +111,6 @@ int sendHelper(zmq::socket_t &_pub, const std::string &_data, int _type)
       break;
   }
   return sendHelper(_pub, _data, flags);
-#else
-  return _pub.send(msg, _type);
-#endif
 }
 
 //////////////////////////////////////////////////
@@ -125,11 +119,7 @@ std::string receiveHelper(zmq::socket_t &_socket)
 {
   zmq::message_t msg(0);
 
-#ifdef GZ_ZMQ_POST_4_3_1
   if (!_socket.recv(msg))
-#else
-  if (!_socket.recv(&msg, 0))
-#endif
     return std::string();
 
   return std::string(reinterpret_cast<char *>(msg.data()), msg.size());
@@ -141,17 +131,10 @@ std::string receiveHelper(zmq::socket_t &_socket)
 void sendAuthErrorHelper(zmq::socket_t &_socket, const std::string &_err)
 {
   std::cerr << _err << std::endl;
-#ifdef GZ_ZMQ_POST_4_3_1
   sendHelper(_socket, "400", zmq::send_flags::sndmore);
   sendHelper(_socket, _err, zmq::send_flags::sndmore);
   sendHelper(_socket, "", zmq::send_flags::sndmore);
   sendHelper(_socket, "", zmq::send_flags::none);
-#else
-  sendHelper(_socket, "400", ZMQ_SNDMORE);
-  sendHelper(_socket, _err, ZMQ_SNDMORE);
-  sendHelper(_socket, "", ZMQ_SNDMORE);
-  sendHelper(_socket, "", 0);
-#endif
 }
 
 namespace gz::transport
@@ -411,15 +394,9 @@ bool NodeShared::Publish(
     // Send the messages
     std::lock_guard<std::recursive_mutex> lock(this->mutex);
 
-#ifdef GZ_ZMQ_POST_4_3_1
     this->dataPtr->publisher->send(msg0, zmq::send_flags::sndmore);
     this->dataPtr->publisher->send(msg1, zmq::send_flags::sndmore);
     this->dataPtr->publisher->send(msg2, zmq::send_flags::sndmore);
-#else
-    this->dataPtr->publisher->send(msg0, ZMQ_SNDMORE);
-    this->dataPtr->publisher->send(msg1, ZMQ_SNDMORE);
-    this->dataPtr->publisher->send(msg2, ZMQ_SNDMORE);
-#endif
 
     if (this->dataPtr->topicStatsEnabled)
     {
@@ -432,21 +409,12 @@ bool NodeShared::Publish(
       meta.stamp = std::chrono::duration_cast<std::chrono::milliseconds>(
           std::chrono::steady_clock::now().time_since_epoch()).count();
       zmq::message_t msg4(&meta, sizeof(meta));
-#ifdef GZ_ZMQ_POST_4_3_1
       this->dataPtr->publisher->send(msg3, zmq::send_flags::sndmore);
       this->dataPtr->publisher->send(msg4, zmq::send_flags::none);
-#else
-      this->dataPtr->publisher->send(msg3, ZMQ_SNDMORE);
-      this->dataPtr->publisher->send(msg4, 0);
-#endif
     }
     else
     {
-#ifdef GZ_ZMQ_POST_4_3_1
       this->dataPtr->publisher->send(msg3, zmq::send_flags::none);
-#else
-      this->dataPtr->publisher->send(msg3, 0);
-#endif
     }
   }
   catch(const zmq::error_t& ze)
@@ -473,46 +441,26 @@ void NodeShared::RecvMsgUpdate()
 
     try
     {
-#ifdef GZ_ZMQ_POST_4_3_1
       if (!this->dataPtr->subscriber->recv(msg))
-#else
-      if (!this->dataPtr->subscriber->recv(&msg, 0))
-#endif
         return;
       topic = std::string(reinterpret_cast<char *>(msg.data()), msg.size());
 
       // TODO(caguero): Use this as extra metadata for the subscriber.
-#ifdef GZ_ZMQ_POST_4_3_1
       if (!this->dataPtr->subscriber->recv(msg))
-#else
-      if (!this->dataPtr->subscriber->recv(&msg, 0))
-#endif
         return;
       sender = std::string(reinterpret_cast<char *>(msg.data()), msg.size());
 
-#ifdef GZ_ZMQ_POST_4_3_1
       if (!this->dataPtr->subscriber->recv(msg))
-#else
-      if (!this->dataPtr->subscriber->recv(&msg, 0))
-#endif
         return;
       data = std::string(reinterpret_cast<char *>(msg.data()), msg.size());
 
-#ifdef GZ_ZMQ_POST_4_3_1
       if (!this->dataPtr->subscriber->recv(msg))
-#else
-      if (!this->dataPtr->subscriber->recv(&msg, 0))
-#endif
         return;
       msgType = std::string(reinterpret_cast<char *>(msg.data()), msg.size());
 
       if (this->dataPtr->topicStatsEnabled)
       {
-#ifdef GZ_ZMQ_POST_4_3_1
         if (!this->dataPtr->subscriber->recv(msg))
-#else
-        if (!this->dataPtr->subscriber->recv(&msg, 0))
-#endif
           return;
         PublicationMetadata *meta =
           reinterpret_cast<PublicationMetadata *>(msg.data());
@@ -683,74 +631,38 @@ void NodeShared::RecvSrvRequest()
 
     try
     {
-#ifdef GZ_ZMQ_POST_4_3_1
       if (!this->dataPtr->replier->recv(msg))
-#else
-      if (!this->dataPtr->replier->recv(&msg, 0))
-#endif
         return;
 
-#ifdef GZ_ZMQ_POST_4_3_1
       if (!this->dataPtr->replier->recv(msg))
-#else
-      if (!this->dataPtr->replier->recv(&msg, 0))
-#endif
         return;
       topic = std::string(reinterpret_cast<char *>(msg.data()), msg.size());
 
-#ifdef GZ_ZMQ_POST_4_3_1
       if (!this->dataPtr->replier->recv(msg))
-#else
-      if (!this->dataPtr->replier->recv(&msg, 0))
-#endif
         return;
       sender = std::string(reinterpret_cast<char *>(msg.data()), msg.size());
 
-#ifdef GZ_ZMQ_POST_4_3_1
       if (!this->dataPtr->replier->recv(msg))
-#else
-      if (!this->dataPtr->replier->recv(&msg, 0))
-#endif
         return;
       dstId = std::string(reinterpret_cast<char *>(msg.data()), msg.size());
 
-#ifdef GZ_ZMQ_POST_4_3_1
       if (!this->dataPtr->replier->recv(msg))
-#else
-      if (!this->dataPtr->replier->recv(&msg, 0))
-#endif
         return;
       nodeUuid = std::string(reinterpret_cast<char *>(msg.data()), msg.size());
 
-#ifdef GZ_ZMQ_POST_4_3_1
       if (!this->dataPtr->replier->recv(msg))
-#else
-      if (!this->dataPtr->replier->recv(&msg, 0))
-#endif
         return;
       reqUuid = std::string(reinterpret_cast<char *>(msg.data()), msg.size());
 
-#ifdef GZ_ZMQ_POST_4_3_1
       if (!this->dataPtr->replier->recv(msg))
-#else
-      if (!this->dataPtr->replier->recv(&msg, 0))
-#endif
         return;
       req = std::string(reinterpret_cast<char *>(msg.data()), msg.size());
 
-#ifdef GZ_ZMQ_POST_4_3_1
       if (!this->dataPtr->replier->recv(msg))
-#else
-      if (!this->dataPtr->replier->recv(&msg, 0))
-#endif
         return;
       reqType = std::string(reinterpret_cast<char *>(msg.data()), msg.size());
 
-#ifdef GZ_ZMQ_POST_4_3_1
       if (!this->dataPtr->replier->recv(msg))
-#else
-      if (!this->dataPtr->replier->recv(&msg, 0))
-#endif
         return;
       repType = std::string(reinterpret_cast<char *>(msg.data()), msg.size());
     }
@@ -809,51 +721,27 @@ void NodeShared::RecvSrvRequest()
 
       response.rebuild(dstId.size());
       memcpy(response.data(), dstId.data(), dstId.size());
-#ifdef GZ_ZMQ_POST_4_3_1
       this->dataPtr->replier->send(response, zmq::send_flags::sndmore);
-#else
-      this->dataPtr->replier->send(response, ZMQ_SNDMORE);
-#endif
 
       response.rebuild(topic.size());
       memcpy(response.data(), topic.data(), topic.size());
-#ifdef GZ_ZMQ_POST_4_3_1
       this->dataPtr->replier->send(response, zmq::send_flags::sndmore);
-#else
-      this->dataPtr->replier->send(response, ZMQ_SNDMORE);
-#endif
 
       response.rebuild(nodeUuid.size());
       memcpy(response.data(), nodeUuid.data(), nodeUuid.size());
-#ifdef GZ_ZMQ_POST_4_3_1
       this->dataPtr->replier->send(response, zmq::send_flags::sndmore);
-#else
-      this->dataPtr->replier->send(response, ZMQ_SNDMORE);
-#endif
 
       response.rebuild(reqUuid.size());
       memcpy(response.data(), reqUuid.data(), reqUuid.size());
-#ifdef GZ_ZMQ_POST_4_3_1
       this->dataPtr->replier->send(response, zmq::send_flags::sndmore);
-#else
-      this->dataPtr->replier->send(response, ZMQ_SNDMORE);
-#endif
 
       response.rebuild(rep.size());
       memcpy(response.data(), rep.data(), rep.size());
-#ifdef GZ_ZMQ_POST_4_3_1
       this->dataPtr->replier->send(response, zmq::send_flags::sndmore);
-#else
-      this->dataPtr->replier->send(response, ZMQ_SNDMORE);
-#endif
 
       response.rebuild(resultStr.size());
       memcpy(response.data(), resultStr.data(), resultStr.size());
-#ifdef GZ_ZMQ_POST_4_3_1
       this->dataPtr->replier->send(response, zmq::send_flags::none);
-#else
-      this->dataPtr->replier->send(response, 0);
-#endif
     }
     catch(const zmq::error_t &_error)
     {
@@ -889,50 +777,26 @@ void NodeShared::RecvSrvResponse()
 
     try
     {
-#ifdef GZ_ZMQ_POST_4_3_1
       if (!this->dataPtr->responseReceiver->recv(msg))
-#else
-      if (!this->dataPtr->responseReceiver->recv(&msg, 0))
-#endif
         return;
 
-#ifdef GZ_ZMQ_POST_4_3_1
       if (!this->dataPtr->responseReceiver->recv(msg))
-#else
-      if (!this->dataPtr->responseReceiver->recv(&msg, 0))
-#endif
         return;
       topic = std::string(reinterpret_cast<char *>(msg.data()), msg.size());
 
-#ifdef GZ_ZMQ_POST_4_3_1
       if (!this->dataPtr->responseReceiver->recv(msg))
-#else
-      if (!this->dataPtr->responseReceiver->recv(&msg, 0))
-#endif
         return;
       nodeUuid = std::string(reinterpret_cast<char *>(msg.data()), msg.size());
 
-#ifdef GZ_ZMQ_POST_4_3_1
       if (!this->dataPtr->responseReceiver->recv(msg))
-#else
-      if (!this->dataPtr->responseReceiver->recv(&msg, 0))
-#endif
         return;
       reqUuid = std::string(reinterpret_cast<char *>(msg.data()), msg.size());
 
-#ifdef GZ_ZMQ_POST_4_3_1
       if (!this->dataPtr->responseReceiver->recv(msg))
-#else
-      if (!this->dataPtr->responseReceiver->recv(&msg, 0))
-#endif
         return;
       rep = std::string(reinterpret_cast<char *>(msg.data()), msg.size());
 
-#ifdef GZ_ZMQ_POST_4_3_1
       if (!this->dataPtr->responseReceiver->recv(msg))
-#else
-      if (!this->dataPtr->responseReceiver->recv(&msg, 0))
-#endif
         return;
       resultStr = std::string(reinterpret_cast<char *>(msg.data()), msg.size());
       result = resultStr == "1";
@@ -1068,77 +932,41 @@ void NodeShared::SendPendingRemoteReqs(const std::string &_topic,
 
           msg.rebuild(responserId.size());
           memcpy(msg.data(), responserId.data(), responserId.size());
-#ifdef GZ_ZMQ_POST_4_3_1
           this->dataPtr->requester->send(msg, zmq::send_flags::sndmore);
-#else
-          this->dataPtr->requester->send(msg, ZMQ_SNDMORE);
-#endif
 
           msg.rebuild(_topic.size());
           memcpy(msg.data(), _topic.data(), _topic.size());
-#ifdef GZ_ZMQ_POST_4_3_1
           this->dataPtr->requester->send(msg, zmq::send_flags::sndmore);
-#else
-          this->dataPtr->requester->send(msg, ZMQ_SNDMORE);
-#endif
 
           msg.rebuild(this->dataPtr->myRequesterAddress.size());
           memcpy(msg.data(), this->dataPtr->myRequesterAddress.data(),
             this->dataPtr->myRequesterAddress.size());
-#ifdef GZ_ZMQ_POST_4_3_1
           this->dataPtr->requester->send(msg, zmq::send_flags::sndmore);
-#else
-          this->dataPtr->requester->send(msg, ZMQ_SNDMORE);
-#endif
 
           std::string myId = this->responseReceiverId.ToString();
           msg.rebuild(myId.size());
           memcpy(msg.data(), myId.data(), myId.size());
-#ifdef GZ_ZMQ_POST_4_3_1
           this->dataPtr->requester->send(msg, zmq::send_flags::sndmore);
-#else
-          this->dataPtr->requester->send(msg, ZMQ_SNDMORE);
-#endif
 
           msg.rebuild(nodeUuid.size());
           memcpy(msg.data(), nodeUuid.data(), nodeUuid.size());
-#ifdef GZ_ZMQ_POST_4_3_1
           this->dataPtr->requester->send(msg, zmq::send_flags::sndmore);
-#else
-          this->dataPtr->requester->send(msg, ZMQ_SNDMORE);
-#endif
 
           msg.rebuild(reqUuid.size());
           memcpy(msg.data(), reqUuid.data(), reqUuid.size());
-#ifdef GZ_ZMQ_POST_4_3_1
           this->dataPtr->requester->send(msg, zmq::send_flags::sndmore);
-#else
-          this->dataPtr->requester->send(msg, ZMQ_SNDMORE);
-#endif
 
           msg.rebuild(data.size());
           memcpy(msg.data(), data.data(), data.size());
-#ifdef GZ_ZMQ_POST_4_3_1
           this->dataPtr->requester->send(msg, zmq::send_flags::sndmore);
-#else
-          this->dataPtr->requester->send(msg, ZMQ_SNDMORE);
-#endif
 
           msg.rebuild(_reqType.size());
           memcpy(msg.data(), _reqType.data(), _reqType.size());
-#ifdef GZ_ZMQ_POST_4_3_1
           this->dataPtr->requester->send(msg, zmq::send_flags::sndmore);
-#else
-          this->dataPtr->requester->send(msg, ZMQ_SNDMORE);
-#endif
 
           msg.rebuild(_repType.size());
           memcpy(msg.data(), _repType.data(), _repType.size());
-#ifdef GZ_ZMQ_POST_4_3_1
           this->dataPtr->requester->send(msg, zmq::send_flags::none);
-#else
-          this->dataPtr->requester->send(msg, 0);
-#endif
         }
         catch(const zmq::error_t& /*ze*/)
         {
@@ -1190,12 +1018,7 @@ void NodeShared::OnNewConnection(const MessagePublisher &_pub)
       this->dataPtr->subscriber->connect(addr.c_str());
 
     // Add a new filter for the topic.
-#ifdef GZ_CPPZMQ_POST_4_7_0
     this->dataPtr->subscriber->set(zmq::sockopt::subscribe, topic);
-#else
-    this->dataPtr->subscriber->setsockopt(ZMQ_SUBSCRIBE,
-        topic.data(), topic.size());
-#endif
 
     // Register the new connection with the publisher.
     this->connections.AddPublisher(_pub);
@@ -1405,29 +1228,18 @@ bool NodeShared::InitializeSockets()
     this->dataPtr->SecurityInit();
 
     int lingerVal = 0;
-#ifdef GZ_CPPZMQ_POST_4_7_0
     this->dataPtr->publisher->set(zmq::sockopt::linger, lingerVal);
-#else
-    this->dataPtr->publisher->setsockopt(ZMQ_LINGER,
-        &lingerVal, sizeof(lingerVal));
-#endif
 
     // Set the capacity of the buffer for receiving messages.
     int rcvQueueVal = this->dataPtr->NonNegativeEnvVar(
       "GZ_TRANSPORT_RCVHWM", kDefaultRcvHwm);
 
-#ifdef GZ_CPPZMQ_POST_4_7_0
     this->dataPtr->subscriber->set(zmq::sockopt::rcvhwm, rcvQueueVal);
-#else
-    this->dataPtr->subscriber->setsockopt(ZMQ_RCVHWM,
-          &rcvQueueVal, sizeof(rcvQueueVal));
-#endif
 
     // Set the capacity of the buffer for sending messages.
     int sndQueueVal = this->dataPtr->NonNegativeEnvVar(
       "GZ_TRANSPORT_SNDHWM", kDefaultSndHwm);
 
-#ifdef GZ_CPPZMQ_POST_4_7_0
     this->dataPtr->publisher->set(zmq::sockopt::sndhwm, sndQueueVal);
 
     this->dataPtr->publisher->bind(anyTcpEp.c_str());
@@ -1453,43 +1265,6 @@ bool NodeShared::InitializeSockets()
 
     this->dataPtr->requester->set(zmq::sockopt::linger, lingerVal);
     this->dataPtr->requester->set(zmq::sockopt::router_mandatory, routeOn);
-#else
-    char bindEndPoint[1024];
-    this->dataPtr->publisher->setsockopt(ZMQ_SNDHWM,
-        &sndQueueVal, sizeof(sndQueueVal));
-
-    this->dataPtr->publisher->bind(anyTcpEp.c_str());
-    size_t size = sizeof(bindEndPoint);
-    this->dataPtr->publisher->getsockopt(ZMQ_LAST_ENDPOINT,
-        &bindEndPoint, &size);
-    this->myAddress = bindEndPoint;
-
-    // ResponseReceiver socket listening in a random port.
-    std::string id = this->responseReceiverId.ToString();
-    this->dataPtr->responseReceiver->setsockopt(ZMQ_IDENTITY,
-        id.c_str(), id.size());
-    this->dataPtr->responseReceiver->bind(anyTcpEp.c_str());
-    this->dataPtr->responseReceiver->getsockopt(ZMQ_LAST_ENDPOINT,
-        &bindEndPoint, &size);
-    this->myRequesterAddress = bindEndPoint;
-
-    // Replier socket listening in a random port.
-    id = this->replierId.ToString();
-    this->dataPtr->replier->setsockopt(ZMQ_IDENTITY, id.c_str(), id.size());
-    int RouteOn = 1;
-    this->dataPtr->replier->setsockopt(ZMQ_LINGER,
-        &lingerVal, sizeof(lingerVal));
-    this->dataPtr->replier->setsockopt(ZMQ_ROUTER_MANDATORY,
-        &RouteOn, sizeof(RouteOn));
-    this->dataPtr->replier->bind(anyTcpEp.c_str());
-    this->dataPtr->replier->getsockopt(ZMQ_LAST_ENDPOINT, &bindEndPoint, &size);
-    this->myReplierAddress = bindEndPoint;
-
-    this->dataPtr->requester->setsockopt(ZMQ_LINGER,
-        &lingerVal, sizeof(lingerVal));
-    this->dataPtr->requester->setsockopt(ZMQ_ROUTER_MANDATORY, &RouteOn,
-      sizeof(RouteOn));
-#endif
   }
   catch(const zmq::error_t& ze)
   {
@@ -1527,12 +1302,7 @@ int NodeShared::RcvHwm()
   int rcvHwm;
   try
   {
-#ifdef GZ_CPPZMQ_POST_4_7_0
     rcvHwm = this->dataPtr->subscriber->get(zmq::sockopt::rcvhwm);
-#else
-    size_t rcvHwmSize = sizeof(rcvHwm);
-    this->dataPtr->subscriber->getsockopt(ZMQ_RCVHWM, &rcvHwm, &rcvHwmSize);
-#endif
   }
   catch (zmq::error_t &_e)
   {
@@ -1548,12 +1318,7 @@ int NodeShared::SndHwm()
   int sndHwm;
   try
   {
-#ifdef GZ_CPPZMQ_POST_4_7_0
     sndHwm = this->dataPtr->publisher->get(zmq::sockopt::sndhwm);
-#else
-    size_t sndHwmSize = sizeof(sndHwm);
-    this->dataPtr->publisher->getsockopt(ZMQ_SNDHWM, &sndHwm, &sndHwmSize);
-#endif
   }
   catch (zmq::error_t &_e)
   {
@@ -1699,13 +1464,8 @@ void NodeSharedPrivate::SecurityOnNewConnection()
   // See issue #74
   if (userPass(user, pass))
   {
-#ifdef GZ_CPPZMQ_POST_4_7_0
     this->subscriber->set(zmq::sockopt::plain_username, user);
     this->subscriber->set(zmq::sockopt::plain_password, pass);
-#else
-    this->subscriber->setsockopt(ZMQ_PLAIN_USERNAME, user.c_str(), user.size());
-    this->subscriber->setsockopt(ZMQ_PLAIN_PASSWORD, pass.c_str(), pass.size());
-#endif
   }
 }
 
@@ -1724,15 +1484,8 @@ void NodeSharedPrivate::SecurityInit()
     int asPlainSecurityServer = static_cast<int>(
         ZmqPlainSecurityServerOptions::ZMQ_PLAIN_SECURITY_SERVER_ENABLED);
 
-#ifdef GZ_CPPZMQ_POST_4_7_0
     this->publisher->set(zmq::sockopt::plain_server, asPlainSecurityServer);
     this->publisher->set(zmq::sockopt::zap_domain, kGzAuthDomain);
-#else
-    this->publisher->setsockopt(ZMQ_PLAIN_SERVER,
-        &asPlainSecurityServer, sizeof(asPlainSecurityServer));
-    this->publisher->setsockopt(ZMQ_ZAP_DOMAIN, kGzAuthDomain,
-        std::strlen(kGzAuthDomain));
-#endif
   }
 }
 
@@ -1844,28 +1597,16 @@ void NodeSharedPrivate::AccessControlHandler()
           continue;
         }
 
-#ifdef GZ_ZMQ_POST_4_3_1
         sendHelper(*sock, version, zmq::send_flags::sndmore);
         sendHelper(*sock, sequence, zmq::send_flags::sndmore);
-#else
-        sendHelper(*sock, version, ZMQ_SNDMORE);
-        sendHelper(*sock, sequence, ZMQ_SNDMORE);
-#endif
 
         // Check the username and password
         if (givenUsername == user && givenPassword == pass)
         {
-#ifdef GZ_ZMQ_POST_4_3_1
           sendHelper(*sock, "200", zmq::send_flags::sndmore);
           sendHelper(*sock, "OK", zmq::send_flags::sndmore);
           sendHelper(*sock, "anonymous", zmq::send_flags::sndmore);
           sendHelper(*sock, "", zmq::send_flags::none);
-#else
-          sendHelper(*sock, "200", ZMQ_SNDMORE);
-          sendHelper(*sock, "OK", ZMQ_SNDMORE);
-          sendHelper(*sock, "anonymous", ZMQ_SNDMORE);
-          sendHelper(*sock, "", 0);
-#endif
         }
         else
         {
@@ -2175,13 +1916,8 @@ bool NodeShared::Unsubscribe(const std::string &_topic,
   // Remove the filter for this topic if I am the last subscriber.
   if (!this->localSubscribers.HasSubscriber(fullyQualifiedTopic))
   {
-#ifdef GZ_CPPZMQ_POST_4_7_0
     this->dataPtr->subscriber->set(
       zmq::sockopt::unsubscribe, fullyQualifiedTopic);
-#else
-    this->dataPtr->subscriber->setsockopt(
-      ZMQ_UNSUBSCRIBE, fullyQualifiedTopic.data(), fullyQualifiedTopic.size());
-#endif
   }
 
   // Notify to the publishers that I am no longer interested in the topic.


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🎉 New feature

## Summary

Proposal to no longer expose zmq in our public header and cmake target. This makes it possible for users to build gz-transport without zmq in the future. 

I believe the `zmq.hpp` header include in `include/gz/transport/Helpers.hh` is only used to determine whether or not the version of zmq is > 4.3.1 and cppzmq is > 4.7.0. 

Looking at the zmq versions that are now on the supported platforms, I think we no longer need these version definitions because the versions are all greater than the versions mentioned above.

* ubuntu noble
  * [libzmq3-dev](https://launchpad.net/ubuntu/noble/+package/libzmq3-dev):  4.3.4 and 4.3.5
  * [cppzmq-dev](https://launchpad.net/ubuntu/noble/+package/cppzmq-dev): 4.10.0
* homebrew
  * [zeromq](https://formulae.brew.sh/formula/zeromq): 4.3.5 
  * [cppzmq](https://formulae.brew.sh/formula/cppzmq): 4.11.0 
* conda
  * [cppzmq](https://anaconda.org/conda-forge/cppzmq): 4.10.0 

As the result, a bunch of code wrapped in `ifdef`s checks for zmq versions are removed. 

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

