### PR TITLE
Set IGN_IP for gz_src_TEST

### DIFF
--- a/src/cmd/CMakeLists.txt
+++ b/src/cmd/CMakeLists.txt
@@ -69,7 +69,7 @@ endif()
 
 if (TARGET UNIT_gz_src_TEST)
   set(_env_vars)
-  list(APPEND _env_vars "GZ_IP=127.0.0.1")
+  list(APPEND _env_vars "IGN_IP=127.0.0.1")
   set_tests_properties(UNIT_gz_src_TEST
     PROPERTIES ENVIRONMENT "${_env_vars}"
   )


### PR DESCRIPTION
# 🦟 Bug fix

Fix environment variable name backported in #728

## Summary

I backported a fix for a flaky `UNIT_gz_src_TEST` that sets `GZ_IP` in #728, but forgot to rename to `IGN_IP`  for fortress.

I noticed because the test just failed despite merging the fix:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_transport-ci-ign-transport11-homebrew-arm64&build=6)](https://build.osrfoundation.org/job/gz_transport-ci-ign-transport11-homebrew-arm64/6/) https://build.osrfoundation.org/job/gz_transport-ci-ign-transport11-homebrew-arm64/6/testReport/junit/(root)/UNIT_gz_src_TEST/test_ran/

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
