### PR TITLE
Mark flaky Bazel integration tests as flaky

### DIFF
--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -111,6 +111,7 @@ flaky_test_srcs = [
         "GZ_BAZEL": "1",
         "GZ_IP": "127.0.0.1",
     },
+    flaky = src in flaky_test_srcs,
     deps = [
         ":Config",
         ":utils",
@@ -121,4 +122,4 @@ flaky_test_srcs = [
         "@gz-utils//:Environment",
         "@gz-utils//:Subprocess",
     ],
-) for src in integration_test_sources if src not in flaky_test_srcs]
+) for src in integration_test_sources]


### PR DESCRIPTION
# Bug fix

Fixes #865

## Summary

Before this change, the Bazel integration tests listed in `flaky_test_srcs` were filtered out of target generation, so they did not run as Bazel tests. This keeps those targets generated and sets Bazel's target-level `flaky` attribute from the existing list instead.

Verification performed locally:
- `go run github.com/bazelbuild/buildtools/buildifier@latest test/BUILD.bazel`
- `go run github.com/bazelbuild/buildtools/buildifier@latest -mode=check test/BUILD.bazel`

Current PR checks are also passing for DCO, Mergify summary, homebrew arm64, noble amd64, and Windows CI.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add Generated-by to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: OpenAI Codex