### PR TITLE
Return `FullyQualifiedTopic::FullTopic()` by const reference

### DIFF
--- a/include/gz/transport/TopicUtils.hh
+++ b/include/gz/transport/TopicUtils.hh
@@ -414,7 +414,7 @@ namespace gz::transport
     }
     /// \brief Gets the fully qualified topic if it is valid
     /// \return THe fully qualified topic if valid, otherwise std::nullopt
-    std::optional<std::string> FullTopic() const
+    const std::optional<std::string> &FullTopic() const
     {
       return this->fullTopic;
     }


### PR DESCRIPTION
  
  ## Summary
  GCC 15 emits a spurious `-Wmaybe-uninitialized` diagnostic inside
  `std::optional<std::string>`'s copy constructor when `FullTopic()` returns
  by value. The warning is attributed to inlined call sites in downstream
  code (e.g. `Node::SubscribeImpl`), breaking builds compiled with
  `-Werror`.
  
  Returning the member by `const&` removes the `optional<string>` copy from
  the inlined call chain, which avoids the false positive without
  suppressing the warning globally or papering over it with pragmas.
  
  ## Change
  `std::optional<std::string> FullTopic() const` →
  `const std::optional<std::string> &FullTopic() const`

  All in-tree callers use only `if (!t.FullTopic())` truthiness checks and
  `*t.FullTopic()` dereference — both compatible with the new signature.
  
  ## Compatibility
  - ABI: the symbol is `inline` in a header; downstream code recompiles
    against the new return type. No exported library symbol changes.
  - API: callers binding the return to `auto`/`auto&`/`const auto&` work
    unchanged. Callers explicitly copying via
    `std::optional<std::string> x = t.FullTopic();` still compile.
  
  ## Reproducer
  GCC 15.x + libstdc++ 15, building any consumer of
  `gz/transport/Node.hh` with `-Werror -Wmaybe-uninitialized` (default
  under `-Wextra -Werror`). Observed in PX4-Autopilot SITL on Ubuntu
  26.04 with ROS 2 Lyrical Luth.

  ## Test
  - Local build of `gz-transport15` with GCC 15 (warning gone).
  - Downstream rebuild of PX4 `gz_bridge` + `gz_plugins` succeeds with
    `-Werror` and without `-Wno-error=maybe-uninitialized` workaround.
