### PR TITLE
Improve gz topic publish

### DIFF
--- a/src/cmd/gz.cc
+++ b/src/cmd/gz.cc
@@ -45,6 +45,7 @@
 #include "gz/transport/config.hh"
 #include "gz/transport/Helpers.hh"
 #include "gz/transport/Node.hh"
+#include "gz/transport/WaitHelpers.hh"
 
 namespace gz::transport
 {
@@ -194,13 +195,9 @@ extern "C" void cmdTopicPub(const char *_topic,
       // Wait for subscribers to be discovered before publishing. After the
       // timeout the message is published anyway, preserving the fire and
       // forget behavior when nobody is listening (see issue #47).
-      auto deadline = std::chrono::steady_clock::now() +
-        std::chrono::milliseconds(3000);
-      while (!pub.HasConnections() &&
-             std::chrono::steady_clock::now() < deadline)
-      {
-        std::this_thread::sleep_for(std::chrono::milliseconds(50));
-      }
+      waitUntil([&pub]{return pub.HasConnections();},
+                std::chrono::milliseconds(3000),
+                std::chrono::milliseconds(50));
 
       // Give new connections a moment to be fully established.
       std::this_thread::sleep_for(std::chrono::milliseconds(100));

--- a/src/cmd/gz.cc
+++ b/src/cmd/gz.cc
@@ -191,10 +191,25 @@ extern "C" void cmdTopicPub(const char *_topic,
     // Publish the message
     if (pub)
     {
-      // \todo(anyone) Change this sleep to a WaitForSubscribers() call.
-      // See issue #47.
-      std::this_thread::sleep_for(std::chrono::milliseconds(800));
+      // Wait for subscribers to be discovered before publishing. After the
+      // timeout the message is published anyway, preserving the fire and
+      // forget behavior when nobody is listening (see issue #47).
+      auto deadline = std::chrono::steady_clock::now() +
+        std::chrono::milliseconds(3000);
+      while (!pub.HasConnections() &&
+             std::chrono::steady_clock::now() < deadline)
+      {
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+      }
+
+      // Give new connections a moment to be fully established.
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
       pub.Publish(*msg);
+
+      // Give the middleware a chance to deliver the message before
+      // destroying the node and closing the sockets, which do not linger.
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
     else
     {

--- a/src/cmd/gz_TEST.cc
+++ b/src/cmd/gz_TEST.cc
@@ -298,8 +298,11 @@ TEST(gzTest, TopicPublish)
   g_topicCBStr = "bad_value";
   EXPECT_TRUE(node.Subscribe("/bar", topicCB));
 
+  // Each attempt waits for the subscriber to be discovered before
+  // publishing, so a few retries are enough. Keep the total runtime within
+  // the test timeout even when discovery is completely broken.
   unsigned int retries = 0;
-  while (retries++ < 100u)
+  while (retries++ < 30u)
   {
     auto output = custom_exec_str({"topic",
         "-t", "/bar",


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

This patch improves the way gz topic publish work removing a hardcoded `sleep_for` in favor of a more robust approach.

## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [x] Ionic
    - [x] Harmonic
    - [x] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Assisted-by: Fable 5

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.