### PR TITLE
Fix memory leak in ReqHandler<> specialization

### DIFF
--- a/include/gz/transport/ReqHandler.hh
+++ b/include/gz/transport/ReqHandler.hh
@@ -318,7 +318,7 @@ namespace gz::transport
         return;
       }
 
-      this->reqMsg = _reqMsg->New();
+      this->reqMsg.reset(_reqMsg->New());
       this->reqMsg->CopyFrom(*_reqMsg);
     }
 
@@ -334,7 +334,7 @@ namespace gz::transport
         return;
       }
 
-      this->repMsg = _repMsg->New();
+      this->repMsg.reset(_repMsg->New());
       this->repMsg->CopyFrom(*_repMsg);
     }
 
@@ -394,10 +394,10 @@ namespace gz::transport
     }
 
     /// \brief Protobuf message containing the request's parameters.
-    private: google::protobuf::Message *reqMsg = nullptr;
+    private: std::unique_ptr<google::protobuf::Message> reqMsg;
 
     /// \brief Protobuf message containing the response.
-    private: google::protobuf::Message *repMsg = nullptr;
+    private: std::unique_ptr<google::protobuf::Message> repMsg;
   };
   }
 }


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixed memory leak found with AddressSanitizer:

```
  ==4002066==ERROR: LeakSanitizer: detected memory leaks

  Direct leak of 64 byte(s) in 2 object(s) allocated from:
      #0 0x7ea5c5cfe548 in operator new(unsigned long)
      #1 0x7ea5c5589699 in google::protobuf::Arena::InternalHelper<gz::msgs::Int32>::New()
      #4 0x7ea5c588c367 in gz::transport::v16::Node::RequestRaw(...)
      #5 0x5db8feb61478 in MyTestClass::TestServiceCall()

  SUMMARY: AddressSanitizer: 64 byte(s) leaked in 2 allocation(s).

```

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.