### PR TITLE
Parse the version correctly when using gz log subcommands

### DIFF
--- a/log/src/cmd/cmdlog.rb.in
+++ b/log/src/cmd/cmdlog.rb.in
@@ -36,7 +36,7 @@ class Cmd
       exe_name = File.expand_path(File.join(File.dirname(__FILE__), exe_name))
     end
     conf_version = LIBRARY_VERSION
-    exe_version = `#{exe_name} --version`.strip
+    exe_version = `#{exe_name} --version record`.strip
 
     # Sanity check: Verify that the version of the yaml file matches the version
     # of the library that we are using.


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes #742

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

It looks like the stand-alone `gz-transport-log-main` executable wasn't properly parsing the version number.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
