### PR TITLE
Simplify zenoh shutdown logic

### DIFF
--- a/include/gz/transport/RepHandler.hh
+++ b/include/gz/transport/RepHandler.hh
@@ -59,6 +59,7 @@ namespace gz::transport
   /// \class IRepHandler RepHandler.hh gz/transport/RepHandler.hh
   /// \brief Interface class used to manage a replier handler.
   class GZ_TRANSPORT_VISIBLE IRepHandler
+    : public std::enable_shared_from_this<IRepHandler>
   {
     /// \brief Constructor.
     /// \param[in] _pUuid Process UUID.
@@ -98,15 +99,6 @@ namespace gz::transport
     public: virtual std::string RepTypeName() const = 0;
 
 #ifdef HAVE_ZENOH
-    /// \brief Temporarily store the dispatch closure. Must be called by the
-    /// most derived RepHandler subclass before CreateZenohQueriable.
-    /// The dispatch closure should capture a weak_ptr to the handler to safely
-    /// abort if invoked during handler destruction.
-    protected: void SetZenohQueryableDispatch(
-      const std::string &_service,
-      std::function<bool(const std::string &request,
-                         std::string &response)> _dispatch);
-
     /// \brief Create a Zenoh queriable.
     /// \param[in] _session Zenoh session.
     /// \param[in] _service The service.
@@ -135,8 +127,7 @@ namespace gz::transport
   // the service call. 'Rep' is the protobuf message type that will be filled
   /// with the service response.
   template <typename Req, typename Rep> class RepHandler
-    : public IRepHandler,
-      public std::enable_shared_from_this<RepHandler<Req, Rep>>
+    : public IRepHandler
   {
     // Documentation inherited.
     using IRepHandler::IRepHandler;
@@ -168,15 +159,6 @@ namespace gz::transport
       const std::string &_service)
     {
       this->SetCallback(std::move(_cb));
-      std::weak_ptr<RepHandler<Req, Rep>> weakSelf = this->weak_from_this();
-      this->SetZenohQueryableDispatch(_service,
-        [weakSelf](const std::string &request, std::string &response) -> bool
-        {
-          auto self = weakSelf.lock();
-          if (!self)
-            return false;
-          return self->RunCallback(request, response);
-        });
       this->CreateZenohQueriable(_session, _service);
     }
 #endif

--- a/include/gz/transport/SubscriptionHandler.hh
+++ b/include/gz/transport/SubscriptionHandler.hh
@@ -179,8 +179,7 @@ namespace gz::transport
   /// message. 'T' is the Protobuf message type that will be used for this
   /// particular handler.
   template <typename T> class SubscriptionHandler
-    : public ISubscriptionHandler,
-      public std::enable_shared_from_this<SubscriptionHandler<T>>
+    : public ISubscriptionHandler
   {
     // Documentation inherited.
     public: explicit SubscriptionHandler(const std::string &_pUuid,

--- a/include/gz/transport/SubscriptionHandler.hh
+++ b/include/gz/transport/SubscriptionHandler.hh
@@ -104,18 +104,6 @@ namespace gz::transport
     /// \return true if the callback should be executed or false otherwise.
     protected: bool UpdateThrottling();
 
-#ifdef HAVE_ZENOH
-    /// \brief Temporarily store the dispatch closure. Must be called by the
-    /// most derived subscriber subclass before CreateGenericZenohSubscriber.
-    /// The dispatch closure should capture a weak_ptr to the handler to safely
-    /// abort if invoked during handler destruction.
-    protected: void SetZenohSubscriberDispatch(
-      const std::string &_topic,
-      const std::string &_expectedType,
-      std::function<void(const std::string &payload,
-                         const std::string &msgType)> _dispatch);
-#endif
-
     /// \brief Subscribe options.
     protected: SubscribeOptions opts;
 
@@ -145,7 +133,8 @@ namespace gz::transport
   /// messages. Those functions are not needed by the RawSubscriptionHandler
   /// class.
   class GZ_TRANSPORT_VISIBLE ISubscriptionHandler
-      : public SubscriptionHandlerBase
+      : public SubscriptionHandlerBase,
+        public std::enable_shared_from_this<ISubscriptionHandler>
   {
     /// \brief Constructor.
     /// \param[in] _pUuid UUID of the process registering the handler.
@@ -242,25 +231,6 @@ namespace gz::transport
                              const FullyQualifiedTopic &_fullyQualifiedTopic)
     {
       this->SetCallback(std::move(_cb));
-      const std::string topic = _fullyQualifiedTopic.Topic();
-      std::weak_ptr<SubscriptionHandler<T>> weakSelf = this->weak_from_this();
-      this->SetZenohSubscriberDispatch(
-        topic, this->TypeName(),
-        [weakSelf, topic](const std::string &payload,
-                           const std::string &msgType)
-        {
-          auto self = weakSelf.lock();
-          if (!self)
-            return;
-          auto msg = self->CreateMsg(payload, msgType);
-          if (!msg)
-            return;
-          MessageInfo info;
-          info.SetTopic(topic);
-          info.SetType(msgType);
-          info.SetIntraProcess(false);
-          self->RunLocalCallback(*msg, info);
-        });
       this->CreateGenericZenohSubscriber(_session, _fullyQualifiedTopic);
     }
 #endif
@@ -322,8 +292,7 @@ namespace gz::transport
   /// \brief Specialized template when the user prefers a callbacks that
   /// accepts a generic google::protobuf::message instead of a specific type.
   template <> class SubscriptionHandler<ProtoMsg>
-    : public ISubscriptionHandler,
-      public std::enable_shared_from_this<SubscriptionHandler<ProtoMsg>>
+    : public ISubscriptionHandler
   {
     // Documentation inherited.
     public: explicit SubscriptionHandler(const std::string &_pUuid,
@@ -393,26 +362,6 @@ namespace gz::transport
                              const FullyQualifiedTopic &_fullyQualifiedTopic)
     {
       this->SetCallback(std::move(_cb));
-      const std::string topic = _fullyQualifiedTopic.Topic();
-      std::weak_ptr<SubscriptionHandler<ProtoMsg>> weakSelf =
-        this->weak_from_this();
-      this->SetZenohSubscriberDispatch(
-        topic, this->TypeName(),
-        [weakSelf, topic](const std::string &payload,
-                           const std::string &msgType)
-        {
-          auto self = weakSelf.lock();
-          if (!self)
-            return;
-          auto msg = self->CreateMsg(payload, msgType);
-          if (!msg)
-            return;
-          MessageInfo info;
-          info.SetTopic(topic);
-          info.SetType(msgType);
-          info.SetIntraProcess(false);
-          self->RunLocalCallback(*msg, info);
-        });
       this->CreateGenericZenohSubscriber(_session, _fullyQualifiedTopic);
     }
 #endif

--- a/src/Node.cc
+++ b/src/Node.cc
@@ -18,7 +18,6 @@
 #include <gz/msgs/statistic.pb.h>
 
 #include <algorithm>
-#include <atomic>
 #include <cassert>
 #include <chrono>
 #include <iostream>
@@ -28,7 +27,6 @@
 #include <mutex>
 #include <string>
 #include <unordered_set>
-#include <utility>
 #include <vector>
 
 #include "gz/transport/Helpers.hh"

--- a/src/Node.cc
+++ b/src/Node.cc
@@ -159,38 +159,13 @@ class Node::PublisherPrivate
   }
 
   /// \brief Zenoh teardown. Safe to call multiple times.
-  ///
-  /// Drops the Zenoh wrappers without calling undeclare() on them.
-  /// undeclare() blocks until any in-flight callback for that
-  /// entity returns, and that blocking wait is harmful here for two
-  /// reasons:
-  ///   (a) At process exit, the Zenoh background runtime has
-  ///       already been torn down, so the wait crashes the process.
-  ///   (b) Mid-process, this destructor runs while NodeShared's
-  ///       mutex is held by the caller, and an in-flight callback
-  ///       may be waiting on the same mutex. Both threads then
-  ///       deadlock.
-  /// Publishers do not run a user callback, so leaking the wrapper
-  /// is harmless. The leftover Zenoh liveliness entry clears when
-  /// the process exits and the kernel closes the socket.
+  /// See ZenohTeardownEntity in NodeSharedPrivate.hh for the
+  /// shared pattern (atomic guard + detached undeclare).
   public: void ZenohShutdown()
   {
 #ifdef HAVE_ZENOH
-    // Atomically claim the right to run shutdown. The first caller
-    // flips the flag from false to true and proceeds. Any concurrent
-    // or later caller finds the flag already true and bails out, so
-    // the body below runs exactly once.
-    bool expected = false;
-    if (!this->zenohIsShutdown.compare_exchange_strong(expected, true,
-          std::memory_order_acq_rel, std::memory_order_relaxed))
-      return;
-
-    // Deliberately leak the Zenoh wrappers. release() hands the raw
-    // pointer over to nobody and skips the wrapper's destructor,
-    // which would otherwise call undeclare() and crash or deadlock
-    // (see the doc comment above).
-    (void) this->zToken.release();
-    (void) this->zPub.release();
+    ZenohTeardownEntity(this->zenohIsShutdown,
+                        this->zPub, this->zToken);
 #endif
   }
 

--- a/src/Node.cc
+++ b/src/Node.cc
@@ -145,9 +145,6 @@ class Node::PublisherPrivate
   /// \brief Destructor.
   public: virtual ~PublisherPrivate()
   {
-    // Zenoh teardown before NodeShared::mutex is acquired below.
-    this->ZenohShutdown();
-
     std::lock_guard<std::recursive_mutex> lk(this->shared->mutex);
     // Notify the discovery service to unregister and unadvertise my topic.
     if (!this->shared->dataPtr->msgDiscovery->Unadvertise(
@@ -156,17 +153,6 @@ class Node::PublisherPrivate
       std::cerr << "~PublisherPrivate() Error unadvertising topic ["
                 << this->publisher.Topic() << "]" << std::endl;
     }
-  }
-
-  /// \brief Zenoh teardown. Safe to call multiple times.
-  /// See ZenohTeardownEntity in NodeSharedPrivate.hh for the
-  /// shared pattern (atomic guard + detached undeclare).
-  public: void ZenohShutdown()
-  {
-#ifdef HAVE_ZENOH
-    ZenohTeardownEntity(this->zenohIsShutdown,
-                        this->zPub, this->zToken);
-#endif
   }
 
   /// \brief Create a MessageInfo object for this Publisher
@@ -196,9 +182,6 @@ class Node::PublisherPrivate
 
   /// \brief The liveliness token.
   public: std::unique_ptr<zenoh::LivelinessToken> zToken;
-
-  /// \brief Atomic guard for ZenohShutdown idempotence.
-  public: std::atomic<bool> zenohIsShutdown{false};
 #endif
 
   /// \brief Timestamp of the last callback executed.

--- a/src/NodeSharedPrivate.hh
+++ b/src/NodeSharedPrivate.hh
@@ -48,46 +48,7 @@ namespace gz::transport
 {
   // Inline bracket to help doxygen filtering.
   inline namespace GZ_TRANSPORT_VERSION_NAMESPACE {
-#ifdef HAVE_ZENOH
-  /// \internal
-  /// \brief Teardown a per-handler Zenoh entity. Safe to call
-  /// multiple times.
-  ///
-  /// Implements the shared shutdown pattern used by subscribers
-  /// and queryables:
-  ///   1. Thread-safe one-shot guard so the body runs exactly once,
-  ///      even if multiple threads call it at the same time.
-  ///   2. Move the entity and token into a detached thread that
-  ///      calls undeclare() on each. Detached because undeclare()
-  ///      blocks until in-flight callbacks return, which would
-  ///      deadlock if run inline: the caller may be holding a
-  ///      mutex the callback is waiting on, or the callback may
-  ///      itself be what triggered the teardown.
-  template <typename EntityT>
-  inline void ZenohTeardownEntity(
-      std::atomic<bool> &_isShutdown,
-      std::unique_ptr<EntityT> &_entity,
-      std::unique_ptr<zenoh::LivelinessToken> &_token)
-  {
-    bool expected = false;
-    if (!_isShutdown.compare_exchange_strong(expected, true,
-          std::memory_order_acq_rel, std::memory_order_relaxed))
-      return;
 
-    auto entityWrap = std::move(_entity);
-    auto tokenWrap = std::move(_token);
-    if (entityWrap || tokenWrap)
-    {
-      std::thread([e = std::move(entityWrap),
-                   t = std::move(tokenWrap)]() mutable
-      {
-        zenoh::ZResult result = Z_OK;
-        if (t) std::move(*t).undeclare(&result);
-        if (e) std::move(*e).undeclare(&result);
-      }).detach();
-    }
-  }
-#endif
 
   //
   /// \brief Metadata for a publication. This is sent as part of the ZMQ

--- a/src/NodeSharedPrivate.hh
+++ b/src/NodeSharedPrivate.hh
@@ -20,15 +20,12 @@
 
 #include <algorithm>
 #include <atomic>
-#include <chrono>
 #include <cstdlib>
 #include <filesystem>
-#include <functional>
 #include <list>
 #include <map>
 #include <memory>
 #include <string>
-#include <thread>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -48,8 +45,6 @@ namespace gz::transport
 {
   // Inline bracket to help doxygen filtering.
   inline namespace GZ_TRANSPORT_VERSION_NAMESPACE {
-
-
   //
   /// \brief Metadata for a publication. This is sent as part of the ZMQ
   /// message for topic statistics.

--- a/src/RepHandler.cc
+++ b/src/RepHandler.cc
@@ -17,6 +17,7 @@
 
 #include <memory>
 #include <string>
+#include <thread>
 #include "gz/transport/config.hh"
 #include "gz/transport/RepHandler.hh"
 #include "gz/transport/TopicUtils.hh"
@@ -45,7 +46,24 @@ namespace gz::transport
     }
 
     /// \brief Destructor.
-    public: virtual ~IRepHandlerPrivate() = default;
+    public: virtual ~IRepHandlerPrivate()
+    {
+#ifdef HAVE_ZENOH
+      // When unregistering from within a Zenoh callback, destroying the
+      // Queryable synchronously causes a deadlock in Zenoh's wait_callbacks()
+      // because it waits for the current thread (callback worker) to finish.
+      // Move them to a detached thread so the callback can return cleanly.
+      if (this->zQueryable || this->zToken)
+      {
+        std::thread([queryable = std::move(this->zQueryable),
+                     token = std::move(this->zToken)]() mutable
+        {
+          queryable.reset();
+          token.reset();
+        }).detach();
+      }
+#endif
+    }
 
     /// \brief Process UUID.
     public: std::string pUuid;

--- a/src/RepHandler.cc
+++ b/src/RepHandler.cc
@@ -90,9 +90,6 @@ namespace gz::transport
 
     /// \brief Atomic guard for Shutdown idempotence.
     public: std::atomic<bool> isShutdown{false};
-
-    /// \brief Temporarily store the dispatch closure passed from the header.
-    public: std::function<bool(const std::string&, std::string&)> zenohDispatch;
 #endif
   };
 
@@ -116,34 +113,22 @@ namespace gz::transport
 
 #ifdef HAVE_ZENOH
   /////////////////////////////////////////////////
-  void IRepHandler::SetZenohQueryableDispatch(
-      const std::string &/*_service*/,
-      std::function<bool(const std::string &request,
-                         std::string &response)> _dispatch)
-  {
-    this->dataPtr->zenohDispatch = std::move(_dispatch);
-  }
-
-  /////////////////////////////////////////////////
   void IRepHandler::CreateZenohQueriable(
     std::shared_ptr<zenoh::Session> _session,
     const std::string &_service)
   {
-    if (!this->dataPtr->zenohDispatch)
-    {
-      std::cerr << "IRepHandler::CreateZenohQueriable: no dispatch set. "
-                << "Call SetZenohQueryableDispatch first.\n";
-      return;
-    }
+    std::weak_ptr<IRepHandler> weakSelf = this->weak_from_this();
     auto onQuery =
-      [_dispatch = std::move(this->dataPtr->zenohDispatch), _service](
-        const zenoh::Query &_query)
+      [weakSelf, _service](const zenoh::Query &_query)
     {
+      auto self = weakSelf.lock();
+      if (!self)
+        return;
       std::string input = "";
       if (_query.get_payload())
         input = _query.get_payload()->get().as_string();
       std::string output;
-      if (_dispatch(input, output))
+      if (self->RunCallback(input, output))
         _query.reply(_service, output);
     };
 
@@ -152,7 +137,7 @@ namespace gz::transport
     zenoh::Session::QueryableOptions opts;
     this->dataPtr->zQueryable = std::make_unique<zenoh::Queryable<void>>(
       _session->declare_queryable(
-        _service, onQuery, onDropQueryable, std::move(opts)));
+        _service, std::move(onQuery), onDropQueryable, std::move(opts)));
 
     std::string token = TopicUtils::CreateLivelinessToken(
       _service, this->dataPtr->pUuid, this->dataPtr->nUuid, "SS",

--- a/src/RepHandler.cc
+++ b/src/RepHandler.cc
@@ -50,25 +50,7 @@ namespace gz::transport
     }
 
     /// \brief Destructor.
-    public: virtual ~IRepHandlerPrivate()
-    {
-      this->Shutdown();
-    }
-
-    /// \brief Zenoh teardown. Safe to call multiple times.
-    /// See ZenohTeardownEntity in NodeSharedPrivate.hh for the
-    /// shared pattern (atomic guard + detached undeclare). Running
-    /// undeclare() inline would self-deadlock if a service callback
-    /// itself triggers UnadvertiseSrv (which calls this teardown):
-    /// the callback would wait for teardown to finish, and teardown
-    /// would wait for the callback to return.
-    public: void Shutdown()
-    {
-#ifdef HAVE_ZENOH
-      ZenohTeardownEntity(this->isShutdown,
-                          this->zQueryable, this->zToken);
-#endif
-    }
+    public: virtual ~IRepHandlerPrivate() = default;
 
     /// \brief Process UUID.
     public: std::string pUuid;
@@ -87,9 +69,6 @@ namespace gz::transport
 
     /// \brief The liveliness token.
     public: std::unique_ptr<zenoh::LivelinessToken> zToken;
-
-    /// \brief Atomic guard for Shutdown idempotence.
-    public: std::atomic<bool> isShutdown{false};
 #endif
   };
 

--- a/src/RepHandler.cc
+++ b/src/RepHandler.cc
@@ -15,12 +15,8 @@
  *
 */
 
-#include <atomic>
-#include <functional>
-#include <iostream>
 #include <memory>
 #include <string>
-#include <utility>
 #include "gz/transport/config.hh"
 #include "gz/transport/RepHandler.hh"
 #include "gz/transport/TopicUtils.hh"
@@ -28,7 +24,6 @@
 
 #ifdef HAVE_ZENOH
 #include <zenoh.hxx>
-#include "NodeSharedPrivate.hh"
 #endif
 
 namespace gz::transport

--- a/src/SubscriptionHandler.cc
+++ b/src/SubscriptionHandler.cc
@@ -17,6 +17,7 @@
 
 #include <memory>
 #include <string>
+#include <thread>
 
 #include "gz/transport/config.hh"
 #include "gz/transport/SubscriptionHandler.hh"
@@ -51,7 +52,24 @@ namespace gz::transport
     }
 
     /// \brief Destructor.
-    public: virtual ~SubscriptionHandlerBasePrivate() = default;
+    public: virtual ~SubscriptionHandlerBasePrivate()
+    {
+#ifdef HAVE_ZENOH
+      // When unregistering from within a Zenoh callback, destroying the
+      // Subscriber synchronously causes a deadlock in Zenoh's wait_callbacks()
+      // because it waits for the current thread (callback worker) to finish.
+      // Move them to a detached thread so the callback can return cleanly.
+      if (this->zSub || this->zToken)
+      {
+        std::thread([sub = std::move(this->zSub),
+                     token = std::move(this->zToken)]() mutable
+        {
+          sub.reset();
+          token.reset();
+        }).detach();
+      }
+#endif
+    }
 
     /// \brief Subscribe options.
     public: SubscribeOptions opts;

--- a/src/SubscriptionHandler.cc
+++ b/src/SubscriptionHandler.cc
@@ -57,21 +57,7 @@ namespace gz::transport
     }
 
     /// \brief Destructor.
-    public: virtual ~SubscriptionHandlerBasePrivate()
-    {
-      this->ZenohShutdown();
-    }
-
-    /// \brief Zenoh teardown. Safe to call multiple times.
-    /// See ZenohTeardownEntity in NodeSharedPrivate.hh for the
-    /// shared pattern (atomic guard + detached undeclare).
-    public: void ZenohShutdown()
-    {
-#ifdef HAVE_ZENOH
-      ZenohTeardownEntity(this->zenohIsShutdown,
-                          this->zSub, this->zToken);
-#endif
-    }
+    public: virtual ~SubscriptionHandlerBasePrivate() = default;
 
     /// \brief Subscribe options.
     public: SubscribeOptions opts;
@@ -101,9 +87,6 @@ namespace gz::transport
 
     /// \brief The liveliness token.
     public: std::unique_ptr<zenoh::LivelinessToken> zToken;
-
-    /// \brief Atomic guard for ZenohShutdown idempotence.
-    public: std::atomic<bool> zenohIsShutdown{false};
 #endif
   };
 

--- a/src/SubscriptionHandler.cc
+++ b/src/SubscriptionHandler.cc
@@ -15,11 +15,8 @@
  *
 */
 
-#include <atomic>
-#include <functional>
 #include <memory>
 #include <string>
-#include <utility>
 
 #include "gz/transport/config.hh"
 #include "gz/transport/SubscriptionHandler.hh"
@@ -27,15 +24,12 @@
 
 #ifdef HAVE_ZENOH
 #include <zenoh.hxx>
-#include "NodeSharedPrivate.hh"
 #endif
 
 namespace gz::transport
 {
   inline namespace GZ_TRANSPORT_VERSION_NAMESPACE
   {
-
-
   /// \internal
   /// \brief Private data for SubscriptionHandlerBase class.
   class SubscriptionHandlerBasePrivate

--- a/src/SubscriptionHandler.cc
+++ b/src/SubscriptionHandler.cc
@@ -104,10 +104,6 @@ namespace gz::transport
 
     /// \brief Atomic guard for ZenohShutdown idempotence.
     public: std::atomic<bool> zenohIsShutdown{false};
-
-    /// \brief Temporarily store the dispatch closure passed from the header.
-    public: std::function<void(const std::string&, const std::string&)>
-              zenohDispatch;
 #endif
   };
 
@@ -149,18 +145,6 @@ namespace gz::transport
     return this->dataPtr->opts.IgnoreLocalMessages();
   }
 
-#ifdef HAVE_ZENOH
-  /////////////////////////////////////////////////
-  void SubscriptionHandlerBase::SetZenohSubscriberDispatch(
-      const std::string &/*_topic*/,
-      const std::string &/*_expectedType*/,
-      std::function<void(const std::string &payload,
-                         const std::string &msgType)> _dispatch)
-  {
-    this->dataPtr->zenohDispatch = std::move(_dispatch);
-  }
-#endif
-
   /////////////////////////////////////////////////
   bool SubscriptionHandlerBase::UpdateThrottling()
   {
@@ -199,19 +183,17 @@ namespace gz::transport
     std::shared_ptr<zenoh::Session> _session,
     const FullyQualifiedTopic &_fullyQualifiedTopic)
   {
-    if (!this->dataPtr->zenohDispatch)
-    {
-      std::cerr << "ISubscriptionHandler::CreateGenericZenohSubscriber: "
-                << "no dispatch set. Call SetZenohSubscriberDispatch first.\n";
-      return;
-    }
-    // Capture the expected type by value (never `this`) so the lambda
-    // stays lifetime-safe after the handler is destroyed.
+    std::weak_ptr<ISubscriptionHandler> weakSelf = this->weak_from_this();
     const std::string expectedType = this->TypeName();
+    const std::string topic = _fullyQualifiedTopic.Topic();
+
     auto onSample =
-      [_dispatch = std::move(this->dataPtr->zenohDispatch), expectedType](
-        const zenoh::Sample &_sample)
+      [weakSelf, expectedType, topic](const zenoh::Sample &_sample)
     {
+      auto self = weakSelf.lock();
+      if (!self)
+        return;
+
       auto attachment = _sample.get_attachment();
       if (!attachment.has_value())
       {
@@ -225,7 +207,14 @@ namespace gz::transport
         // Same topic but different type, not interested.
         return;
       }
-      _dispatch(_sample.get_payload().as_string(), msgType);
+      auto msg = self->CreateMsg(_sample.get_payload().as_string(), msgType);
+      if (!msg)
+        return;
+      MessageInfo info;
+      info.SetTopic(topic);
+      info.SetType(msgType);
+      info.SetIntraProcess(false);
+      self->RunLocalCallback(*msg, info);
     };
 
     this->dataPtr->zSub = std::make_unique<zenoh::Subscriber<void>>(

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -47,6 +47,7 @@ test_executables = [
     "twoProcsSrvCallWithoutInputReplierInc_aux",
     "twoProcsSrvCallWithoutOutputReplier_aux",
     "twoProcsSrvCallWithoutOutputReplierInc_aux",
+    "zenohShutdown_aux",
 ]
 
 [cc_binary(
@@ -76,6 +77,7 @@ integration_test_sources = [
     "twoProcsSrvCallWithoutInputSync1.cc",
     "twoProcsSrvCallWithoutOutput.cc",
     "twoProcsSrvCallWithoutOutputStress.cc",
+    "zenohShutdownStress.cc",
 ]
 
 # Found with
@@ -108,6 +110,7 @@ flaky_test_srcs = [
         'TWO_PROCS_SRV_CALL_WITHOUT_INPUT_REPLIER_INC_EXE=\\"./test/twoProcsSrvCallWithoutInputReplierInc_aux\\"',
         'TWO_PROCS_SRV_CALL_WITHOUT_OUTPUT_REPLIER_EXE=\\"./test/twoProcsSrvCallWithoutOutputReplier_aux\\"',
         'TWO_PROCS_SRV_CALL_WITHOUT_OUTPUT_REPLIER_INC_EXE=\\"./test/twoProcsSrvCallWithoutOutputReplierInc_aux\\"',
+        'ZENOH_SHUTDOWN_AUX_EXE=\\"./test/zenohShutdown_aux\\"',
     ],
     env = {
         "GZ_BAZEL": "1",


### PR DESCRIPTION
# 🎉 New feature

Simplify #867 by using `shared_from_this` and removing intermediate `std::function` objects, parallel cleanup threads in favor of pure RAII.

## Summary

To be honest I'm not very familiar with how Zenoh works but I thought we could take inspiration from how `rmw_zenoh` does the same thing since it's a library that is fairly tested and used by now.
Specifically, it seems the pattern used there is to use `enable_shared_from_this` for subscriptions, then pass a weak pointer to the lambda directly.
While the object is alive, the weak pointer `lock()` call will work as intended. As soon as the object is destroyed `lock()` will return a `nullptr` and we won't execute the lambdas.

Ref in rmw_zenoh https://github.com/ros2/rmw_zenoh/blob/e3159856e3816e726f2c5f1f9b4858ad6b7ee63e/rmw_zenoh_cpp/src/detail/rmw_subscription_data.cpp#L758-L764.

This seems to make the code quite a bit simpler, removing 200 LOC or so, all the new `std::function` wrappers, the parallel thread cleanup.

I also added missing files to the test bazel build (otherwise this PR would have made bazel red post https://github.com/gazebosim/gz-transport/pull/937)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Assisted-by: Gemini

## Test

Tested it in CI in my fork https://github.com/luca-della-vedova/gz-transport/pull/1