### PR TITLE
[TopicUtils] Optimize MangleName(), DemangleName() and MangleType()

### DIFF
--- a/src/TopicUtils.cc
+++ b/src/TopicUtils.cc
@@ -490,28 +490,16 @@ std::string TopicUtils::CreateLivelinessToken(
 //////////////////////////////////////////////////
 std::string TopicUtils::MangleName(const std::string &_input)
 {
-  std::string output = "";
-  for (std::size_t i = 0; i < _input.length(); ++i)
-  {
-    if (_input[i] == '/')
-      output += kSlashReplacement;
-    else
-      output += _input[i];
-  }
+  std::string output = _input;
+  std::replace(output.begin(), output.end(), '/', kSlashReplacement);
   return output;
 }
 
 //////////////////////////////////////////////////
 std::string TopicUtils::DemangleName(const std::string &_input)
 {
-  std::string output = "";
-  for (std::size_t i = 0; i < _input.length(); ++i)
-  {
-    if (_input[i] == kSlashReplacement)
-      output += kTokenSeparator;
-    else
-      output += _input[i];
-  }
+  std::string output = _input;
+  std::replace(output.begin(), output.end(), kSlashReplacement, '/');
   return output;
 }
 
@@ -524,7 +512,7 @@ bool TopicUtils::MangleType(const std::vector<std::string> &_input,
   if (_input.empty())
     return false;
 
-  for (auto type : _input)
+  for (const auto &type : _input)
   {
     if (type.empty())
       return false;


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Continuing the improvements in `TopicUtils`, this patch optimizes `MangleName()`, `DemangleName()` and `MangleType()`.

It replaces character-by-character string building with `std::replace` and adds a missing const reference to avoid copying each string.

The benchmarks show that the new functions (the ones with the `2` suffix improve the original ones).

<img width="1198" height="550" alt="Screenshot from 2026-01-26 18-40-31" src="https://github.com/user-attachments/assets/48e628b6-4629-4edf-948f-98309a2f390d" />


## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
