### PR TITLE
Return FullTopic() by const reference for consistency

### DIFF
--- a/include/gz/transport/TopicUtils.hh
+++ b/include/gz/transport/TopicUtils.hh
@@ -413,8 +413,8 @@ namespace gz::transport
       return this->topic;
     }
     /// \brief Gets the fully qualified topic if it is valid
-    /// \return THe fully qualified topic if valid, otherwise std::nullopt
-    std::optional<std::string> FullTopic() const
+    /// \return The fully qualified topic if valid, otherwise std::nullopt
+    const std::optional<std::string> &FullTopic() const
     {
       return this->fullTopic;
     }


### PR DESCRIPTION
## Summary

Return `FullTopic()` by const reference, for consistency with `Partition()`, `Namespace()` and `Topic()`, which all return by reference.

## Backport Policy

- [x] This **should not** be backported

Slightly API change

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)