### PR TITLE
Refactor TopicUtils::AsValidTopic() removing regex

### DIFF
--- a/src/TopicUtils.cc
+++ b/src/TopicUtils.cc
@@ -16,7 +16,6 @@
 */
 
 #include <algorithm>
-#include <regex>
 #include <string>
 #include <vector>
 
@@ -385,18 +384,43 @@ bool TopicUtils::DecomposeLivelinessToken(
 //////////////////////////////////////////////////
 std::string TopicUtils::AsValidTopic(const std::string &_topic)
 {
-  std::string validTopic{_topic};
+  std::string validTopic;
+  validTopic.reserve(_topic.size());
 
-  // Substitute spaces with _
-  validTopic = std::regex_replace(validTopic, std::regex(" "), "_");
+  for (std::size_t i = 0; i < _topic.size(); ++i)
+  {
+    char c = _topic[i];
 
-  // Remove special characters and combinations
-  validTopic = std::regex_replace(validTopic, std::regex("@|~|//|:="), "");
+    // Substitute spaces with '_'.
+    if (c == ' ')
+    {
+      validTopic += '_';
+      continue;
+    }
+
+    // Skip '@' and '~'.
+    if (c == '@' || c == '~')
+      continue;
+
+    // Skip ":=".
+    if (c == ':' && i + 1 < _topic.size() && _topic[i + 1] == '=')
+    {
+      ++i;
+      continue;
+    }
+
+    // Skip "//".
+    if (c == '/' && i + 1 < _topic.size() && _topic[i + 1] == '/')
+    {
+      ++i;
+      continue;
+    }
+
+    validTopic += c;
+  }
 
   if (!IsValidTopic(validTopic))
-  {
     return std::string();
-  }
 
   return validTopic;
 }


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

This patch refactors `AsValidTopic()` with the following benefits:

* Single pass instead of multiple `regex` compilations and scans.
* No `regex` overhead.
* A bit more memory efficient using `reserve()`.

[My benchmark](https://quick-bench.com/q/OgfrzrQZ1IztC4_SDUuKf6vLfE4) shows around 30X improvement (blue is the original code, yellow the new one. Lower is faster).

<img width="1189" height="594" alt="image" src="https://github.com/user-attachments/assets/d9d15be8-c9d4-4b60-9e89-1da0e0844cff" />


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.