### PR TITLE
More gz service updates (backport #829, #896)

### DIFF
--- a/include/gz/transport/Node.hh
+++ b/include/gz/transport/Node.hh
@@ -794,6 +794,56 @@ namespace gz::transport
         const std::string &_service,
         std::vector<ServicePublisher> &_publishers) const;
 
+    /// \brief Result of a call to ResolveServiceTypes().
+    public: enum class ServiceTypeResolution
+    {
+      /// \brief All requested types were resolved unambiguously.
+      kResolved = 0,
+
+      /// \brief The service name is not valid.
+      kInvalidService,
+
+      /// \brief No provider advertised the service before the timeout
+      /// expired.
+      kNoProviders,
+
+      /// \brief The advertised providers disagree on at least one of the
+      /// types being resolved.
+      kAmbiguousTypes,
+
+      /// \brief The service is advertised, but no provider offers the
+      /// types that were specified by the caller.
+      kIncompatibleTypes,
+    };
+
+    /// \brief Resolve the request and response types advertised by the
+    /// providers of a service. Only the types that are empty on entry are
+    /// resolved; non-empty types are left untouched and are instead used to
+    /// select the providers that the empty types are resolved from. Only
+    /// those matching providers take part in the ambiguity check. If the
+    /// service is not advertised yet, this function keeps polling discovery
+    /// until a matching provider appears or _timeoutMs expires.
+    ///
+    /// Non-empty types must be spelled the same way the providers advertise
+    /// them, i.e. using the canonical protobuf name ("gz.msgs.Empty").
+    ///
+    /// If both types are non-empty there is nothing to resolve, so discovery
+    /// is not consulted at all and kResolved is returned.
+    /// \param[in] _service Name of the service.
+    /// \param[in, out] _reqType Request type. Resolved if empty on entry,
+    /// used to select the providers otherwise.
+    /// \param[in, out] _repType Response type. Resolved if empty on entry,
+    /// used to select the providers otherwise.
+    /// \param[in] _timeoutMs Maximum time to wait, in milliseconds, for a
+    /// matching service provider to appear.
+    /// \return ServiceTypeResolution::kResolved if all the empty types were
+    /// resolved, or the reason for the failure otherwise.
+    public: ServiceTypeResolution ResolveServiceTypes(
+        const std::string &_service,
+        std::string &_reqType,
+        std::string &_repType,
+        unsigned int _timeoutMs = 0) const;
+
     /// \brief Subscribe to a topic registering a callback. The callback must
     /// accept a std::string to represent the message data, and a MessageInfo
     /// which provides metadata about the message.

--- a/src/Node.cc
+++ b/src/Node.cc
@@ -17,8 +17,11 @@
 #include <gz/msgs/discovery.pb.h>
 #include <gz/msgs/statistic.pb.h>
 
+#include <algorithm>
 #include <cassert>
+#include <chrono>
 #include <iostream>
+#include <iterator>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -34,6 +37,7 @@
 #include "gz/transport/TopicUtils.hh"
 #include "gz/transport/TransportTypes.hh"
 #include "gz/transport/Uuid.hh"
+#include "gz/transport/WaitHelpers.hh"
 
 #include "NodePrivate.hh"
 #include "NodeSharedPrivate.hh"
@@ -1139,6 +1143,75 @@ bool Node::ServiceInfo(const std::string &_service,
   }
 
   return true;
+}
+
+//////////////////////////////////////////////////
+Node::ServiceTypeResolution Node::ResolveServiceTypes(
+    const std::string &_service, std::string &_reqType,
+    std::string &_repType, const unsigned int _timeoutMs) const
+{
+  const bool resolveReq = _reqType.empty();
+  const bool resolveRep = _repType.empty();
+  if (!resolveReq && !resolveRep)
+    return ServiceTypeResolution::kResolved;
+
+  std::string fullyQualifiedTopic;
+  if (!TopicUtils::FullyQualifiedName(this->Options().Partition(),
+        this->Options().NameSpace(), _service, fullyQualifiedTopic))
+  {
+    return ServiceTypeResolution::kInvalidService;
+  }
+
+  // A type that the caller pinned down selects which providers the
+  // remaining type is resolved from, so that an explicit type can
+  // disambiguate a service offered with more than one signature.
+  auto compatible = [&](const ServicePublisher &_pub)
+  {
+    return (resolveReq || _pub.ReqTypeName() == _reqType) &&
+           (resolveRep || _pub.RepTypeName() == _repType);
+  };
+
+  // Poll discovery until a compatible provider appears or the timeout
+  // expires.
+  std::vector<ServicePublisher> publishers;
+  bool anyProvider = false;
+  if (!waitUntil([&]{
+        std::vector<ServicePublisher> allPublishers;
+        this->ServiceInfo(_service, allPublishers);
+        anyProvider = !allPublishers.empty();
+
+        publishers.clear();
+        std::copy_if(allPublishers.begin(), allPublishers.end(),
+            std::back_inserter(publishers), compatible);
+        return !publishers.empty();
+      },
+      std::chrono::milliseconds(_timeoutMs), std::chrono::milliseconds(100)))
+  {
+    // Distinguish "nobody is there" from "somebody is there, but not with
+    // the types you asked for": only the latter is worth telling the user
+    // to fix their types over.
+    return anyProvider ? ServiceTypeResolution::kIncompatibleTypes
+                       : ServiceTypeResolution::kNoProviders;
+  }
+
+  const std::string reqType = publishers.front().ReqTypeName();
+  const std::string repType = publishers.front().RepTypeName();
+
+  for (const ServicePublisher &pub : publishers)
+  {
+    if ((resolveReq && pub.ReqTypeName() != reqType) ||
+        (resolveRep && pub.RepTypeName() != repType))
+    {
+      return ServiceTypeResolution::kAmbiguousTypes;
+    }
+  }
+
+  if (resolveReq)
+    _reqType = reqType;
+  if (resolveRep)
+    _repType = repType;
+
+  return ServiceTypeResolution::kResolved;
 }
 
 /////////////////////////////////////////////////

--- a/src/Node_TEST.cc
+++ b/src/Node_TEST.cc
@@ -1934,6 +1934,159 @@ TEST(NodeTest, ServiceCallWithoutInputSyncTimeout)
 }
 
 //////////////////////////////////////////////////
+/// \brief Check that service request and response types can be resolved
+/// from the advertised providers.
+TEST(NodeTest, ResolveServiceTypes)
+{
+  using Resolution = transport::Node::ServiceTypeResolution;
+
+  reset();
+
+  transport::Node node;
+  EXPECT_TRUE(node.Advertise(g_topic, srvEcho));
+
+  // Resolve both types.
+  std::string reqType;
+  std::string repType;
+  EXPECT_EQ(Resolution::kResolved,
+    node.ResolveServiceTypes(g_topic, reqType, repType));
+  EXPECT_EQ("gz.msgs.Int32", reqType);
+  EXPECT_EQ("gz.msgs.Int32", repType);
+
+  // A non-empty type is left untouched, and selects the providers that the
+  // empty type is resolved from.
+  reqType = "gz.msgs.Int32";
+  repType.clear();
+  EXPECT_EQ(Resolution::kResolved,
+    node.ResolveServiceTypes(g_topic, reqType, repType));
+  EXPECT_EQ("gz.msgs.Int32", reqType);
+  EXPECT_EQ("gz.msgs.Int32", repType);
+
+  // A non-empty type that no provider offers is reported, instead of
+  // resolving the other type from a provider that could never serve the
+  // request.
+  reqType = "custom.msgs.Type";
+  repType.clear();
+  EXPECT_EQ(Resolution::kIncompatibleTypes,
+    node.ResolveServiceTypes(g_topic, reqType, repType));
+  EXPECT_EQ("custom.msgs.Type", reqType);
+  EXPECT_TRUE(repType.empty());
+
+  // Nothing to resolve: no discovery involved, even without providers.
+  reqType = "custom.msgs.Type";
+  repType = "custom.msgs.Type";
+  EXPECT_EQ(Resolution::kResolved,
+    node.ResolveServiceTypes("/unadvertised", reqType, repType));
+
+  // An invalid service name.
+  reqType.clear();
+  repType.clear();
+  EXPECT_EQ(Resolution::kInvalidService,
+    node.ResolveServiceTypes("invalid service", reqType, repType));
+
+  // No providers: expect to wait for approximately the timeout.
+  auto t1 = std::chrono::steady_clock::now();
+  EXPECT_EQ(Resolution::kNoProviders,
+    node.ResolveServiceTypes("/unadvertised", reqType, repType, 300));
+  auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+    std::chrono::steady_clock::now() - t1).count();
+  EXPECT_GE(elapsed, 300);
+  EXPECT_TRUE(reqType.empty());
+  EXPECT_TRUE(repType.empty());
+
+  reset();
+}
+
+//////////////////////////////////////////////////
+/// \brief Check that type resolution keeps waiting for a provider that
+/// appears after the call started but before the timeout expires.
+TEST(NodeTest, ResolveServiceTypesWaitsForProvider)
+{
+  using Resolution = transport::Node::ServiceTypeResolution;
+
+  reset();
+
+  std::atomic<bool> testDone{false};
+  std::thread advertiser([&testDone]
+  {
+    // Advertise the service while the main thread is already waiting.
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    transport::Node providerNode;
+    EXPECT_TRUE(providerNode.Advertise(g_topic, srvEcho));
+
+    // Keep the provider alive until the main thread is done resolving.
+    while (!testDone)
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  });
+
+  transport::Node node;
+  std::string reqType;
+  std::string repType;
+  auto t1 = std::chrono::steady_clock::now();
+  EXPECT_EQ(Resolution::kResolved,
+    node.ResolveServiceTypes(g_topic, reqType, repType, 5000));
+  auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+    std::chrono::steady_clock::now() - t1).count();
+
+  // The call must have waited for the provider, not exhausted the timeout.
+  EXPECT_LT(elapsed, 5000);
+  EXPECT_EQ("gz.msgs.Int32", reqType);
+  EXPECT_EQ("gz.msgs.Int32", repType);
+
+  testDone = true;
+  advertiser.join();
+
+  reset();
+}
+
+//////////////////////////////////////////////////
+/// \brief Check that type resolution detects providers that disagree on the
+/// types being resolved and ignores disagreements on explicit types.
+TEST(NodeTest, ResolveServiceTypesAmbiguous)
+{
+  using Resolution = transport::Node::ServiceTypeResolution;
+
+  reset();
+
+  transport::Node node1;
+  transport::Node node2;
+
+  // Same request type as srvEcho, different response type.
+  std::function<bool(const msgs::Int32 &, msgs::StringMsg &)> mixedCb =
+    [](const msgs::Int32 &, msgs::StringMsg &)
+    {
+      return true;
+    };
+
+  EXPECT_TRUE(node1.Advertise(g_topic, srvEcho));
+  EXPECT_TRUE(node2.Advertise(g_topic, mixedCb));
+
+  // The response type is ambiguous.
+  std::string reqType;
+  std::string repType;
+  EXPECT_EQ(Resolution::kAmbiguousTypes,
+    node1.ResolveServiceTypes(g_topic, reqType, repType));
+
+  // An explicit response type selects one of the two providers, so the
+  // request type is no longer ambiguous.
+  reqType.clear();
+  repType = "gz.msgs.StringMsg";
+  EXPECT_EQ(Resolution::kResolved,
+    node1.ResolveServiceTypes(g_topic, reqType, repType));
+  EXPECT_EQ("gz.msgs.Int32", reqType);
+
+  // An explicit response type that neither provider offers is reported as
+  // incompatible rather than resolved from the wrong provider.
+  reqType.clear();
+  repType = "gz.msgs.Vector3d";
+  EXPECT_EQ(Resolution::kIncompatibleTypes,
+    node1.ResolveServiceTypes(g_topic, reqType, repType));
+  EXPECT_TRUE(reqType.empty());
+
+  reset();
+}
+
+//////////////////////////////////////////////////
 /// \brief Create a publisher that sends messages "forever". This function will
 /// be used emitting a SIGINT or SIGTERM signal, to make sure that the transport
 /// library captures the signals, stop all the tasks and signal the event with

--- a/src/cmd/gz.cc
+++ b/src/cmd/gz.cc
@@ -27,6 +27,7 @@
 #include <mutex>
 #include <numeric>
 #include <string>
+#include <utility>
 #include <vector>
 
 #ifdef _MSC_VER
@@ -35,6 +36,7 @@
 #endif
 #include <google/protobuf/text_format.h>
 #include <google/protobuf/util/json_util.h>
+#include <gz/msgs/empty.pb.h>
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif
@@ -224,7 +226,7 @@ extern "C" void cmdTopicPub(const char *_topic,
 //////////////////////////////////////////////////
 extern "C" void cmdServiceReq(const char *_service,
   const char *_reqType, const char *_repType, const int _timeout,
-  const char *_reqData)
+  const char *_reqData, const int _verbose)
 {
   if (!_service)
   {
@@ -236,37 +238,99 @@ extern "C" void cmdServiceReq(const char *_service,
   std::string repType = _repType ? _repType : "";
   Node node;
 
-  if (reqType.empty() || repType.empty())
+  // Service providers advertise canonical protobuf names ("gz.msgs.Empty"),
+  // but the factory also accepts the underscore spelling ("gz_msgs.Empty").
+  // Normalize up front so that every later comparison, both against the
+  // advertised types and against gz.msgs.Empty, sees the canonical name.
+  // Names the factory does not recognize are left alone; they are reported
+  // below, when the message is created.
+  auto canonicalType = [](const std::string &_type) -> std::string
   {
-    std::vector<ServicePublisher> publishers;
-    node.ServiceInfo(_service, publishers);
+    if (auto msg = msgs::Factory::New(_type))
+      return std::string(msg->GetTypeName());
+    return _type;
+  };
 
-    if (publishers.empty())
+  if (!reqType.empty())
+    reqType = canonicalType(reqType);
+  if (!repType.empty())
+    repType = canonicalType(repType);
+
+  const bool inferReq = reqType.empty();
+  const bool inferRep = repType.empty();
+  if (inferReq || inferRep)
+  {
+    const unsigned int timeoutMs =
+      _timeout > 0 ? static_cast<unsigned int>(_timeout) : 0u;
+
+    switch (node.ResolveServiceTypes(_service, reqType, repType, timeoutMs))
     {
-      std::cerr << "No service providers on service [" << _service << "]\n";
-      return;
-    }
-
-    const std::string discoveredReqType = publishers[0].ReqTypeName();
-    const std::string discoveredRepType = publishers[0].RepTypeName();
-
-    for (size_t i = 1; i < publishers.size(); ++i)
-    {
-      if (publishers[i].ReqTypeName() != discoveredReqType ||
-          publishers[i].RepTypeName() != discoveredRepType)
+      case Node::ServiceTypeResolution::kInvalidService:
+        std::cerr << "Service [" << _service << "] is not valid.\n";
+        return;
+      case Node::ServiceTypeResolution::kNoProviders:
+        std::cerr << "No service providers on service [" << _service
+          << "] after waiting " << timeoutMs << " ms.\n"
+          << "Use --reqtype and --reptype to request without discovery.\n";
+        return;
+      case Node::ServiceTypeResolution::kAmbiguousTypes:
       {
+        std::vector<ServicePublisher> publishers;
+        node.ServiceInfo(_service, publishers);
+
         std::cerr << "Ambiguous service types for service [" << _service
-          << "].\n" << "  Provider 1: request=" << discoveredReqType
-          << ", response=" << discoveredRepType << "\n"
-          << "  Provider 2: request=" << publishers[i].ReqTypeName()
-          << ", response=" << publishers[i].RepTypeName() << "\n"
-          << "Use --reqtype and --reptype to specify explicitly.\n";
+          << "]:\n";
+        std::vector<std::pair<std::string, std::string>> uniqueTypes;
+        for (const ServicePublisher &pub : publishers)
+        {
+          auto types = std::make_pair(pub.ReqTypeName(), pub.RepTypeName());
+          if (std::find(uniqueTypes.begin(), uniqueTypes.end(), types) !=
+              uniqueTypes.end())
+          {
+            continue;
+          }
+          uniqueTypes.push_back(types);
+          std::cerr << "  request=" << types.first
+            << ", response=" << types.second << "\n";
+        }
+        std::cerr << "Use --reqtype and --reptype to specify explicitly.\n";
+        // Only suggest --oneway when it has not been given already: with an
+        // explicit response type the ambiguity is on the request type, which
+        // --oneway cannot settle.
+        if (inferRep &&
+            std::any_of(uniqueTypes.begin(), uniqueTypes.end(),
+              [](const auto &_types)
+              {
+                return _types.second == "gz.msgs.Empty";
+              }))
+        {
+          std::cerr << "Use --oneway to select the one-way provider.\n";
+        }
         return;
       }
+      case Node::ServiceTypeResolution::kIncompatibleTypes:
+        // The resolver is only consulted when at least one type is missing,
+        // so exactly one type was given here and it is the one that no
+        // provider offers.
+        std::cerr << "No provider on service [" << _service << "] offers "
+          << (inferReq ? "response" : "request") << " type ["
+          << (inferReq ? repType : reqType) << "].\n";
+        return;
+      case Node::ServiceTypeResolution::kResolved:
+      default:
+        break;
     }
 
-    reqType = reqType.empty() ? discoveredReqType : reqType;
-    repType = repType.empty() ? discoveredRepType : repType;
+    // Let the user know which types were inferred without polluting stdout.
+    if (_verbose)
+    {
+      std::cerr << "Inferred types:";
+      if (inferReq)
+        std::cerr << " request=" << reqType;
+      if (inferRep)
+        std::cerr << (inferReq ? ", response=" : " response=") << repType;
+      std::cerr << "\n";
+    }
   }
 
   if (!_reqData)
@@ -294,9 +358,22 @@ extern "C" void cmdServiceReq(const char *_service,
 
   bool result;
 
-  if (repType == "gz.msgs.Empty")
+  // Match how the core decides that a request is one-way
+  // (see NodeShared::SendPendingRemoteReqs).
+  if (rep->GetTypeName() == msgs::Empty().GetTypeName())
   {
-    // One-way service.
+    // One-way service. No response is ever sent, so the return value and
+    // `result` carry no information and the wait below can only expire.
+    // It is kept, and deliberately not tied to _timeout, purely to give
+    // ZeroMQ a window to flush the request before this process exits: the
+    // requester socket is created with linger set to 0, so returning
+    // immediately would discard anything still queued.
+    //
+    // With explicit types this is best effort by design: discovery is not
+    // consulted (Node::ServiceInfo() would block until discovery is
+    // initialized), so a request that no provider can serve is dropped
+    // silently. When a type is inferred, ResolveServiceTypes() above has
+    // already checked that a compatible provider exists.
     node.Request(_service, *req, 1000, *rep, result);
   }
   else

--- a/src/cmd/gz.cc
+++ b/src/cmd/gz.cc
@@ -232,16 +232,41 @@ extern "C" void cmdServiceReq(const char *_service,
     return;
   }
 
-  if (!_reqType)
-  {
-    std::cerr << "Request type is null\n";
-    return;
-  }
+  std::string reqType = _reqType ? _reqType : "";
+  std::string repType = _repType ? _repType : "";
+  Node node;
 
-  if (!_repType)
+  if (reqType.empty() || repType.empty())
   {
-    std::cerr << "Response type is null\n";
-    return;
+    std::vector<ServicePublisher> publishers;
+    node.ServiceInfo(_service, publishers);
+
+    if (publishers.empty())
+    {
+      std::cerr << "No service providers on service [" << _service << "]\n";
+      return;
+    }
+
+    const std::string discoveredReqType = publishers[0].ReqTypeName();
+    const std::string discoveredRepType = publishers[0].RepTypeName();
+
+    for (size_t i = 1; i < publishers.size(); ++i)
+    {
+      if (publishers[i].ReqTypeName() != discoveredReqType ||
+          publishers[i].RepTypeName() != discoveredRepType)
+      {
+        std::cerr << "Ambiguous service types for service [" << _service
+          << "].\n" << "  Provider 1: request=" << discoveredReqType
+          << ", response=" << discoveredRepType << "\n"
+          << "  Provider 2: request=" << publishers[i].ReqTypeName()
+          << ", response=" << publishers[i].RepTypeName() << "\n"
+          << "Use --reqtype and --reptype to specify explicitly.\n";
+        return;
+      }
+    }
+
+    reqType = reqType.empty() ? discoveredReqType : reqType;
+    repType = repType.empty() ? discoveredRepType : repType;
   }
 
   if (!_reqData)
@@ -251,27 +276,25 @@ extern "C" void cmdServiceReq(const char *_service,
   }
 
   // Create the request, and populate the field with _reqData
-  auto req = msgs::Factory::New(_reqType, _reqData);
+  auto req = msgs::Factory::New(reqType, _reqData);
   if (!req)
   {
-    std::cerr << "Unable to create request of type[" << _reqType << "] "
+    std::cerr << "Unable to create request of type[" << reqType << "] "
               << "with data[" << _reqData << "].\n";
     return;
   }
 
   // Create the response.
-  auto rep = msgs::Factory::New(_repType);
+  auto rep = msgs::Factory::New(repType);
   if (!rep)
   {
-    std::cerr << "Unable to create response of type[" << _repType << "].\n";
+    std::cerr << "Unable to create response of type[" << repType << "].\n";
     return;
   }
 
-  // Create the node.
-  Node node;
   bool result;
 
-  if (!strcmp(_repType, "gz.msgs.Empty"))
+  if (repType == "gz.msgs.Empty")
   {
     // One-way service.
     node.Request(_service, *req, 1000, *rep, result);

--- a/src/cmd/gz.hh
+++ b/src/cmd/gz.hh
@@ -51,8 +51,10 @@ extern "C" void cmdTopicPub(const char *_topic,
 
 /// \brief External hook to execute 'gz service -r' from the command line.
 /// \param[in] _service Service name.
-/// \param[in] _reqType Message type used in the request.
-/// \param[in] _repType Message type used in the response.
+/// \param[in] _reqType Message type used in the request. May be null, in which
+///                     case the type will be auto-discovered.
+/// \param[in] _repType Message type used in the response. May be null, in which
+///                     case the type will be auto-discovered.
 ///                     If "gz.msgs.Empty" is used, the request will be one-way
 ///                     and _repType and _timeout will be ignored.
 /// \param[in] _timeout The request will timeout after '_timeout' ms.

--- a/src/cmd/gz.hh
+++ b/src/cmd/gz.hh
@@ -52,23 +52,35 @@ extern "C" void cmdTopicPub(const char *_topic,
 /// \brief External hook to execute 'gz service -r' from the command line.
 /// \param[in] _service Service name.
 /// \param[in] _reqType Message type used in the request. May be null, in which
-///                     case the type will be auto-discovered.
-/// \param[in] _repType Message type used in the response. May be null, in which
-///                     case the type will be auto-discovered.
-///                     If "gz.msgs.Empty" is used, the request will be one-way
-///                     and _repType and _timeout will be ignored.
-/// \param[in] _timeout The request will timeout after '_timeout' ms.
+///                     case the type is resolved from the advertised service
+///                     provider (see Node::ResolveServiceTypes()). When given,
+///                     it also selects which providers the other type is
+///                     resolved from. Both the canonical ("gz.msgs.Empty")
+///                     and the underscore ("gz_msgs.Empty") spellings are
+///                     accepted.
+/// \param[in] _repType Message type used in the response. May be null, in
+///                     which case the type is resolved from the advertised
+///                     service provider. When given, it also selects which
+///                     providers the other type is resolved from. If
+///                     "gz.msgs.Empty" is used or resolved, the request will
+///                     be one-way and _timeout will be ignored.
+/// \param[in] _timeout The request will timeout after '_timeout' ms. When
+///                     types are being resolved, this value also bounds how
+///                     long to wait for a service provider to appear.
 /// \param[in] _reqData Input data sent in the request.
 /// The format expected is the same used by
 /// google::protobuf::TextFormat::PrintToString().
 /// E.g.: cmdServiceReq("/bar", "gz.msgs.StringMsg",
 ///                     "gz.msgs.StringMsg", 1000,
 ///                     "'data:\"Custom data\"');
+/// \param[in] _verbose When not zero, show extra information, e.g. the
+///                     types resolved from discovery.
 extern "C" void cmdServiceReq(const char *_service,
                               const char *_reqType,
                               const char *_repType,
                               const int _timeout,
-                              const char *_reqData);
+                              const char *_reqData,
+                              const int _verbose = 0);
 
 extern "C" {
   /// \brief Enum used for specifying the message output format for functions

--- a/src/cmd/gz_TEST.cc
+++ b/src/cmd/gz_TEST.cc
@@ -433,6 +433,78 @@ TEST(gzTest, ServiceRequestNoInput)
 }
 
 //////////////////////////////////////////////////
+/// \brief Check 'gz service -r' to request a service with inferred types
+TEST(gzTest, ServiceRequestAutoTypes)
+{
+  transport::Node node;
+
+  // Advertise a service.
+  std::string service = "/echo";
+  std::string value = "10";
+  EXPECT_TRUE(node.Advertise(service, srvEcho));
+
+  auto output = exec_with_retry(
+    {"service",
+     "-s", service,
+     "--timeout", "1000",
+     "--req", "data: " + value},
+    [value](const auto &_out)
+    {
+      return _out.cout == "data: " + value + "\n\n";
+    });
+
+  ASSERT_TRUE(output);
+  EXPECT_EQ(output->cout, "data: " + value + "\n\n");
+  EXPECT_EQ(output->cerr, "");
+}
+
+//////////////////////////////////////////////////
+/// \brief Check 'gz service -r' to request a one-way service with inferred
+/// request type.
+TEST(gzTest, ServiceOnewayRequestAutoTypes)
+{
+  g_topicCBStr = "bad_value";
+  transport::Node node;
+
+  // Advertise a one-way service.
+  std::string service = "/oneway";
+  EXPECT_TRUE(node.Advertise(service, srvOneway));
+
+  auto output = exec_with_retry(
+    {"service", "-s", service, "--req", "data: \"good_value\""},
+    [](const auto &/*_out*/)
+    {
+      return g_topicCBStr == "good_value";
+    });
+
+  ASSERT_TRUE(output);
+  EXPECT_EQ("good_value", g_topicCBStr);
+}
+
+//////////////////////////////////////////////////
+/// \brief Check 'gz service -r' to request a service without input args
+/// with inferred response type.
+TEST(gzTest, ServiceRequestNoInputAutoTypes)
+{
+  transport::Node node;
+
+  // Advertise a service without input.
+  std::string service = "/no_input";
+  EXPECT_TRUE(node.Advertise(service, srvNoInput));
+
+  auto output = exec_with_retry(
+    {"service", "-s", service, "--req"},
+    [](const auto &_out)
+    {
+      return _out.cout == "data: \"good_value\"\n\n";
+    });
+
+  ASSERT_TRUE(output);
+  EXPECT_EQ("data: \"good_value\"\n\n", output->cout);
+  EXPECT_EQ("", output->cerr);
+}
+
+//////////////////////////////////////////////////
 /// \brief Check 'gz topic -e' running the publisher on a separate process.
 TEST(gzTest, TopicEcho)
 {

--- a/src/cmd/gz_TEST.cc
+++ b/src/cmd/gz_TEST.cc
@@ -433,6 +433,34 @@ TEST(gzTest, ServiceRequestNoInput)
 }
 
 //////////////////////////////////////////////////
+/// \brief Check that 'gz service -r' with only --reqtype is still a one-way
+/// request that does not consult discovery: with nobody advertising the
+/// service it returns silently instead of waiting for a provider.
+TEST(gzTest, ServiceOnewayRequestNoProvider)
+{
+  auto output = custom_exec_str(
+    {"service", "-s", "/nobody", "--reqtype", "gz.msgs.StringMsg",
+     "--req", "data: \"good_value\""});
+
+  EXPECT_EQ("", output.cout);
+  EXPECT_EQ("", output.cerr);
+}
+
+//////////////////////////////////////////////////
+/// \brief Check that 'gz service -r' with only --reptype still sends a
+/// gz.msgs.Empty request instead of inferring the request type: with nobody
+/// advertising the service it times out instead of reporting no providers.
+TEST(gzTest, ServiceRequestNoInputNoProvider)
+{
+  auto output = custom_exec_str(
+    {"service", "-s", "/nobody", "--reptype", "gz.msgs.StringMsg",
+     "--timeout", "100", "--req"});
+
+  EXPECT_EQ("", output.cout);
+  EXPECT_EQ("Service call timed out\n", output.cerr);
+}
+
+//////////////////////////////////////////////////
 /// \brief Check 'gz service -r' to request a service with inferred types
 TEST(gzTest, ServiceRequestAutoTypes)
 {
@@ -447,6 +475,7 @@ TEST(gzTest, ServiceRequestAutoTypes)
     {"service",
      "-s", service,
      "--timeout", "1000",
+     "--verbose",
      "--req", "data: " + value},
     [value](const auto &_out)
     {
@@ -455,7 +484,8 @@ TEST(gzTest, ServiceRequestAutoTypes)
 
   ASSERT_TRUE(output);
   EXPECT_EQ(output->cout, "data: " + value + "\n\n");
-  EXPECT_EQ(output->cerr, "");
+  EXPECT_EQ(output->cerr,
+    "Inferred types: request=gz.msgs.Int32, response=gz.msgs.Int32\n");
 }
 
 //////////////////////////////////////////////////
@@ -479,6 +509,76 @@ TEST(gzTest, ServiceOnewayRequestAutoTypes)
 
   ASSERT_TRUE(output);
   EXPECT_EQ("good_value", g_topicCBStr);
+}
+
+//////////////////////////////////////////////////
+/// \brief Check 'gz service -r --oneway' with an explicit request type. No
+/// discovery is involved, so this works even before the provider is visible.
+TEST(gzTest, ServiceOnewayFlag)
+{
+  g_topicCBStr = "bad_value";
+  transport::Node node;
+
+  // Advertise a one-way service.
+  std::string service = "/oneway";
+  EXPECT_TRUE(node.Advertise(service, srvOneway));
+
+  auto output = exec_with_retry(
+    {"service",
+     "-s", service,
+     "--oneway",
+     "--reqtype", "gz.msgs.StringMsg",
+     "--req", "data: \"good_value\""},
+    [](const auto &/*_out*/)
+    {
+      return g_topicCBStr == "good_value";
+    });
+
+  ASSERT_TRUE(output);
+  EXPECT_EQ("good_value", g_topicCBStr);
+  EXPECT_EQ("", output->cerr);
+}
+
+//////////////////////////////////////////////////
+/// \brief Check 'gz service -r --oneway' with an inferred request type.
+TEST(gzTest, ServiceOnewayFlagAutoReqType)
+{
+  g_topicCBStr = "bad_value";
+  transport::Node node;
+
+  // Advertise a one-way service.
+  std::string service = "/oneway";
+  EXPECT_TRUE(node.Advertise(service, srvOneway));
+
+  auto output = exec_with_retry(
+    {"service",
+     "-s", service,
+     "--oneway",
+     "--req", "data: \"good_value\""},
+    [](const auto &/*_out*/)
+    {
+      return g_topicCBStr == "good_value";
+    });
+
+  ASSERT_TRUE(output);
+  EXPECT_EQ("good_value", g_topicCBStr);
+  EXPECT_EQ("", output->cerr);
+}
+
+//////////////////////////////////////////////////
+/// \brief Check that 'gz service -r' rejects --oneway with --reptype.
+TEST(gzTest, ServiceOnewayFlagExcludesRepType)
+{
+  auto output = custom_exec_str(
+    {"service",
+     "-s", "/oneway",
+     "--oneway",
+     "--reptype", "gz.msgs.Empty",
+     "--req", "data: \"good_value\""});
+
+  EXPECT_EQ("", output.cout);
+  EXPECT_NE(std::string::npos, output.cerr.find("--oneway"));
+  EXPECT_NE(std::string::npos, output.cerr.find("--reptype"));
 }
 
 //////////////////////////////////////////////////

--- a/src/cmd/gz_src_TEST.cc
+++ b/src/cmd/gz_src_TEST.cc
@@ -18,6 +18,7 @@
 #include <google/protobuf/text_format.h>
 #include "gtest/gtest.h"
 #include <gz/msgs/int32.pb.h>
+#include <gz/msgs/stringmsg.pb.h>
 
 #include <future>
 #include <string>
@@ -70,10 +71,24 @@ void restoreIO()
 }
 
 /// \brief Provide a service.
-bool srvEcho(const msgs::Int32 &_req, msgs::Int32 &_rep)
+bool srvEchoFail(const msgs::Int32 &_req, msgs::Int32 &_rep)
 {
   _rep.set_data(_req.data());
   return false;
+}
+
+/// \brief Provide a service.
+bool srvEchoOk(const msgs::Int32 &_req, msgs::Int32 &_rep)
+{
+  _rep.set_data(_req.data());
+  return true;
+}
+
+/// \brief Provide a StringMsg echo service
+bool srvEchoStringOk(const msgs::StringMsg &_req, msgs::StringMsg &_rep)
+{
+  _rep.set_data(_req.data());
+  return true;
 }
 
 //////////////////////////////////////////////////
@@ -166,7 +181,7 @@ TEST(gzTest, cmdServiceReq)
   const int         kTimeout     = 10;
 
   transport::Node node;
-  EXPECT_TRUE(node.Advertise(g_service, srvEcho));
+  EXPECT_TRUE(node.Advertise(g_service, srvEchoFail));
 
   msgs::Int32 msg;
   msg.set_data(10);
@@ -175,18 +190,6 @@ TEST(gzTest, cmdServiceReq)
   cmdServiceReq(nullptr, g_intType.c_str(), g_intType.c_str(),
     kTimeout, g_reqData.c_str());
   EXPECT_EQ(stdErrBuffer.str(), "Service name is null\n");
-  clearIOStreams(stdOutBuffer, stdErrBuffer);
-
-  // A null service request type should generate an error message.
-  cmdServiceReq(g_service.c_str(), nullptr, g_intType.c_str(),
-    kTimeout, g_reqData.c_str());
-  EXPECT_EQ(stdErrBuffer.str(), "Request type is null\n");
-  clearIOStreams(stdOutBuffer, stdErrBuffer);
-
-  // A null service response type should generate an error message.
-  cmdServiceReq(g_service.c_str(), g_intType.c_str(), nullptr,
-    kTimeout, g_reqData.c_str());
-  EXPECT_EQ(stdErrBuffer.str(), "Response type is null\n");
   clearIOStreams(stdOutBuffer, stdErrBuffer);
 
   // Null data should generate an error message.
@@ -224,6 +227,74 @@ TEST(gzTest, cmdServiceReq)
   EXPECT_EQ(stdErrBuffer.str(), "Service call timed out\n");
   clearIOStreams(stdOutBuffer, stdErrBuffer);
 
+  restoreIO();
+}
+
+//////////////////////////////////////////////////
+/// \brief Check cmdServiceReq with type resolution
+TEST(gzTest, cmdServiceReqInferTypes)
+{
+  std::stringstream  stdOutBuffer;
+  std::stringstream  stdErrBuffer;
+  redirectIO(stdOutBuffer, stdErrBuffer);
+
+  const std::string kUnknownType = "_unknown_type_";
+  const int         kTimeout     = 10;
+  const int         value        = 10;
+  const std::string value_s      = std::to_string(value);
+
+  transport::Node node;
+  EXPECT_TRUE(node.Advertise(g_service, srvEchoOk));
+
+  msgs::Int32 msg;
+  msg.set_data(value);
+
+  // A null service request type should be automatically inferred
+  cmdServiceReq(g_service.c_str(), nullptr, g_intType.c_str(),
+    kTimeout, g_reqData.c_str());
+  EXPECT_EQ(stdOutBuffer.str(), "data: " + value_s + "\n\n");
+  clearIOStreams(stdOutBuffer, stdErrBuffer);
+
+  // A null service response type should be automatically inferred
+  cmdServiceReq(g_service.c_str(), g_intType.c_str(), nullptr,
+    kTimeout, g_reqData.c_str());
+  EXPECT_EQ(stdOutBuffer.str(), "data: " + value_s + "\n\n");
+  clearIOStreams(stdOutBuffer, stdErrBuffer);
+
+  cmdServiceReq(g_service.c_str(), nullptr, nullptr,
+    kTimeout, g_reqData.c_str());
+  EXPECT_EQ(stdOutBuffer.str(), "data: " + value_s + "\n\n");
+  clearIOStreams(stdOutBuffer, stdErrBuffer);
+
+  restoreIO();
+}
+
+//////////////////////////////////////////////////
+/// \brief Check cmdServiceReq with ambiguous types
+TEST(gzTest, cmdServiceReqAmbiguousTypes)
+{
+  std::stringstream stdOutBuffer;
+  std::stringstream stdErrBuffer;
+  redirectIO(stdOutBuffer, stdErrBuffer);
+
+  const int kTimeout = 10;
+  const std::string service = "/ambiguous_echo";
+
+  transport::Node node1;
+  transport::Node node2;
+
+  EXPECT_TRUE(node1.Advertise(service, srvEchoOk));
+  EXPECT_TRUE(node2.Advertise(service, srvEchoStringOk));
+
+  cmdServiceReq(service.c_str(), nullptr, nullptr,
+      kTimeout, g_reqData.c_str());
+
+  EXPECT_EQ(stdOutBuffer.str(), "");
+  EXPECT_EQ(stdErrBuffer.str(),
+      "Ambiguous service types for service [/ambiguous_echo].\n"
+      "  Provider 1: request=gz.msgs.Int32, response=gz.msgs.Int32\n"
+      "  Provider 2: request=gz.msgs.StringMsg, response=gz.msgs.StringMsg\n"
+      "Use --reqtype and --reptype to specify explicitly.\n");
   restoreIO();
 }
 

--- a/src/cmd/gz_src_TEST.cc
+++ b/src/cmd/gz_src_TEST.cc
@@ -44,6 +44,7 @@ static const std::string g_reqData = "data: 10"; // NOLINT(*)
 static std::string     g_partition; // NOLINT(*)
 static std::streambuf *g_stdOutFile;
 static std::streambuf *g_stdErrFile;
+static int             g_onewayData = 0;
 
 // \brief Redirect stdout and stderr to streams.
 void redirectIO(std::stringstream &_stdOutBuffer,
@@ -89,6 +90,17 @@ bool srvEchoStringOk(const msgs::StringMsg &_req, msgs::StringMsg &_rep)
 {
   _rep.set_data(_req.data());
   return true;
+}
+
+/// \brief Provide a one-way service.
+void srvOnewayInt(const msgs::Int32 &_req)
+{
+  g_onewayData = _req.data();
+}
+
+/// \brief Provide a one-way service with a different request type.
+void srvOnewayString(const msgs::StringMsg &)
+{
 }
 
 //////////////////////////////////////////////////
@@ -249,22 +261,205 @@ TEST(gzTest, cmdServiceReqInferTypes)
   msgs::Int32 msg;
   msg.set_data(value);
 
-  // A null service request type should be automatically inferred
+  // A null service request type should be automatically inferred. In
+  // verbose mode the inferred type is reported on stderr.
   cmdServiceReq(g_service.c_str(), nullptr, g_intType.c_str(),
-    kTimeout, g_reqData.c_str());
+    kTimeout, g_reqData.c_str(), 1);
   EXPECT_EQ(stdOutBuffer.str(), "data: " + value_s + "\n\n");
+  EXPECT_EQ(stdErrBuffer.str(), "Inferred types: request=gz.msgs.Int32\n");
   clearIOStreams(stdOutBuffer, stdErrBuffer);
 
   // A null service response type should be automatically inferred
   cmdServiceReq(g_service.c_str(), g_intType.c_str(), nullptr,
-    kTimeout, g_reqData.c_str());
+    kTimeout, g_reqData.c_str(), 1);
   EXPECT_EQ(stdOutBuffer.str(), "data: " + value_s + "\n\n");
+  EXPECT_EQ(stdErrBuffer.str(), "Inferred types: response=gz.msgs.Int32\n");
   clearIOStreams(stdOutBuffer, stdErrBuffer);
 
   cmdServiceReq(g_service.c_str(), nullptr, nullptr,
+    kTimeout, g_reqData.c_str(), 1);
+  EXPECT_EQ(stdOutBuffer.str(), "data: " + value_s + "\n\n");
+  EXPECT_EQ(stdErrBuffer.str(),
+    "Inferred types: request=gz.msgs.Int32, response=gz.msgs.Int32\n");
+  clearIOStreams(stdOutBuffer, stdErrBuffer);
+
+  // Without verbose mode the inference is silent.
+  cmdServiceReq(g_service.c_str(), nullptr, nullptr,
     kTimeout, g_reqData.c_str());
   EXPECT_EQ(stdOutBuffer.str(), "data: " + value_s + "\n\n");
+  EXPECT_EQ(stdErrBuffer.str(), "");
   clearIOStreams(stdOutBuffer, stdErrBuffer);
+
+  restoreIO();
+}
+
+//////////////////////////////////////////////////
+/// \brief Check cmdServiceReq with type resolution and no service providers
+TEST(gzTest, cmdServiceReqNoProviders)
+{
+  std::stringstream stdOutBuffer;
+  std::stringstream stdErrBuffer;
+  redirectIO(stdOutBuffer, stdErrBuffer);
+
+  const int kTimeout = 100;
+
+  // The types cannot be resolved because nobody advertises the service.
+  cmdServiceReq("/unadvertised", nullptr, nullptr,
+    kTimeout, g_reqData.c_str());
+  EXPECT_EQ(stdOutBuffer.str(), "");
+  EXPECT_EQ(stdErrBuffer.str(),
+    "No service providers on service [/unadvertised] after waiting 100 ms.\n"
+    "Use --reqtype and --reptype to request without discovery.\n");
+
+  restoreIO();
+}
+
+//////////////////////////////////////////////////
+/// \brief Check cmdServiceReq with type resolution and an invalid service
+/// name.
+TEST(gzTest, cmdServiceReqInvalidService)
+{
+  std::stringstream stdOutBuffer;
+  std::stringstream stdErrBuffer;
+  redirectIO(stdOutBuffer, stdErrBuffer);
+
+  const int kTimeout = 10;
+
+  // The types cannot be resolved because the service name is not valid.
+  cmdServiceReq("invalid service", nullptr, nullptr,
+    kTimeout, g_reqData.c_str());
+  EXPECT_EQ(stdOutBuffer.str(), "");
+  EXPECT_EQ(stdErrBuffer.str(),
+    "Service [invalid service] is not valid.\n");
+
+  restoreIO();
+}
+
+//////////////////////////////////////////////////
+/// \brief Check that an explicit "gz.msgs.Empty" response type (what the
+/// --oneway flag maps to) disambiguates between a two-way and a one-way
+/// provider on the same service.
+TEST(gzTest, cmdServiceReqOnewayDisambiguation)
+{
+  std::stringstream stdOutBuffer;
+  std::stringstream stdErrBuffer;
+  redirectIO(stdOutBuffer, stdErrBuffer);
+
+  const int kTimeout = 10;
+  const std::string service = "/mixed_echo";
+  g_onewayData = 0;
+
+  transport::Node node1;
+  transport::Node node2;
+
+  EXPECT_TRUE(node1.Advertise(service, srvEchoOk));
+  EXPECT_TRUE(node2.Advertise(service, srvOnewayInt));
+
+  // Without any explicit type the service is ambiguous. One of the
+  // providers is one-way, so --oneway is suggested.
+  cmdServiceReq(service.c_str(), nullptr, nullptr,
+    kTimeout, g_reqData.c_str());
+  EXPECT_EQ(stdOutBuffer.str(), "");
+  EXPECT_EQ(stdErrBuffer.str(),
+      "Ambiguous service types for service [/mixed_echo]:\n"
+      "  request=gz.msgs.Int32, response=gz.msgs.Int32\n"
+      "  request=gz.msgs.Int32, response=gz.msgs.Empty\n"
+      "Use --reqtype and --reptype to specify explicitly.\n"
+      "Use --oneway to select the one-way provider.\n");
+  clearIOStreams(stdOutBuffer, stdErrBuffer);
+
+  // An explicit "gz.msgs.Empty" response type resolves the request type
+  // (all the providers agree on it) and reaches the one-way provider.
+  cmdServiceReq(service.c_str(), nullptr, "gz.msgs.Empty",
+    kTimeout, g_reqData.c_str());
+  EXPECT_EQ(stdOutBuffer.str(), "");
+  EXPECT_EQ(stdErrBuffer.str(), "");
+  EXPECT_EQ(10, g_onewayData);
+  clearIOStreams(stdOutBuffer, stdErrBuffer);
+
+  // An explicit two-way response type selects the two-way provider.
+  cmdServiceReq(service.c_str(), nullptr, "gz.msgs.Int32",
+    kTimeout, g_reqData.c_str());
+  EXPECT_EQ(stdOutBuffer.str(), "data: 10\n\n");
+  EXPECT_EQ(stdErrBuffer.str(), "");
+  clearIOStreams(stdOutBuffer, stdErrBuffer);
+
+  // The underscore spelling of a type is normalized, so it selects the
+  // one-way provider just like the canonical spelling does.
+  g_onewayData = 0;
+  cmdServiceReq(service.c_str(), nullptr, "gz_msgs.Empty",
+    kTimeout, g_reqData.c_str());
+  EXPECT_EQ(stdOutBuffer.str(), "");
+  EXPECT_EQ(stdErrBuffer.str(), "");
+  EXPECT_EQ(10, g_onewayData);
+
+  restoreIO();
+}
+
+//////////////////////////////////////////////////
+/// \brief Check that a one-way request with an inferred type is reported,
+/// rather than silently dropped, when no provider offers the requested
+/// types, while explicit types remain best effort.
+TEST(gzTest, cmdServiceReqOnewayNoCompatibleProvider)
+{
+  std::stringstream stdOutBuffer;
+  std::stringstream stdErrBuffer;
+  redirectIO(stdOutBuffer, stdErrBuffer);
+
+  const int kTimeout = 10;
+  const std::string service = "/twoway_only";
+
+  // The only provider is two-way.
+  transport::Node node;
+  EXPECT_TRUE(node.Advertise(service, srvEchoOk));
+
+  // Asking for a one-way request cannot be served by it. The request type
+  // is inferred, so the resolver reports the incompatibility.
+  cmdServiceReq(service.c_str(), nullptr, "gz.msgs.Empty",
+    kTimeout, g_reqData.c_str());
+  EXPECT_EQ(stdOutBuffer.str(), "");
+  EXPECT_EQ(stdErrBuffer.str(),
+      "No provider on service [/twoway_only] offers "
+      "response type [gz.msgs.Empty].\n");
+  clearIOStreams(stdOutBuffer, stdErrBuffer);
+
+  // With both types given explicitly discovery is not consulted: the
+  // request is sent best effort and nothing is reported.
+  cmdServiceReq(service.c_str(), "gz.msgs.Int32", "gz.msgs.Empty",
+    kTimeout, g_reqData.c_str());
+  EXPECT_EQ(stdOutBuffer.str(), "");
+  EXPECT_EQ(stdErrBuffer.str(), "");
+
+  restoreIO();
+}
+
+//////////////////////////////////////////////////
+/// \brief Check that --oneway is not suggested when the response type is
+/// already explicit and the request type is the ambiguous one.
+TEST(gzTest, cmdServiceReqOnewayAmbiguousRequest)
+{
+  std::stringstream stdOutBuffer;
+  std::stringstream stdErrBuffer;
+  redirectIO(stdOutBuffer, stdErrBuffer);
+
+  const int kTimeout = 10;
+  const std::string service = "/oneway_ambiguous";
+
+  transport::Node node1;
+  transport::Node node2;
+
+  // Two one-way providers that disagree on the request type.
+  EXPECT_TRUE(node1.Advertise(service, srvOnewayInt));
+  EXPECT_TRUE(node2.Advertise(service, srvOnewayString));
+
+  cmdServiceReq(service.c_str(), nullptr, "gz.msgs.Empty",
+    kTimeout, g_reqData.c_str());
+  EXPECT_EQ(stdOutBuffer.str(), "");
+  EXPECT_EQ(stdErrBuffer.str(),
+      "Ambiguous service types for service [/oneway_ambiguous]:\n"
+      "  request=gz.msgs.Int32, response=gz.msgs.Empty\n"
+      "  request=gz.msgs.StringMsg, response=gz.msgs.Empty\n"
+      "Use --reqtype and --reptype to specify explicitly.\n");
 
   restoreIO();
 }
@@ -282,18 +477,22 @@ TEST(gzTest, cmdServiceReqAmbiguousTypes)
 
   transport::Node node1;
   transport::Node node2;
+  transport::Node node3;
 
+  // node3 repeats node1's types: the error should list each distinct
+  // request/response pair only once.
   EXPECT_TRUE(node1.Advertise(service, srvEchoOk));
   EXPECT_TRUE(node2.Advertise(service, srvEchoStringOk));
+  EXPECT_TRUE(node3.Advertise(service, srvEchoOk));
 
   cmdServiceReq(service.c_str(), nullptr, nullptr,
       kTimeout, g_reqData.c_str());
 
   EXPECT_EQ(stdOutBuffer.str(), "");
   EXPECT_EQ(stdErrBuffer.str(),
-      "Ambiguous service types for service [/ambiguous_echo].\n"
-      "  Provider 1: request=gz.msgs.Int32, response=gz.msgs.Int32\n"
-      "  Provider 2: request=gz.msgs.StringMsg, response=gz.msgs.StringMsg\n"
+      "Ambiguous service types for service [/ambiguous_echo]:\n"
+      "  request=gz.msgs.Int32, response=gz.msgs.Int32\n"
+      "  request=gz.msgs.StringMsg, response=gz.msgs.StringMsg\n"
       "Use --reqtype and --reptype to specify explicitly.\n");
   restoreIO();
 }

--- a/src/cmd/service_main.cc
+++ b/src/cmd/service_main.cc
@@ -68,28 +68,16 @@ void runServiceCommand(const ServiceOptions &_opt)
       cmdServiceInfo(_opt.service.c_str());
       break;
     case ServiceCommand::kServiceReq:
-      if (_opt.repType.empty())
-      {
-        // One-way service request.
-        cmdServiceReq(_opt.service.c_str(),
-            _opt.reqType.c_str(), "gz.msgs.Empty",
-            0, _opt.reqData.c_str());
-      }
-      else if (_opt.reqType.empty())
-      {
-        // No input service request.
-        cmdServiceReq(_opt.service.c_str(),
-            "gz.msgs.Empty", _opt.repType.c_str(),
-            _opt.timeout, "unused:true");
-      }
-      else
-      {
-        // Two-way service request.
-        cmdServiceReq(_opt.service.c_str(),
-            _opt.reqType.c_str(), _opt.repType.c_str(),
-            _opt.timeout, _opt.reqData.c_str());
-      }
+    {
+      const char *repType =
+        _opt.repType.empty() ? nullptr : _opt.repType.c_str();
+      const char *reqType =
+        _opt.reqType.empty() ? nullptr : _opt.reqType.c_str();
+
+      cmdServiceReq(_opt.service.c_str(), reqType, repType,
+          _opt.timeout, _opt.reqData.c_str());
       break;
+    }
     case ServiceCommand::kNone:
     default:
       // In the event that there is no command, display help
@@ -129,8 +117,9 @@ void addServiceFlags(CLI::App &_app)
       },
 R"(Request a service.
 TEXT is the input data.
-The format expected is
-the same used by google::protobuf::TextFormat::PrintToString(). E.g.:
+Types are auto-discovered if --reqtype/--reptype are omitted.
+E.g.:
+  gz service -s /echo --req 'data: "Hello"'
   gz service -s /echo \
     --reqtype gz.msgs.StringMsg \
     --reptype gz.msgs.StringMsg \

--- a/src/cmd/service_main.cc
+++ b/src/cmd/service_main.cc
@@ -51,6 +51,12 @@ struct ServiceOptions
   /// \brief Response type to use when requesting
   std::string repType;
 
+  /// \brief Send the request without waiting for a response
+  bool oneway{false};
+
+  /// \brief Show extra information
+  bool verbose{false};
+
   /// \brief Timeout to use when requesting (in milliseconds)
   int timeout{5000};
 };
@@ -69,13 +75,26 @@ void runServiceCommand(const ServiceOptions &_opt)
       break;
     case ServiceCommand::kServiceReq:
     {
-      const char *repType =
-        _opt.repType.empty() ? nullptr : _opt.repType.c_str();
-      const char *reqType =
-        _opt.reqType.empty() ? nullptr : _opt.reqType.c_str();
+      // A one-way request is expressed as a "gz.msgs.Empty" response type,
+      // which never needs to be resolved from discovery.
+      std::string reqType = _opt.reqType;
+      std::string repType = _opt.oneway ? "gz.msgs.Empty" : _opt.repType;
 
-      cmdServiceReq(_opt.service.c_str(), reqType, repType,
-          _opt.timeout, _opt.reqData.c_str());
+      // Gazebo Transport 15 keeps the legacy meaning of a single omitted
+      // type, so that existing scripts behave the same: --reqtype alone is
+      // a one-way request and --reptype alone is a request without input.
+      // Types are only inferred from the service provider when both are
+      // omitted, which used to be an error, or with the new --oneway flag.
+      // Gazebo Transport 16 infers either type.
+      if (!reqType.empty() && repType.empty())
+        repType = "gz.msgs.Empty";
+      else if (reqType.empty() && !_opt.repType.empty())
+        reqType = "gz.msgs.Empty";
+
+      cmdServiceReq(_opt.service.c_str(),
+          reqType.empty() ? nullptr : reqType.c_str(),
+          repType.empty() ? nullptr : repType.c_str(),
+          _opt.timeout, _opt.reqData.c_str(), _opt.verbose ? 1 : 0);
       break;
     }
     case ServiceCommand::kNone:
@@ -93,9 +112,24 @@ void addServiceFlags(CLI::App &_app)
 
   auto serviceOpt = _app.add_option("-s,--service",
                                     opt->service, "Name of a service.");
-  _app.add_option("--reqtype", opt->reqType, "Type of a request.");
-  _app.add_option("--reptype", opt->repType, "Type of a response.");
-  _app.add_option("--timeout", opt->timeout, "Timeout in milliseconds.");
+  _app.add_option("--reqtype", opt->reqType,
+      "Type of a request. gz.msgs.Empty if only --reptype is given.\n"
+      "Inferred from the service provider if both types are omitted.");
+  auto repTypeOpt = _app.add_option("--reptype", opt->repType,
+      "Type of a response. gz.msgs.Empty (one-way) if only --reqtype\n"
+      "is given. Inferred from the service provider if both types are\n"
+      "omitted.");
+  _app.add_option("--timeout", opt->timeout,
+      "Timeout in milliseconds (default 5000). Also bounds the wait for\n"
+      "a service provider when inferring types.");
+
+  _app.add_flag("--oneway", opt->oneway,
+      "Send the request without waiting for a response\n"
+      "(the response type is gz.msgs.Empty).")
+    ->excludes(repTypeOpt);
+
+  _app.add_flag("--verbose", opt->verbose,
+      "Show extra information, e.g. the types resolved from discovery.");
 
   auto command = _app.add_option_group("command", "Command to be executed.");
 
@@ -116,9 +150,12 @@ void addServiceFlags(CLI::App &_app)
         opt->reqData = _reqData;
       },
 R"(Request a service.
-TEXT is the input data.
-Types are auto-discovered if --reqtype/--reptype are omitted.
-E.g.:
+TEXT is the input data. The format expected is the same used by
+google::protobuf::TextFormat::PrintToString().
+If both --reqtype and --reptype are omitted, the types are resolved
+from the advertised service provider, waiting up to --timeout ms for
+one to appear. Use --oneway to send the request without waiting for
+a response. E.g.:
   gz service -s /echo --req 'data: "Hello"'
   gz service -s /echo \
     --reqtype gz.msgs.StringMsg \
@@ -140,7 +177,7 @@ int main(int argc, char** argv)
   app.add_flag_callback("-v,--version", [](){
       std::cout << GZ_TRANSPORT_VERSION_FULL << std::endl;
       throw CLI::Success();
-  });
+  }, "Print the version.");
 
   addServiceFlags(app);
   app.formatter(std::make_shared<GzFormatter>(&app));

--- a/src/cmd/transport.bash_completion.sh
+++ b/src/cmd/transport.bash_completion.sh
@@ -55,6 +55,8 @@ GZ_SERVICE_COMPLETION_LIST="
   --reqtype
   --reptype
   --timeout
+  --oneway
+  --verbose
   -l --list
   -i --info
   -r --req


### PR DESCRIPTION
## Summary

Manual backport of #829 and #896: `gz service --req` can infer the request and response types from the advertised service provider, waits up to `--timeout` ms for a provider to appear, detects ambiguous/incompatible providers, and gains `--oneway` and `--verbose`. Adds `Node::ResolveServiceTypes()` (ABI additive).

Manual adaptations for Jetty (no behavior change for existing scripts):
* `service_main.cc`: a single omitted type keeps its legacy meaning (`--reqtype` alone is a one-way request, `--reptype` alone sends `gz.msgs.Empty`). Types are only inferred when both are omitted, which used to be an error. Help text updated accordingly, and two CLI tests added to pin the legacy behavior.
* `Migration.md`: the 16.X behavior change note is not applicable and was dropped.

## Backport Policy

- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [x] Ionic
    - [x] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [x] Added tests
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Assisted-by: Fable 5

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
