### PR TITLE
Fix compiler warning with protobuf 35.0

### DIFF
--- a/log/test/integration/recorder.cc
+++ b/log/test/integration/recorder.cc
@@ -486,7 +486,11 @@ void TestBufferSizeSettings(const std::optional<std::size_t> &_bufferSize,
     // Number of ints to get a message size larger than 1MB.
     std::size_t numInts = 1000000;
     MsgType msg;
+#if GOOGLE_PROTOBUF_VERSION >= 7035000
+    msg.mutable_data()->resize(numInts, 0);
+#else
     msg.mutable_data()->Resize(numInts, 0);
+#endif
     // Fill with sequence to avoid compression
     std::iota(msg.mutable_data()->begin(), msg.mutable_data()->end(), i);
     sentMsgSize += msg.SerializeAsString().size();


### PR DESCRIPTION
# 🦟 Bug fix

Part of https://github.com/gazebosim/gz-transport/issues/873

## Summary

The `Resize()` method from `protobuf/repeated_field.h` was deprecated in favor of `resize()` in https://github.com/protocolbuffers/protobuf/pull/26025 and released in protobuf 35.0. This adds compiler directives to select the API based on the available protobuf version.

It should fix the macOS compiler warnings:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_transport-ci-main-homebrew-arm64&build=76)](https://build.osrfoundation.org/job/gz_transport-ci-main-homebrew-arm64/76/) https://build.osrfoundation.org/job/gz_transport-ci-main-homebrew-arm64/76/clang/

I believe this is safe to backport.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
