### PR TITLE
Fix GCC -Wmaybe-uninitialized warning in Ubuntu 26.04

### DIFF
--- a/include/gz/transport/TopicUtils.hh
+++ b/include/gz/transport/TopicUtils.hh
@@ -21,6 +21,7 @@
 #include <cstdint>
 #include <string>
 #include <optional>
+#include <utility>
 #include <vector>
 
 #include "gz/transport/config.hh"
@@ -387,12 +388,11 @@ namespace gz::transport
                                 const std::string &_topic)
         : partition(_partition), ns(_ns), topic(_topic)
     {
-      this->fullTopic.emplace();
-      if (!TopicUtils::FullyQualifiedName(_partition, _ns, _topic,
-                                          *this->fullTopic))
-      {
-        this->fullTopic.reset();
-      }
+      // Avoid emplace+reset on fullTopic: GCC -Wmaybe-uninitialized
+      // false-positives the reset path through inlined readers.
+      std::string fullName;
+      if (TopicUtils::FullyQualifiedName(_partition, _ns, _topic, fullName))
+        this->fullTopic = std::move(fullName);
     }
     /// \brief Gets the partition
     /// \return partition


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes [this warning](https://build.osrfoundation.org/job/gz_transport-ci-main-resolute-amd64/2/gcc/) on GCC in Ubuntu 26.04.

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Opus 4.7

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.