### PR TITLE
Fix flaky ignTest.TopicInfo on macOS (#887)

### DIFF
--- a/src/cmd/gz_TEST.cc
+++ b/src/cmd/gz_TEST.cc
@@ -80,13 +80,17 @@ void topicCB(const msgs::StringMsg &_msg)
 /// \brief Check 'ign topic -l' running the advertiser on a different process.
 TEST(ignTest, IGN_UTILS_TEST_DISABLED_ON_MAC(TopicList))
 {
-  // Launch a new publisher process that advertises a topic.
+  // Launch a new publisher process that advertises a topic. Keep it alive long
+  // enough for this (potentially slow) discovery query to find it, even when
+  // process startup plus discovery initialization is slow under load (#887).
   std::string publisher_path = testing::portablePathUnion(
     IGN_TRANSPORT_TEST_DIR,
     "INTEGRATION_twoProcsPublisher_aux");
 
+  setenv("IGN_TRANSPORT_TEST_KEEP_ALIVE_SEC", "60", 1);
   testing::forkHandlerType pi = testing::forkAndRun(publisher_path.c_str(),
     g_partition.c_str());
+  unsetenv("IGN_TRANSPORT_TEST_KEEP_ALIVE_SEC");
 
   // Check the 'ign topic -l' command.
   std::string ign = std::string(IGN_PATH);
@@ -103,7 +107,8 @@ TEST(ignTest, IGN_UTILS_TEST_DISABLED_ON_MAC(TopicList))
 
   EXPECT_TRUE(topicFound);
 
-  // Wait for the child process to return.
+  // Stop the (long-lived) publisher and reap it.
+  testing::killFork(pi);
   testing::waitAndCleanupFork(pi);
 }
 
@@ -111,7 +116,9 @@ TEST(ignTest, IGN_UTILS_TEST_DISABLED_ON_MAC(TopicList))
 /// \brief Check 'ign topic -i' running the advertiser on a different process.
 TEST(ignTest, TopicInfo)
 {
-  // Launch a new publisher process that advertises a topic.
+  // Launch a new publisher process that advertises a topic. Keep it alive long
+  // enough for this (potentially slow) discovery query to find it, even when
+  // process startup plus discovery initialization is slow under load (#887).
   std::string publisher_path = testing::portablePathUnion(
     IGN_TRANSPORT_TEST_DIR,
     "INTEGRATION_twoProcsPublisher_aux");
@@ -123,18 +130,23 @@ TEST(ignTest, TopicInfo)
   bool infoFound = false;
   std::string output;
 
+  // Retry until the publisher is actually discovered. Checking for the message
+  // type is a stronger condition than the raw output size, which would also be
+  // satisfied by the "No publishers/subscribers" placeholder output.
   auto testLoop = std::async(std::launch::async, [&]{
     while (!infoFound && retries++ < 10u)
     {
       output = custom_exec_str(ign + " topic -t /foo -i " + g_ignVersion);
-      infoFound = output.size() > 50u;
+      infoFound = output.find("ignition.msgs.Vector3d") != std::string::npos;
       std::this_thread::sleep_for(std::chrono::milliseconds(300));
     }
   });
 
   std::this_thread::sleep_for(std::chrono::seconds(1));
+  setenv("IGN_TRANSPORT_TEST_KEEP_ALIVE_SEC", "60", 1);
   testing::forkHandlerType pi = testing::forkAndRun(publisher_path.c_str(),
     g_partition.c_str());
+  unsetenv("IGN_TRANSPORT_TEST_KEEP_ALIVE_SEC");
 
   testLoop.wait();
   EXPECT_TRUE(infoFound) << "OUTPUT["
@@ -142,7 +154,8 @@ TEST(ignTest, TopicInfo)
     << "]. Expected Size=50" << std::endl;
   EXPECT_TRUE(output.find("ignition.msgs.Vector3d") != std::string::npos);
 
-  // Wait for the child process to return.
+  // Stop the (long-lived) publisher and reap it.
+  testing::killFork(pi);
   testing::waitAndCleanupFork(pi);
 }
 

--- a/test/integration/twoProcsPublisher_aux.cc
+++ b/test/integration/twoProcsPublisher_aux.cc
@@ -15,6 +15,7 @@
  *
 */
 #include <chrono>
+#include <cstdlib>
 #include <string>
 #include <ignition/msgs.hh>
 
@@ -27,7 +28,14 @@ static std::string g_topic = "/foo"; // NOLINT(*)
 
 //////////////////////////////////////////////////
 /// \brief A publisher node.
-void advertiseAndPublish()
+/// \param[in] _keepAliveSec Number of additional seconds to keep the node
+/// alive (still advertising and sending discovery heartbeats) after the two
+/// messages have been published. This lets slow discovery consumers, e.g.
+/// `ign topic -i/-l` on a heavily loaded machine where process startup plus the
+/// ~2s discovery initialization can otherwise outlast a short-lived publisher,
+/// reliably discover this publisher (see issue #887). When 0 (the default) the
+/// node exits promptly, which the waitAndCleanupFork-based tests rely on.
+void advertiseAndPublish(int _keepAliveSec)
 {
   msgs::Vector3d msg;
   msg.set_x(1.0);
@@ -42,6 +50,11 @@ void advertiseAndPublish()
   std::this_thread::sleep_for(std::chrono::milliseconds(1500));
   pub.Publish(msg);
   std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+
+  // Optionally remain alive so slow consumers can still discover us. The
+  // parent process terminates us once it is done, so this is an upper bound.
+  if (_keepAliveSec > 0)
+    std::this_thread::sleep_for(std::chrono::seconds(_keepAliveSec));
 }
 
 //////////////////////////////////////////////////
@@ -56,5 +69,12 @@ int main(int argc, char **argv)
   // Set the partition name for this test.
   setenv("IGN_PARTITION", argv[1], 1);
 
-  advertiseAndPublish();
+  // Optionally stay alive after publishing. The fork-based test helpers cannot
+  // pass extra arguments, so this is controlled via an environment variable
+  // that the parent sets only when it needs a long-lived publisher.
+  int keepAliveSec = 0;
+  if (const char *keepAlive = std::getenv("IGN_TRANSPORT_TEST_KEEP_ALIVE_SEC"))
+    keepAliveSec = std::atoi(keepAlive);
+
+  advertiseAndPublish(keepAliveSec);
 }


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #887

## Summary
Keep the test publisher alive for the whole `ign topic -i/-l` discovery window so the ~3s helper no longer dies before a slow CLI query reads it (and retry on the message type, not output size).

## Backport Policy
- [x] This is safe to backport to the following versions:
    - [x] Fortress

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits.

Generated-by: Claude Opus 4.8 (1M context)