### PR TITLE
Add GZ_TRANSPORT_ZENOH_CONFIG_OVERRIDE env var

### DIFF
--- a/src/NodeSharedPrivate.hh
+++ b/src/NodeSharedPrivate.hh
@@ -104,58 +104,10 @@ namespace gz::transport
         }
 
         // Apply key=value overrides from GZ_TRANSPORT_ZENOH_CONFIG_OVERRIDE.
-        // Format: "key1=value1;key2=value2;..."
-        // Values are passed directly to insert_json5(), so they can be any
-        // valid JSON5 (strings, numbers, objects, arrays).
-        // Example:
-        //   export GZ_TRANSPORT_ZENOH_CONFIG_OVERRIDE=\
-        //     "transport/link/tx/queue/size/data=8;\
-        //      transport/shared_memory/enabled=true"
         const char *overrideEnv =
             std::getenv("GZ_TRANSPORT_ZENOH_CONFIG_OVERRIDE");
         if (overrideEnv)
-        {
-          std::string overrides(overrideEnv);
-          std::string::size_type pos = 0;
-          while (pos < overrides.size())
-          {
-            auto semi = overrides.find(';', pos);
-            if (semi == std::string::npos)
-              semi = overrides.size();
-            auto eq = overrides.find('=', pos);
-            if (eq != std::string::npos && eq < semi)
-            {
-              std::string key = overrides.substr(pos, eq - pos);
-              std::string val = overrides.substr(eq + 1, semi - eq - 1);
-              // Trim leading/trailing whitespace.
-              auto trim = [](std::string &s)
-              {
-                auto start = s.find_first_not_of(" \t");
-                auto end = s.find_last_not_of(" \t");
-                s = (start == std::string::npos) ? "" :
-                    s.substr(start, end - start + 1);
-              };
-              trim(key);
-              trim(val);
-              if (!key.empty())
-              {
-                zenoh::ZResult result;
-                config.insert_json5(key, val, &result);
-                if (result != Z_OK)
-                {
-                  std::cerr << "gz-transport: failed to apply Zenoh config "
-                            << "override: " << key << "=" << val << std::endl;
-                }
-                else if (this->verbose)
-                {
-                  std::cout << "Zenoh config override: " << key
-                            << "=" << val << std::endl;
-                }
-              }
-            }
-            pos = semi + 1;
-          }
-        }
+          ApplyZenohConfigOverrides(config, overrideEnv, this->verbose);
 
         try
         {
@@ -243,6 +195,60 @@ namespace gz::transport
               // Fallback to default configuration.
               _configSource = ZenohConfigSource::kDefault;
               return zenoh::Config::create_default();
+            }
+
+    /// \brief Apply key=value config overrides to a Zenoh config.
+    /// Format: "key1=value1;key2=value2;..."
+    /// Values are passed directly to insert_json5(), so they can be any
+    /// valid JSON5 (strings, numbers, objects, arrays).
+    /// \param[in,out] _config The Zenoh config to modify.
+    /// \param[in] _overrides The override string to parse.
+    /// \param[in] _verbose Print applied overrides to stdout.
+    public: static inline void ApplyZenohConfigOverrides(
+              zenoh::Config &_config,
+              const std::string &_overrides,
+              bool _verbose = false)
+            {
+              std::string::size_type pos = 0;
+              while (pos < _overrides.size())
+              {
+                auto semi = _overrides.find(';', pos);
+                if (semi == std::string::npos)
+                  semi = _overrides.size();
+                auto eq = _overrides.find('=', pos);
+                if (eq != std::string::npos && eq < semi)
+                {
+                  std::string key = _overrides.substr(pos, eq - pos);
+                  std::string val = _overrides.substr(eq + 1, semi - eq - 1);
+                  // Trim leading/trailing whitespace.
+                  auto trim = [](std::string &s)
+                  {
+                    auto start = s.find_first_not_of(" \t");
+                    auto end = s.find_last_not_of(" \t");
+                    s = (start == std::string::npos) ? "" :
+                        s.substr(start, end - start + 1);
+                  };
+                  trim(key);
+                  trim(val);
+                  if (!key.empty())
+                  {
+                    zenoh::ZResult result;
+                    _config.insert_json5(key, val, &result);
+                    if (result != Z_OK)
+                    {
+                      std::cerr << "gz-transport: failed to apply Zenoh "
+                                << "config override: " << key << "="
+                                << val << std::endl;
+                    }
+                    else if (_verbose)
+                    {
+                      std::cout << "Zenoh config override: " << key
+                                << "=" << val << std::endl;
+                    }
+                  }
+                }
+                pos = semi + 1;
+              }
             }
 
     /// \brief Pointer to the Zenoh session.

--- a/src/NodeSharedPrivate.hh
+++ b/src/NodeSharedPrivate.hh
@@ -20,6 +20,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <cstdlib>
 #include <filesystem>
 #include <list>
 #include <map>
@@ -101,6 +102,61 @@ namespace gz::transport
           else
             std::cout << "Zenoh default config loaded" << std::endl;
         }
+
+        // Apply key=value overrides from GZ_TRANSPORT_ZENOH_CONFIG_OVERRIDE.
+        // Format: "key1=value1;key2=value2;..."
+        // Values are passed directly to insert_json5(), so they can be any
+        // valid JSON5 (strings, numbers, objects, arrays).
+        // Example:
+        //   export GZ_TRANSPORT_ZENOH_CONFIG_OVERRIDE=\
+        //     "transport/link/tx/queue/size/data=8;\
+        //      transport/shared_memory/enabled=true"
+        const char *overrideEnv =
+            std::getenv("GZ_TRANSPORT_ZENOH_CONFIG_OVERRIDE");
+        if (overrideEnv)
+        {
+          std::string overrides(overrideEnv);
+          std::string::size_type pos = 0;
+          while (pos < overrides.size())
+          {
+            auto semi = overrides.find(';', pos);
+            if (semi == std::string::npos)
+              semi = overrides.size();
+            auto eq = overrides.find('=', pos);
+            if (eq != std::string::npos && eq < semi)
+            {
+              std::string key = overrides.substr(pos, eq - pos);
+              std::string val = overrides.substr(eq + 1, semi - eq - 1);
+              // Trim leading/trailing whitespace.
+              auto trim = [](std::string &s)
+              {
+                auto start = s.find_first_not_of(" \t");
+                auto end = s.find_last_not_of(" \t");
+                s = (start == std::string::npos) ? "" :
+                    s.substr(start, end - start + 1);
+              };
+              trim(key);
+              trim(val);
+              if (!key.empty())
+              {
+                zenoh::ZResult result;
+                config.insert_json5(key, val, &result);
+                if (result != Z_OK)
+                {
+                  std::cerr << "gz-transport: failed to apply Zenoh config "
+                            << "override: " << key << "=" << val << std::endl;
+                }
+                else if (this->verbose)
+                {
+                  std::cout << "Zenoh config override: " << key
+                            << "=" << val << std::endl;
+                }
+              }
+            }
+            pos = semi + 1;
+          }
+        }
+
         try
         {
           this->session = std::make_shared<zenoh::Session>(

--- a/src/NodeShared_TEST.cc
+++ b/src/NodeShared_TEST.cc
@@ -131,4 +131,133 @@ TEST(ZenohConfigTest, InvalidConfigContent)
   ASSERT_TRUE(gz::utils::unsetenv("ZENOH_CONFIG"));
 }
 
+//////////////////////////////////////////////////
+/// \brief Test applying a single config override.
+TEST(ZenohConfigTest, ConfigOverrideSingle)
+{
+  auto config = zenoh::Config::create_default();
+
+  gz::transport::NodeSharedPrivate::ApplyZenohConfigOverrides(
+    config, "scouting/multicast/enabled=false");
+
+  EXPECT_EQ("false", config.get("scouting/multicast/enabled"));
+}
+
+//////////////////////////////////////////////////
+/// \brief Test applying multiple config overrides separated by semicolons.
+TEST(ZenohConfigTest, ConfigOverrideMultiple)
+{
+  auto config = zenoh::Config::create_default();
+
+  gz::transport::NodeSharedPrivate::ApplyZenohConfigOverrides(
+    config,
+    "scouting/multicast/enabled=false;"
+    "listen/endpoints=[\"tcp/127.0.0.1:0\"]");
+
+  EXPECT_EQ("false", config.get("scouting/multicast/enabled"));
+  EXPECT_EQ("[\"tcp/127.0.0.1:0\"]", config.get("listen/endpoints"));
+}
+
+//////////////////////////////////////////////////
+/// \brief Test that whitespace around keys and values is trimmed.
+TEST(ZenohConfigTest, ConfigOverrideWhitespace)
+{
+  auto config = zenoh::Config::create_default();
+
+  gz::transport::NodeSharedPrivate::ApplyZenohConfigOverrides(
+    config, "  scouting/multicast/enabled  =  false  ");
+
+  EXPECT_EQ("false", config.get("scouting/multicast/enabled"));
+}
+
+//////////////////////////////////////////////////
+/// \brief Test that trailing semicolons are handled gracefully.
+TEST(ZenohConfigTest, ConfigOverrideTrailingSemicolon)
+{
+  auto config = zenoh::Config::create_default();
+
+  gz::transport::NodeSharedPrivate::ApplyZenohConfigOverrides(
+    config, "scouting/multicast/enabled=false;");
+
+  EXPECT_EQ("false", config.get("scouting/multicast/enabled"));
+}
+
+//////////////////////////////////////////////////
+/// \brief Test that empty override string is a no-op.
+TEST(ZenohConfigTest, ConfigOverrideEmpty)
+{
+  auto config = zenoh::Config::create_default();
+  auto valBefore = config.get("scouting/multicast/enabled");
+
+  gz::transport::NodeSharedPrivate::ApplyZenohConfigOverrides(config, "");
+
+  EXPECT_EQ(valBefore, config.get("scouting/multicast/enabled"));
+}
+
+//////////////////////////////////////////////////
+/// \brief Test that invalid keys produce an error on stderr but don't crash.
+TEST(ZenohConfigTest, ConfigOverrideInvalidKey)
+{
+  auto config = zenoh::Config::create_default();
+
+  testing::internal::CaptureStderr();
+  gz::transport::NodeSharedPrivate::ApplyZenohConfigOverrides(
+    config, "nonexistent/key/path=42");
+  std::string stderrOutput = testing::internal::GetCapturedStderr();
+
+  EXPECT_FALSE(stderrOutput.empty())
+    << "Expected an error message for invalid config key";
+  EXPECT_NE(std::string::npos, stderrOutput.find("failed to apply"))
+    << "Error should contain 'failed to apply'. Got: " << stderrOutput;
+}
+
+//////////////////////////////////////////////////
+/// \brief Test that bare values without '=' are silently skipped.
+TEST(ZenohConfigTest, ConfigOverrideMalformedPair)
+{
+  auto config = zenoh::Config::create_default();
+
+  // "noequals" has no '=', should be skipped; second pair should apply
+  gz::transport::NodeSharedPrivate::ApplyZenohConfigOverrides(
+    config, "noequals;scouting/multicast/enabled=false");
+
+  EXPECT_EQ("false", config.get("scouting/multicast/enabled"));
+}
+
+//////////////////////////////////////////////////
+/// \brief Test that values containing '=' are handled correctly.
+/// The value ["tcp/host:7447=extra"] contains an '=' inside the JSON array.
+TEST(ZenohConfigTest, ConfigOverrideEqualsInValue)
+{
+  auto config = zenoh::Config::create_default();
+
+  gz::transport::NodeSharedPrivate::ApplyZenohConfigOverrides(
+    config, "connect/endpoints=[\"tcp/127.0.0.1:7447\"]");
+
+  EXPECT_EQ("[\"tcp/127.0.0.1:7447\"]", config.get("connect/endpoints"));
+}
+
+//////////////////////////////////////////////////
+/// \brief Test that the env var integration path works end-to-end.
+TEST(ZenohConfigTest, ConfigOverrideViaEnvVar)
+{
+  ASSERT_TRUE(gz::utils::setenv(
+    "GZ_TRANSPORT_ZENOH_CONFIG_OVERRIDE",
+    "scouting/multicast/enabled=false"));
+
+  gz::transport::NodeSharedPrivate nodePrivate;
+  ZenohConfigSource source;
+  auto config = nodePrivate.ZenohConfig(source);
+
+  const char *overrideEnv =
+      std::getenv("GZ_TRANSPORT_ZENOH_CONFIG_OVERRIDE");
+  ASSERT_NE(nullptr, overrideEnv);
+  gz::transport::NodeSharedPrivate::ApplyZenohConfigOverrides(
+    config, overrideEnv);
+
+  EXPECT_EQ("false", config.get("scouting/multicast/enabled"));
+
+  ASSERT_TRUE(gz::utils::unsetenv("GZ_TRANSPORT_ZENOH_CONFIG_OVERRIDE"));
+}
+
 #endif  // HAVE_ZENOH

--- a/tutorials/20_env_variables.md
+++ b/tutorials/20_env_variables.md
@@ -64,6 +64,14 @@ Below are descriptions of the available environment variables:
     * *Default value*: zeromq
     * *Description*: Sets the middleware backend.
     * *Available in backend:*: zeromq, zenoh
+* **GZ_TRANSPORT_ZENOH_CONFIG_OVERRIDE**
+    * *Value allowed*: Semicolon-separated `key=value` pairs
+    * *Description*: Override specific Zenoh configuration parameters after
+    loading the config file (or defaults). Keys are Zenoh config paths and
+    values are JSON5 literals. Applied after `ZENOH_CONFIG` is loaded, so
+    overrides take priority. Example:
+    `GZ_TRANSPORT_ZENOH_CONFIG_OVERRIDE="transport/link/tx/queue/size/data=8;transport/shared_memory/enabled=true"`
+    * *Available in backend:*: zenoh
 * **GZ_TRANSPORT_LOG_SQL_PATH**
     * *Value allowed*: Any path
     * *Description*: Path to the SQL files used by logging. This does not


### PR DESCRIPTION
# 🎉 New feature

This patch adds `GZ_TRANSPORT_ZENOH_CONFIG_OVERRIDE`, an environment variable that allows overriding specific Zenoh configuration parameters without requiring a config file.

This is similar to the ZENOH_CONFIG_OVERRIDE in [rmw_zenoh](https://github.com/ros2/rmw_zenoh?tab=readme-ov-file#examples).

  **Format:** Semicolon-separated `key=value` pairs where values are JSON5 literals.

  ```bash
export GZ_TRANSPORT_ZENOH_CONFIG_OVERRIDE= "scouting/multicast/enabled=false;transport/link/tx/queue/size/data=8"
```
**Priority**: Overrides are applied after loading the Zenoh config file (via `ZENOH_CONFIG`), so they take precedence over file-based settings.

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [x] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.