### PR TITLE
Fix gz_TEST.TopicPublish test

### DIFF
--- a/src/cmd/gz_TEST.cc
+++ b/src/cmd/gz_TEST.cc
@@ -320,7 +320,7 @@ TEST(gzTest, TopicPublish)
     "-t", "/bar",
     "-m", "gz.msgs.__bad_msg_type",
     "-p", R"(data: "good_value")"});
-  EXPECT_EQ(output.cerr.compare(0, error.size(), error), 0)
+  EXPECT_NE(output.cerr.find(error), std::string::npos)
     << "error {" << error << "}, output.cerr {" << output.cerr << "}";
 
   // Try to publish using an incorrect topic name.
@@ -329,7 +329,7 @@ TEST(gzTest, TopicPublish)
       "-t", "/",
       "-m", "gz.msgs.StringMsg",
       "-p", R"(data: "good_value")"});
-  EXPECT_EQ(output.cerr.compare(0, error.size(), error), 0)
+  EXPECT_NE(output.cerr.find(error), std::string::npos)
     << "error {" << error << "}, output.cerr {" << output.cerr << "}";
 
   // Try to publish using an incorrect number of arguments.
@@ -338,7 +338,7 @@ TEST(gzTest, TopicPublish)
       "-t", "/", "wrong_topic",
       "-m", "gz.msgs.StringMsg",
       "-p", R"(data: "good_value")"});
-  EXPECT_EQ(output.cerr.compare(0, error.size(), error), 0)
+  EXPECT_NE(output.cerr.find(error), std::string::npos)
     << "error {" << error << "}, output.cerr {" << output.cerr << "}";
 }
 


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

This patch fixes recent [Homebrew failures](https://build.osrfoundation.org/job/gz_transport-ci-pr_any-homebrew-arm64/) in CI. The issue seems related with updates in CLI11 and how it shows the error message not matching our expectations.

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [x] This is safe to backport to the following versions:
    - [ ] Jetty
    - [ ] Ionic
    - [ ] Harmonic
    - [x] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Assisted-by: Fable 5

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.