### PR TITLE
brew: trust eclipse-zenoh/zenoh

### DIFF
--- a/.github/ci/Brewfile
+++ b/.github/ci/Brewfile
@@ -1,3 +1,3 @@
-tap "eclipse-zenoh/zenoh"
+tap "eclipse-zenoh/zenoh", trusted: true
 brew "eclipse-zenoh/zenoh/libzenohc"
 brew "eclipse-zenoh/zenoh/libzenohcpp"


### PR DESCRIPTION
# 🦟 Bug fix

Follow up to https://github.com/gazebo-tooling/release-tools/pull/1508, fixes gz-transport build

[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz_transport-ci-main-homebrew-arm64&build=81)](https://build.osrfoundation.org/view/gz-rotary/job/gz_transport-ci-main-homebrew-arm64/81/) https://build.osrfoundation.org/view/gz-rotary/job/gz_transport-ci-main-homebrew-arm64/81/

## Summary

Homebrew's package descriptions (formulae) are implemented as executable ruby code, which can lead to security issues when using 3rd-party taps, so they have recently added a `brew trust` command to help mitigate security issues, [documented here](https://docs.brew.sh/Tap-Trust). Since brew 6.0.0 was released today, it is now required to declare trust for 3rd party taps, either through the `brew trust` command (done for `osrf/simulation` in https://github.com/gazebo-tooling/release-tools/pull/1508) or by specifying trust in a `Brewfile`, which is done here according to the [brew documentation](https://docs.brew.sh/Tap-Trust).

## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [ ] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
