### PR TITLE
[bazel] Fix build for Bazel 9

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -16,7 +16,7 @@ bazel_dep(name = "rules_cc", version = "0.1.2")
 
 # Gazebo Dependencies
 bazel_dep(name = "rules_gazebo", version = "0.0.6")
-bazel_dep(name = "gz-common", version = "7.0.0")
-bazel_dep(name = "gz-math", version = "9.0.0")
-bazel_dep(name = "gz-msgs", version = "12.0.1")
-bazel_dep(name = "gz-utils", version = "4.0.0")
+bazel_dep(name = "gz-common", version = "7.2.0")
+bazel_dep(name = "gz-math", version = "9.2.0")
+bazel_dep(name = "gz-msgs", version = "12.0.2")
+bazel_dep(name = "gz-utils", version = "4.0.0.bcr.1")


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Fixes bazel 9 build failure introduced in the backport PR https://github.com/gazebosim/gz-transport/pull/890. Fix is to bump the upstream gz-* deps to bazel 9 compatible versions from BCR.

## Backport Policy
- [ ] This is safe to backport to the following versions:
    - [ ] Jetty
    - [ ] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [x] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
