### PR TITLE
Replace sleeps with waitUntil in Node_TEST and gz_TEST

### DIFF
--- a/src/Node_TEST.cc
+++ b/src/Node_TEST.cc
@@ -34,6 +34,7 @@
 #include "gz/transport/Node.hh"
 #include "gz/transport/NodeShared.hh"
 #include "gz/transport/TransportTypes.hh"
+#include "gz/transport/WaitHelpers.hh"
 
 #include <gz/utils/Environment.hh>
 
@@ -451,7 +452,7 @@ class MyTestClass
 
     // Advertise and request a valid service.
     EXPECT_TRUE(this->node.Advertise(g_topic, &MyTestClass::Echo, this));
-    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    transport::waitUntil([&]{ return this->responseExecuted.load(); });
     EXPECT_TRUE(this->responseExecuted);
   }
 
@@ -463,9 +464,9 @@ class MyTestClass
   }
 
   /// \brief Member variables that flag when the actions are executed.
-  public: bool callbackExecuted;
-  public: bool callbackSrvExecuted;
-  public: bool responseExecuted;
+  public: std::atomic<bool> callbackExecuted;
+  public: std::atomic<bool> callbackSrvExecuted;
+  public: std::atomic<bool> responseExecuted;
 
   /// \brief Transport node;
   private: transport::Node node;
@@ -579,8 +580,8 @@ TEST(NodeTest, PubWithoutAdvertise)
   ASSERT_EQ(subscribedTopics.size(), 1u);
   EXPECT_EQ(subscribedTopics.at(0), g_topic);
 
-  // Wait some time before publishing.
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  // Wait until the subscriber is connected.
+  transport::waitUntil([&]{ return pub1.HasConnections(); });
 
   std::unique_lock<std::mutex> lk(cbMutex);
   // Publish a message by each node.
@@ -621,14 +622,14 @@ TEST(NodeTest, PubSubSameThread)
 
   EXPECT_TRUE(node.Subscribe(g_topic, cb));
 
-  // Wait some time before publishing.
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  // Wait until the subscriber is connected.
+  transport::waitUntil([&]{ return pub.HasConnections(); });
 
   // Publish a first message.
   EXPECT_TRUE(pub.Publish(msg));
 
   // Give some time to the subscribers.
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  transport::waitUntil([&]{ return cbExecuted.load(); });
 
   // Check that the message was received.
   EXPECT_TRUE(cbExecuted);
@@ -639,7 +640,7 @@ TEST(NodeTest, PubSubSameThread)
   EXPECT_TRUE(pub.Publish(msg));
 
   // Give some time to the subscribers.
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  transport::waitUntil([&]{ return cbExecuted.load(); });
 
   // Check that the data was received.
   EXPECT_TRUE(cbExecuted);
@@ -663,14 +664,14 @@ TEST(NodeTest, PubSubSameThreadGenericCb)
 
   EXPECT_TRUE(node.Subscribe(g_topic, genericCb));
 
-  // Wait some time before publishing.
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  // Wait until the subscriber is connected.
+  transport::waitUntil([&]{ return pub.HasConnections(); });
 
   // Publish a first message.
   EXPECT_TRUE(pub.Publish(msg));
 
   // Give some time to the subscribers.
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  transport::waitUntil([&]{ return genericCbExecuted.load(); });
 
   // Check that the message was received.
   EXPECT_TRUE(genericCbExecuted);
@@ -681,7 +682,7 @@ TEST(NodeTest, PubSubSameThreadGenericCb)
   EXPECT_TRUE(pub.Publish(msg));
 
   // Give some time to the subscribers.
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  transport::waitUntil([&]{ return genericCbExecuted.load(); });
 
   // Check that the data was received.
   EXPECT_TRUE(genericCbExecuted);
@@ -706,14 +707,14 @@ TEST(NodeTest, PubSubSameThreadMessageInfo)
 
   EXPECT_TRUE(node.Subscribe(g_topic, cbInfo));
 
-  // Wait some time before publishing.
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  // Wait until the subscriber is connected.
+  transport::waitUntil([&]{ return pub.HasConnections(); });
 
   // Publish a first message.
   EXPECT_TRUE(pub.Publish(msg));
 
   // Give some time to the subscribers.
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  transport::waitUntil([&]{ return cbExecuted.load(); });
 
   // Check that the message was received.
   EXPECT_TRUE(cbExecuted);
@@ -724,7 +725,7 @@ TEST(NodeTest, PubSubSameThreadMessageInfo)
   EXPECT_TRUE(pub.Publish(msg));
 
   // Give some time to the subscribers.
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  transport::waitUntil([&]{ return cbExecuted.load(); });
 
   // Check that the data was received.
   EXPECT_TRUE(cbExecuted);
@@ -746,15 +747,15 @@ TEST(NodeTest, RawPubSubSameThreadMessageInfo)
 
   EXPECT_TRUE(node.Subscribe(g_topic, cbInfo));
 
-  // Wait some time before publishing.
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  // Wait until the subscriber is connected.
+  transport::waitUntil([&]{ return pub.HasConnections(); });
 
   // Publish a first message.
   EXPECT_TRUE(pub.PublishRaw(msg.SerializeAsString(),
         std::string(msg.GetTypeName())));
 
   // Give some time to the subscribers.
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  transport::waitUntil([&]{ return cbExecuted.load(); });
 
   // Check that the message was received.
   EXPECT_TRUE(cbExecuted);
@@ -766,7 +767,7 @@ TEST(NodeTest, RawPubSubSameThreadMessageInfo)
         std::string(msg.GetTypeName())));
 
   // Give some time to the subscribers.
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  transport::waitUntil([&]{ return cbExecuted.load(); });
 
   // Check that the data was received.
   EXPECT_TRUE(cbExecuted);
@@ -788,15 +789,15 @@ TEST(NodeTest, RawPubRawSubSameThreadMessageInfo)
 
   EXPECT_TRUE(node.SubscribeRaw(g_topic, rawCbInfo));
 
-  // Wait some time before publishing.
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  // Wait until the subscriber is connected.
+  transport::waitUntil([&]{ return pub.HasConnections(); });
 
   // Publish a first message.
   EXPECT_TRUE(pub.PublishRaw(msg.SerializeAsString(),
         std::string(msg.GetTypeName())));
 
   // Give some time to the subscribers.
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  transport::waitUntil([&]{ return cbExecuted.load(); });
 
   // Check that the message was received.
   EXPECT_TRUE(cbExecuted);
@@ -808,7 +809,7 @@ TEST(NodeTest, RawPubRawSubSameThreadMessageInfo)
         std::string(msg.GetTypeName())));
 
   // Give some time to the subscribers.
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  transport::waitUntil([&]{ return cbExecuted.load(); });
 
   // Check that the data was received.
   EXPECT_TRUE(cbExecuted);
@@ -830,14 +831,14 @@ TEST(NodeTest, PubRawSubSameThreadMessageInfo)
 
   EXPECT_TRUE(node.SubscribeRaw(g_topic, rawCbInfo));
 
-  // Wait some time before publishing.
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  // Wait until the subscriber is connected.
+  transport::waitUntil([&]{ return pub.HasConnections(); });
 
   // Publish a first message.
   EXPECT_TRUE(pub.Publish(msg));
 
   // Give some time to the subscribers.
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  transport::waitUntil([&]{ return cbExecuted.load(); });
 
   // Check that the message was received.
   EXPECT_TRUE(cbExecuted);
@@ -848,7 +849,7 @@ TEST(NodeTest, PubRawSubSameThreadMessageInfo)
   EXPECT_TRUE(pub.Publish(msg));
 
   // Give some time to the subscribers.
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  transport::waitUntil([&]{ return cbExecuted.load(); });
 
   // Check that the data was received.
   EXPECT_TRUE(cbExecuted);
@@ -885,8 +886,8 @@ TEST(NodeTest, PubSubSameThreadLambda)
 
   EXPECT_TRUE(node.Subscribe(g_topic, subCb));
 
-  // Give some time to the subscribers.
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  // Wait until the subscriber is connected.
+  transport::waitUntil([&]{ return pub.HasConnections(); });
 
   // Publish a first message.
   EXPECT_TRUE(pub.Publish(msg));
@@ -935,8 +936,8 @@ TEST(NodeTest, PubSubSameThreadLambdaMessageInfo)
 
   EXPECT_TRUE(node.Subscribe(g_topic, subCb));
 
-  // Give some time to the subscribers.
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  // Wait until the subscriber is connected.
+  transport::waitUntil([&]{ return pub.HasConnections(); });
 
   // Publish a first message.
   std::unique_lock<std::mutex> lk(cbMutex);
@@ -1013,8 +1014,8 @@ TEST(NodeTest, PubSubWithCreateSubscriber)
     sub = node.CreateSubscriber(g_topic, subCb);
     EXPECT_TRUE(sub);
 
-    // Give some time to the subscribers.
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    // Wait until the subscriber is connected.
+    transport::waitUntil([&]{ return pub.HasConnections(); });
 
     // Publish a message.
     EXPECT_TRUE(pub.Publish(msg));
@@ -1097,8 +1098,8 @@ TEST(NodeTest, PubSubWithMixedSubscribeAPIs)
   transport::Node::Subscriber sub3 = node.CreateSubscriber(g_topic, subCb3);
   EXPECT_TRUE(sub3);
 
-  // Give some time to the subscribers.
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  // Wait until the subscriber is connected.
+  transport::waitUntil([&]{ return pub.HasConnections(); });
 
   // Publish a message.
   EXPECT_TRUE(pub.Publish(msg));
@@ -1299,13 +1300,14 @@ TEST(NodeTest, PubSubOneThreadTwoSubs)
     // Subscribe to topic in node2.
     EXPECT_TRUE(node2.Subscribe(g_topic, cb2));
 
-    // Wait some time before publishing.
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    // Wait until the subscriber is connected.
+    transport::waitUntil([&]{ return pub1.HasConnections(); });
 
     EXPECT_TRUE(pub1.Publish(msg));
 
     // Give some time to the subscribers.
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    transport::waitUntil(
+        [&]{ return cbExecuted.load() && cb2Executed.load(); });
 
     // Check that the msg was received by node1.
     EXPECT_TRUE(cbExecuted);
@@ -1331,7 +1333,7 @@ TEST(NodeTest, PubSubOneThreadTwoSubs)
     EXPECT_TRUE(pub1.Publish(msg));
 
     // Give some time to the subscribers.
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    transport::waitUntil([&]{ return cb2Executed.load(); });
 
     // Check that the msg was not received by node1.
     EXPECT_FALSE(cbExecuted);
@@ -1344,7 +1346,7 @@ TEST(NodeTest, PubSubOneThreadTwoSubs)
   }
 
   // Give some time to the subscribers.
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  transport::waitUntil([&]{ return node1.AdvertisedTopics().empty(); });
 
   auto advertisedTopics = node1.AdvertisedTopics();
   ASSERT_TRUE(advertisedTopics.empty());
@@ -1366,7 +1368,7 @@ TEST(NodeTest, ClassMemberCallbackMessage)
   client.SendSomeData();
 
   // Give some time to the subscribers.
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  transport::waitUntil([&]{ return client.callbackExecuted.load(); });
   EXPECT_TRUE(client.callbackExecuted);
 }
 
@@ -1384,7 +1386,7 @@ TEST(NodeTest, ClassMemberCallbackMessageInfo)
   client.SendSomeData();
 
   // Give some time to the subscribers.
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  transport::waitUntil([&]{ return client.callbackExecuted.load(); });
   EXPECT_TRUE(client.callbackExecuted);
 }
 
@@ -2190,8 +2192,8 @@ TEST(NodeTest, PubSubWrongTypesOnPublish)
 
   EXPECT_TRUE(node.Subscribe(g_topic, cb));
 
-  // Wait some time before publishing.
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  // Wait until the subscriber is connected.
+  transport::waitUntil([&]{ return pub.HasConnections(); });
 
   // Send a message with a wrong type.
   EXPECT_FALSE(pub.Publish(msgV));
@@ -2205,7 +2207,7 @@ TEST(NodeTest, PubSubWrongTypesOnPublish)
   EXPECT_TRUE(pub.Publish(msg));
 
   // Give some time to the subscribers.
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  transport::waitUntil([&]{ return cbExecuted.load(); });
 
   // Check that the data was received.
   EXPECT_TRUE(cbExecuted);
@@ -2267,13 +2269,13 @@ TEST(NodeTest, PubSubWrongTypesTwoSubscribers)
   // Bad subscriber: cbVector does not match the types advertised by node1.
   EXPECT_TRUE(node2.Subscribe(g_topic, cbVector));
 
-  // Wait some time before publishing.
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  // Wait until the subscriber is connected.
+  transport::waitUntil([&]{ return pub1.HasConnections(); });
 
   EXPECT_TRUE(pub1.Publish(msg));
 
   // Give some time to the subscribers.
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  transport::waitUntil([&]{ return cbExecuted.load(); });
 
   // Check that the message was received by node1.
   EXPECT_TRUE(cbExecuted);
@@ -2506,7 +2508,7 @@ TEST(NodeTest, SrvTwoRequestsOneWrong)
   // Valid service requests.
   EXPECT_TRUE(node.Request(g_topic, req, timeout, goodRep, result));
   EXPECT_TRUE(node.Request(g_topic, req, response));
-  std::this_thread::sleep_for(std::chrono::milliseconds(300));
+  transport::waitUntil([&]{ return responseExecuted.load(); });
   EXPECT_TRUE(responseExecuted);
 
   reset();
@@ -2538,7 +2540,7 @@ TEST(NodeTest, SrvWithoutInputTwoRequestsOneWrong)
   // Valid service requests.
   EXPECT_TRUE(node.Request(g_topic, timeout, goodRep, result));
   EXPECT_TRUE(node.Request(g_topic, response));
-  std::this_thread::sleep_for(std::chrono::milliseconds(300));
+  transport::waitUntil([&]{ return responseExecuted.load(); });
   EXPECT_TRUE(responseExecuted);
 
   reset();

--- a/src/cmd/gz_TEST.cc
+++ b/src/cmd/gz_TEST.cc
@@ -29,6 +29,7 @@
 
 #include "gtest/gtest.h"
 #include "gz/transport/Node.hh"
+#include "gz/transport/WaitHelpers.hh"
 
 #include "test_config.hh"
 #include "test_utils.hh"
@@ -411,7 +412,7 @@ TEST(gzTest, ServiceOnewayRequest)
     {"service", "-s", service, "--reqtype", "gz.msgs.StringMsg",
      "--req", "data: \"good_value\""});
 
-  std::this_thread::sleep_for(std::chrono::milliseconds(500));
+  transport::waitUntil([]{ return g_topicCBStr == "good_value"; });
   EXPECT_EQ("good_value", g_topicCBStr);
 }
 


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

More effort for reducing flakiness leveraging the `WaitHelpers.hh` feafures instead of the hardcoded sleeps.

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [x] Ionic
    - [x] Harmonic
    - [x] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Assisted-by: Fable 5

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.