### PR TITLE
Capture this explicitly in the statistics callback

### DIFF
--- a/src/Node.cc
+++ b/src/Node.cc
@@ -981,7 +981,7 @@ bool Node::EnableStats(const std::string &_topic, bool _enable,
   // Callback used to publish a statistics message.
   // cppcheck-suppress unreadVariable
   std::function<void(const TopicStatistics &_stats)> statCb =
-    [=](const TopicStatistics &_stats) mutable
+    [this](const TopicStatistics &_stats) mutable
     {
       if (this->dataPtr->statPub.ThrottledUpdateReady())
       {


### PR DESCRIPTION
# 🦟 Bug fix

Part of gazebosim/gz-cmake#580

## Summary

`[=]` implicitly captured `this`, which is deprecated in C++20. The lambda only uses `this->dataPtr`, so the capture is now explicit. No behavior change, and it is valid C++17, so it can land before any standard bump.

Before:
```
src/Node.cc:984:5: warning: implicit capture of ‘this’ via ‘[=]’ is deprecated in C++20 [-Wdeprecated]
```

## Backport Policy
- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [ ] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Assisted-by: Claude Opus 5

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.
