### PR TITLE
Fix unused-result complaint

### DIFF
--- a/src/NodeShared.cc
+++ b/src/NodeShared.cc
@@ -1785,7 +1785,7 @@ void NodeShared::EnableStats(const std::string &_topic, bool _enable,
   }
   else
   {
-    this->dataPtr->enabledTopicStatistics.extract(_topic);
+    this->dataPtr->enabledTopicStatistics.erase(_topic);
     // \todo Also cleanup topicStats.
   }
 }


### PR DESCRIPTION
# 🦟 Bug fix


## Summary

A recent version of llvm complains about this line, so replace the `map::extract` call with `map::erase` since the result is not used.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
