### PR TITLE
Bazel - fix Mac CI

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -17,3 +17,4 @@ build --process_headers_in_dependencies
 # OS specific settings
 build --enable_platform_specific_config
 build:macos --macos_minimum_os=10.15
+build:macos --@rules_rust//rust/settings:use_hermetic_macos_sdkroot=false

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -29,6 +29,9 @@ rust_toolchains.toolchain(
 )
 use_repo(rust_toolchains, "default_rust_toolchains")
 
+rules_rust = use_extension("@rules_rs//rs:rules_rust.bzl", "rules_rust")
+use_repo(rules_rust, "rules_rust")
+
 register_toolchains(
     "@default_rust_toolchains//...",
 )


### PR DESCRIPTION
# 🦟 Bug fix

Fix Bazel CI on Mac

## Summary

It seems Zenoh with Clang on Mac fails to compile unless we set the build to non hermetic, so just set it to hermetic.
I suspect any downstream user of Zenoh, Mac, Clang will have to do this (so downstream gz repos that depend on gz-transport)

## Backport Policy
- [x] This is safe to backport to the following versions:
    - [x] Jetty
    - [ ] Ionic
    - [ ] Harmonic
    - [ ] Fortress
- [ ] This **should not** be backported
- [ ] I am not sure
- [ ] Other (fill in yourself)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Assisted-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Assisted-by: Gemini

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.