### PR TITLE
[Bazel] Update cppzmq libzmq deps in bazel module

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,10 +4,10 @@ module(
 )
 
 bazel_dep(name = "buildifier_prebuilt", version = "8.2.0.2")
-bazel_dep(name = "cppzmq", version = "4.10.0.bcr.2")
+bazel_dep(name = "cppzmq", version = "4.10.0.bcr.3")
 bazel_dep(name = "googletest", version = "1.17.0.bcr.2")
 bazel_dep(name = "libuuid", version = "2.39.3.bcr.1")
-bazel_dep(name = "libzmq", version = "4.3.5.bcr.5")
+bazel_dep(name = "libzmq", version = "4.3.5.bcr.6")
 bazel_dep(name = "protobuf", version = "30.1", repo_name = "com_google_protobuf")
 bazel_dep(name = "rules_license", version = "1.0.0")
 bazel_dep(name = "rules_proto", version = "7.1.0")


### PR DESCRIPTION


# 🎉 New feature

## Summary

Update zmq bazel deps to use version with `rules_cc` instead of `rules_foreign_cc`

## Backport Policy
<!-- Should this PR be backported to older versions? Important factors to consider include API/ABI and behavior changes. If so, which versions? Choose one pre-written option or suggest your own. If you're unsure leave this empty and let the maintainer advise. -->
- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [ ] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)
- [ ] 
## Test it

```sh
bazel build -c opt //...
bazel test //...
```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
