### PR TITLE
[bazel] Few more MacOS fixes

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -11,6 +11,9 @@ build --strict_system_includes
 build --fission=dbg
 build --features=per_object_debug_info
 
+# Enable header processing, required for layering checks with parse_header.
+build --process_headers_in_dependencies
+
 # OS specific settings
 build --enable_platform_specific_config
 build:macos --macos_minimum_os=10.15

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -94,6 +94,8 @@ cc_library(
     visibility = ["//:__subpackages__"],
     deps = [
         ":gz-transport",
+        "@gz-msgs",
+        "@gz-msgs//:gzmsgs_cc_proto",
     ],
 )
 

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -23,7 +23,8 @@ cc_library(
     includes = ["."],
     visibility = ["//:__subpackages__"],
     deps = [
-        "@gz-utils",
+        "//:gz-transport",
+        "@gz-utils//:Subprocess",
     ],
 )
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Fixes downstream build in gz-sim on the main branch (https://github.com/gazebosim/gz-sim/actions/runs/21192351529/job/60961249092#step:8:2724).

These fixes were found by enabling `--process_headers_in_dependencies` by default in .bazelrc. This setting is already enabled in gz-sim, which is why we see the failures there but not on bazel macos CI in gz-transport (green: https://github.com/gazebosim/gz-transport/actions/runs/21304041340).

- Add `--process_headers_in_dependencies` to .bazelrc
- Fix deps for `//test:test_utils`
- Fix deps for `gz-transport-discovery-header`


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.