### PR TITLE
Manual forward port of: Bazel update (#749)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,5 +1,6 @@
 module(
     name = "gz-transport",
+    compatibility_level = 14,
 )
 
 bazel_dep(name = "buildifier_prebuilt", version = "8.2.0.2")
@@ -15,15 +16,15 @@ bazel_dep(name = "rules_cc", version = "0.1.2")
 
 # Gazebo Dependencies
 bazel_dep(name = "rules_gazebo", version = "0.0.6")
-bazel_dep(name = "gz-common")
-bazel_dep(name = "gz-math")
-bazel_dep(name = "gz-utils")
-bazel_dep(name = "gz-msgs")
+bazel_dep(name = "gz-common", version = "7.0.0")
+bazel_dep(name = "gz-math", version = "9.0.0")
+bazel_dep(name = "gz-msgs", version = "12.0.0")
+bazel_dep(name = "gz-utils", version = "4.0.0")
 
 archive_override(
     module_name = "gz-common",
-    strip_prefix = "gz-common-gz-common7",
-    urls = ["https://github.com/gazebosim/gz-common/archive/refs/heads/gz-common7.tar.gz"],
+    strip_prefix = "gz-common-main",
+    urls = ["https://github.com/gazebosim/gz-common/archive/refs/heads/main.tar.gz"],
 )
 
 archive_override(


### PR DESCRIPTION
The change had to be amended to apply it on main. Specifically, the repo archive_overrides in MODULE.bazel for gz deps was removed in that PR on the Jetty branch, but we want to preserve it on main to ensure CI uses gz deps from HEAD.

-- Original PR description
- Add compatibility_level to match what is set in BCR

Also, small fix to use gz-common from main branch in `archive_override` instead of from Jetty release branch.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
