### PR TITLE
Enable remaining Zenoh tests

### DIFF
--- a/log/test/integration/playback.cc
+++ b/log/test/integration/playback.cc
@@ -202,8 +202,6 @@ TEST(playback, GZ_UTILS_TEST_DISABLED_ON_MAC(ReplayNoSuchTopic))
 /// the original.
 TEST(playback, GZ_UTILS_TEST_DISABLED_ON_MAC(ReplayLogRegex))
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
-
   std::vector<std::string> topics = {"/foo", "/bar", "/baz"};
 
   std::vector<MessageInformation> incomingData;
@@ -271,8 +269,6 @@ TEST(playback, GZ_UTILS_TEST_DISABLED_ON_MAC(ReplayLogRegex))
 /// that the playback matches the original.
 TEST(playback, GZ_UTILS_TEST_DISABLED_ON_MAC(RemoveTopic))
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
-
   std::vector<std::string> topics = {"/foo", "/bar", "/baz"};
 
   std::vector<MessageInformation> incomingData;

--- a/log/test/integration/recorder.cc
+++ b/log/test/integration/recorder.cc
@@ -272,16 +272,12 @@ void RecordPatternBeforeAdvertisement(const std::regex &_pattern)
 //////////////////////////////////////////////////
 TEST(recorder, BeginRecordingPatternBeforeAdvertisement)
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
-
   RecordPatternBeforeAdvertisement(std::regex(".*foo.*"));
 }
 
 //////////////////////////////////////////////////
 TEST(recorder, BeginRecordingAllBeforeAdvertisement)
 {
-  CHECK_UNSUPPORTED_IMPLEMENTATION("zenoh")
-
   RecordPatternBeforeAdvertisement(std::regex(".*"));
 }
 

--- a/src/Discovery.hh
+++ b/src/Discovery.hh
@@ -362,10 +362,8 @@ namespace gz
           }
         }
 
-        // TODO(azeey) Uncommenting the following two lines causes a crash for
-        // some reason.
-        // if (cb)
-        //   cb(pub);
+        if (cb)
+          cb(pub);
       }
 
       //////////////////////////////////////////////////

--- a/src/NodeShared.cc
+++ b/src/NodeShared.cc
@@ -994,6 +994,10 @@ void NodeShared::SendPendingRemoteReqs(const std::string &_topic,
 //////////////////////////////////////////////////
 void NodeShared::OnNewConnection(const MessagePublisher &_pub)
 {
+  std::string impl = this->GzImplementation();
+  if (impl != "zeromq")
+    return;
+
   std::string topic = _pub.Topic();
   std::string addr = _pub.Addr();
   std::string procUuid = _pub.PUuid();


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes #760 

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

The `Log::Recorder` class was registering a custom connection callback on the discovery but it wasn't executing when Zenoh was used.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.