### PR TITLE
Fix async signal safety undefined behavior in waitForShutdown()

### DIFF
--- a/src/WaitHelpers.cc
+++ b/src/WaitHelpers.cc
@@ -16,10 +16,17 @@
 */
 
 #include <algorithm>
-#include <condition_variable>
+#include <cerrno>
 #include <csignal>
-#include <mutex>
+#include <string>
 #include <vector>
+
+#ifdef _WIN32
+  #include <io.h>
+  #include <fcntl.h>
+#else
+  #include <unistd.h>
+#endif
 
 #include "gz/transport/WaitHelpers.hh"
 #include "gz/transport/Node.hh"
@@ -28,39 +35,79 @@ namespace gz::transport
 {
 inline namespace GZ_TRANSPORT_VERSION_NAMESPACE
 {
-/// \brief Flag to detect SIGINT or SIGTERM while the code is executing
-/// waitForShutdown().
-static bool g_shutdown = false;
+namespace
+{
+// Platform shims for pipe / read / write. On Windows the C runtime
+// provides POSIX-compatible _pipe / _read / _write in <io.h>.
+#ifdef _WIN32
+  inline int gzPipe(int _fds[2])
+  { return _pipe(_fds, 256, _O_BINARY); }
+  inline int gzRead(int _fd, void *_buf, unsigned int _n)
+  { return _read(_fd, _buf, _n); }
+  inline int gzWrite(int _fd, const void *_buf, unsigned int _n)
+  { return _write(_fd, _buf, _n); }
+#else
+  inline int gzPipe(int _fds[2])
+  { return ::pipe(_fds); }
+  inline ssize_t gzRead(int _fd, void *_buf, size_t _n)
+  { return ::read(_fd, _buf, _n); }
+  inline ssize_t gzWrite(int _fd, const void *_buf, size_t _n)
+  { return ::write(_fd, _buf, _n); }
+#endif
 
-/// \brief Mutex to protect the boolean shutdown variable.
-static std::mutex g_shutdown_mutex;
-
-/// \brief Condition variable to wakeup waitForShutdown() and exit.
-static std::condition_variable g_shutdown_cv;
+/// \brief Self-pipe used to wake waitForShutdown() from the signal handler.
+/// The signal handler writes one byte (async-signal-safe on POSIX, a normal
+/// thread-safe kernel call on Windows). waitForShutdown() blocks on read().
+int g_shutdownPipe[2] = {-1, -1};
+}  // namespace
 
 //////////////////////////////////////////////////
-/// \brief Function executed when a SIGINT or SIGTERM signals are captured.
+/// \brief Function executed when a SIGINT or SIGTERM signal is captured.
+/// Only async-signal-safe operations are used here: per signal-safety(7),
+/// write() is on the POSIX async-signal-safe list, while mutex and condition
+/// variable operations are not.
 /// \param[in] _signal Signal received.
 static void signal_handler(const int _signal)
 {
   if (_signal == SIGINT || _signal == SIGTERM)
   {
-    g_shutdown_mutex.lock();
-    g_shutdown = true;
-    g_shutdown_mutex.unlock();
-    g_shutdown_cv.notify_all();
+    if (g_shutdownPipe[1] < 0)
+      return;
+    const char c = 'x';
+    // On Windows the handler runs on a runtime-spawned thread, so this
+    // is just a thread-safe kernel call. Ignore short writes / EAGAIN —
+    // a single byte is sufficient to wake the reader.
+    auto n = gzWrite(g_shutdownPipe[1], &c, 1);
+    (void)n;
   }
 }
 
 //////////////////////////////////////////////////
 void waitForShutdown()
 {
-  // Install a signal handler for SIGINT and SIGTERM.
+  // Lazily create the self-pipe on first call. We never close the fds:
+  // waitForShutdown() is invoked at most once per process in practice,
+  // and the OS reclaims them at exit.
+  if (g_shutdownPipe[0] < 0 && gzPipe(g_shutdownPipe) != 0)
+    return;
+
+  // Install handlers AFTER the pipe exists so a signal arriving between
+  // the two calls cannot find an uninitialized pipe.
   std::signal(SIGINT,  signal_handler);
   std::signal(SIGTERM, signal_handler);
 
-  std::unique_lock<std::mutex> lk(g_shutdown_mutex);
-  g_shutdown_cv.wait(lk, []{return g_shutdown;});
+  // Block until the signal handler writes one byte. Retry on EINTR
+  // because the signal itself may interrupt the read().
+  char c;
+  while (true)
+  {
+    auto n = gzRead(g_shutdownPipe[0], &c, 1);
+    if (n == 1)
+      break;
+    if (n < 0 && errno == EINTR)
+      continue;
+    break;  // EOF or unrecoverable error
+  }
 }
 
 //////////////////////////////////////////////////

--- a/src/WaitHelpers_TEST.cc
+++ b/src/WaitHelpers_TEST.cc
@@ -158,3 +158,19 @@ TEST(WaitHelpersTest, waitForShutdownSIGTERM)
   raise(SIGTERM);
   aThread.join();
 }
+
+//////////////////////////////////////////////////
+/// \brief Stress-test re-entry into waitForShutdown(). The implementation
+/// keeps a process-wide self-pipe alive across calls; this test loops the
+/// wait-and-signal cycle to flush out edge cases in the persistent state
+/// (e.g. left-over bytes in the pipe, handler installation order).
+TEST(WaitHelpersTest, waitForShutdownReEntryStress)
+{
+  for (int i = 0; i < 10; ++i)
+  {
+    std::thread aThread([]{transport::waitForShutdown();});
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    raise(SIGINT);
+    aThread.join();
+  }
+}


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

`waitForShutdown()` previously called `std::mutex::lock()`, `std::mutex::unlock()`, and `std::condition_variable::notify_all()` from inside its `SIGINT`/`SIGTERM` handler. Today I learned that none of these are on POSIX's async-signal-safe list (`signal-safety(7)`), so the behavior was undefined on Linux/macOS 🤯.
                                                                                                                                                        
This patch replaces the mutex/CV machinery with the **self-pipe trick**: the signal handler does only an async-signal-safe `write()` of one byte to a pipe, and `waitForShutdown()` blocks on `read()` of the read end. Instant wakeup, no polling, no locks, no undefined behavior.

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Claude Opus 4.6

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.