### PR TITLE
Only check GZ_TRANSPORT_TOPIC_STATISTICS once

### DIFF
--- a/src/Discovery.hh
+++ b/src/Discovery.hh
@@ -1570,10 +1570,13 @@ namespace gz
       {
         static std::string gzStats;
         static int topicStats;
+        static bool versionInitialized = false;
 
-        if (env("GZ_TRANSPORT_TOPIC_STATISTICS", gzStats) && !gzStats.empty())
+        if (!versionInitialized &&
+            env("GZ_TRANSPORT_TOPIC_STATISTICS", gzStats) && !gzStats.empty())
         {
           topicStats = (gzStats == "1");
+          versionInitialized = true;
         }
 
         return this->kWireVersion + (topicStats * 100);


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes #701 

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

According to #701, checking an environment variable every time that we're inside the `Version()` function might cause a crash. This patch only checks the environment variable once.

There's some behavior change here because you cannot change the value of the environment variable in the middle of a gz-transport session anymore. I think it's probably a good idea not allowing that but I can be convinced otherwise.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.