### PR TITLE
Avoid copying the optional from FullTopic() in SubscribeImpl

### DIFF
--- a/include/gz/transport/detail/Node.hh
+++ b/include/gz/transport/detail/Node.hh
@@ -148,10 +148,9 @@ namespace gz::transport
     std::string topic = _topic;
     this->Options().TopicRemap(_topic, topic);
 
-    FullyQualifiedTopic fullyQualifiedTopic(
-      this->Options().Partition(), this->Options().NameSpace(), topic);
-
-    if (!fullyQualifiedTopic.FullTopic())
+    std::string fullTopic;
+    if (!TopicUtils::FullyQualifiedName(this->Options().Partition(),
+      this->Options().NameSpace(), topic, fullTopic))
     {
       std::cerr << "Topic [" << topic << "] is not valid." << std::endl;
       return nullptr;
@@ -171,6 +170,8 @@ namespace gz::transport
 #ifdef HAVE_ZENOH
     else if (impl == "zenoh")
     {
+      FullyQualifiedTopic fullyQualifiedTopic(
+        this->Options().Partition(), this->Options().NameSpace(), topic);
       subscrHandlerPtr->SetCallback(std::move(_cb),
         this->Shared()->Session(), fullyQualifiedTopic);
     }
@@ -185,9 +186,9 @@ namespace gz::transport
     // it will recover the subscription handler associated to the topic and
     // will invoke the callback.
     this->Shared()->localSubscribers.normal.AddHandler(
-      *fullyQualifiedTopic.FullTopic(), this->NodeUuid(), subscrHandlerPtr);
+      fullTopic, this->NodeUuid(), subscrHandlerPtr);
 
-    if (!this->SubscribeHelper(*fullyQualifiedTopic.FullTopic()))
+    if (!this->SubscribeHelper(fullTopic))
       return nullptr;
 
     return subscrHandlerPtr;


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

GCC 15 reports `-Wmaybe-uninitialized` warning in `Node::SubscribeImpl` when the template is instantiated by downstream code, triggered by copying the `std::optional` returned by `FullTopic()`. The solution is computing the fully qualified name directly into a `std::string`.

I ran into this issue while building the `gz_sensors_vendor` ROS package on Ubuntu Resolute. `main` resolves the same warning via #905 instead, which changed `FullTopic()` to return by const reference.

## Backport Policy

- [x] This **should not** be backported

`FullyQualifiedTopic` does not exist on Ionic, Harmonic or Fortress, so the warning cannot occur there.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] Updated Bazel files (if adding new files). Created an issue otherwise.
- [x] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)
