### PR TITLE
cmake: Search Development.Module Python component to compile Python bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ if (SKIP_PYBIND11)
 else()
   find_package(Python3
     COMPONENTS Interpreter
-    OPTIONAL_COMPONENTS Development)
+    OPTIONAL_COMPONENTS Development.Module)
 endif()
 
 #--------------------------------------
@@ -193,10 +193,10 @@ add_subdirectory(conf)
 # gz transport python bindings
 #============================================================================
 if (NOT SKIP_PYBIND11)
-  if (Python3_Development_FOUND)
+  if (Python3_Development.Module_FOUND)
     add_subdirectory(python)
   else ()
-    message(WARNING "Python development libraries are missing: Python interfaces are disabled.")
+    message(WARNING "Python Development.Module libraries are missing: Python interfaces are disabled.")
   endif()
 endif()
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -8,7 +8,7 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   find_package(gz-transport REQUIRED)
   set(PROJECT_LIBRARY_TARGET_NAME "gz-transport::gz-transport")
   # require python dependencies to be found
-  find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
+  find_package(Python3 COMPONENTS Interpreter Development.Module REQUIRED)
   set(CMAKE_REQUIRE_FIND_PACKAGE_pybind11 TRUE)
   include(GNUInstallDirs)
   include(CTest)


### PR DESCRIPTION
# 🦟 Bug fix

Fixes looking for `Development` cmake component of Python even if it was not necessary.

## Summary


CMake's FindPython offers two dev-related component of Python: `Development.Module`  and `Development.Embed` (see https://cmake.org/cmake/help/latest/module/FindPython.html), or `Development` to search both. As gz-math is not embedding python, it only need `Development.Module` .

This is relevant in conda-forge since Python 3.15 split the files necessary for `Development.Embed` to suceed in `libpython`, so packages that only depend on `python` and do not embed python, need to only look for  `Development.Module`, see https://github.com/conda-forge/gz-math-feedstock/pull/46#issuecomment-5539679465 .

## Backport Policy

`Development.Module`  requires CMake 3.18, so we can backport to any version that has a greater minimum CMake version.

- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [x] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? No

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

